### PR TITLE
Fix Quick Start in README to works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,7 @@ graph TB
 git clone https://github.com/Cloto-dev/ClotoCore.git
 cd ClotoCore
 # build dashboard first
-cd dashboard/
-npm i
-npm run build
-# back to root
-cd ..
+npm --prefix dashboard ci && npm --prefix dashboard run build
 cargo build --release
 cargo run --package cloto_core
 ```


### PR DESCRIPTION
Added instructions to build `./dashboard` before run `cargo build`.
This closes #2.

## What

Added instructions to build the dashboard.

## Why

To fix issue #2.

## Testing

This only changed README.md so don't needs.