### PR TITLE
fix(dashboard): unblock CI — orphan setUninstallError + ContextUsageBadge ARIA

### DIFF
--- a/dashboard/src/components/ContextUsageBadge.tsx
+++ b/dashboard/src/components/ContextUsageBadge.tsx
@@ -79,6 +79,7 @@ export function ContextUsageBadge({ agentId, refreshKey }: Props) {
 
   return (
     <div
+      role="status"
       className={`card-solid px-4 py-2 rounded-full border text-[13px] font-mono flex items-center gap-2 ${tone}`}
       title={tooltipParts}
       aria-label={t('agent.context_usage_aria', { used, max: maxLabel })}

--- a/dashboard/src/components/mcp/MarketplaceTab.tsx
+++ b/dashboard/src/components/mcp/MarketplaceTab.tsx
@@ -207,7 +207,6 @@ export function MarketplaceTab({ onRefetchRef }: MarketplaceTabProps) {
         onConfirm={handleUninstall}
         onCancel={() => {
           setUninstallTarget(null);
-          setUninstallError(null);
         }}
       />
 


### PR DESCRIPTION
## Summary

- `MarketplaceTab.tsx:210` referenced `setUninstallError`, but the state setter
  was never defined → TS2304 (Cannot find name) on every dashboard build
- Error state is already covered by `showToast('error', ...)` in
  `handleUninstall`'s catch branch, so no separate `uninstallError` state is
  needed — drop the orphan call (1-line fix)

## Context

Part of `Scope 4: ClotoCore baseline 修正` — the master branch currently fails 3
CI checks. This PR addresses Goal 16 (Dashboard TypeScript). Goals 17 (Lint
clippy 19 errors) and 18 (Issue Registry stale entries) will follow as
independent PRs.

## Test plan

- [x] `npx biome check src/components/mcp/MarketplaceTab.tsx` — clean
- [x] `npx tsc --noEmit` — no errors
- [ ] CI Dashboard TypeScript check goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)