### PR TITLE
fix(clippy): resolve 19 Rust 1.95 baseline errors + 1 doc overindent

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -361,8 +361,7 @@ impl AppConfig {
         }
 
         let mcp_streaming_enabled = env::var("CLOTO_MCP_STREAMING_ENABLED")
-            .map(|v| matches!(v.as_str(), "true" | "1" | "yes" | "on"))
-            .unwrap_or(false);
+            .is_ok_and(|v| matches!(v.as_str(), "true" | "1" | "yes" | "on"));
 
         let mcp_health_interval_secs = env::var("CLOTO_MCP_HEALTH_INTERVAL_SECS")
             .unwrap_or_else(|_| "10".to_string())
@@ -570,17 +569,13 @@ impl AppConfig {
             // Magic Seal: block unsigned MCP servers at Untrusted trust level.
             // Core/Standard/Experimental servers are always allowed without a seal.
             // Only affects Untrusted servers — set to true if you register Untrusted servers in dev.
-            allow_unsigned: env::var("CLOTO_ALLOW_UNSIGNED")
-                .map(|v| v == "true" || v == "1")
-                .unwrap_or(false),
+            allow_unsigned: env::var("CLOTO_ALLOW_UNSIGNED").is_ok_and(|v| v == "true" || v == "1"),
             isolation_enabled: env::var("CLOTO_ISOLATION_ENABLED")
-                .map(|v| v != "false" && v != "0")
-                .unwrap_or(true), // Default: true
+                .map_or(true, |v| v != "false" && v != "0"), // Default: true
             sandbox_base_dir: env::var("CLOTO_SANDBOX_DIR")
                 .map_or_else(|_| PathBuf::from("data/mcp-sandbox"), PathBuf::from),
             health_scan_on_startup: env::var("CLOTO_HEALTH_SCAN_ON_STARTUP")
-                .map(|v| v != "false" && v != "0")
-                .unwrap_or(true),
+                .map_or(true, |v| v != "false" && v != "0"),
         })
     }
 }

--- a/crates/core/src/db/llm.rs
+++ b/crates/core/src/db/llm.rs
@@ -47,7 +47,7 @@ pub struct LlmProviderRow {
     /// Semantic is the USER INTENT, not the internal mechanism:
     ///   * `"on"`   — thinking is allowed (no prefill applied)
     ///   * `"off"`  — thinking is suppressed via an assistant `<think></think>`
-    ///                prefill on the outbound request
+    ///     prefill on the outbound request
     ///   * `"auto"` — server-side heuristic on the model id decides
     ///
     /// `augment_mind_env` translates this into the internal

--- a/crates/core/src/handlers.rs
+++ b/crates/core/src/handlers.rs
@@ -129,8 +129,7 @@ pub(crate) fn check_auth_with_query(
         #[cfg(debug_assertions)]
         {
             let skip_auth = std::env::var("CLOTO_DEBUG_SKIP_AUTH")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
+                .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
             if !skip_auth {
                 return Err(AppError::Cloto(cloto_shared::ClotoError::PermissionDenied(
                     cloto_shared::Permission::AdminAccess,

--- a/crates/core/src/handlers/command_approval.rs
+++ b/crates/core/src/handlers/command_approval.rs
@@ -384,7 +384,7 @@ pub(crate) async fn run_approval_gate(
     )
     .await;
 
-    let decision = tokio::time::timeout(std::time::Duration::from_secs(60), arx).await;
+    let decision = tokio::time::timeout(std::time::Duration::from_mins(1), arx).await;
     pending_approvals.remove(&approval_id);
 
     process_approval_decision(

--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -86,7 +86,7 @@ pub struct CatalogCache {
     pub fetched_at: Option<tokio::time::Instant>,
 }
 
-const CACHE_TTL: Duration = Duration::from_secs(3600); // 1 hour
+const CACHE_TTL: Duration = Duration::from_hours(1); // 1 hour
 
 // ── Response types ──────────────────────────────────────────────────
 
@@ -605,7 +605,7 @@ async fn cargo_build_server(
         None
     };
 
-    let status = match tokio::time::timeout(Duration::from_secs(600), child.wait()).await {
+    let status = match tokio::time::timeout(Duration::from_mins(10), child.wait()).await {
         Ok(Ok(status)) => status,
         Ok(Err(e)) => {
             warn!("cargo build process error: {e}");

--- a/crates/core/src/handlers/system.rs
+++ b/crates/core/src/handlers/system.rs
@@ -29,6 +29,7 @@ use sqlx::SqlitePool;
 /// format: `docs/TOOL_REJECTION_TEST_PLAN.md` §3.1.
 ///
 /// `pub` so integration tests can exercise the same template the kernel uses.
+#[must_use]
 pub fn compose_rejection_text(rejection: &ToolRejection) -> String {
     let remediation = rejection
         .remediation_hint
@@ -47,6 +48,7 @@ pub fn compose_rejection_text(rejection: &ToolRejection) -> String {
 /// model. Canonical templates: `docs/TOOL_REJECTION_TEST_PLAN.md` §3.3.
 ///
 /// `pub` so integration tests can exercise the same template the kernel uses.
+#[must_use]
 pub fn compose_rejection_final_response(rejections: &[(String, ToolRejection)]) -> String {
     let last = &rejections
         .last()
@@ -863,8 +865,8 @@ impl SystemHandler {
                             crate::managers::capability_dispatcher::CapabilityType::Speech,
                         )
                         .await
-                        .filter(|sid| granted_server_ids.contains(sid))
-                        .is_some()
+                        .as_ref()
+                        .is_some_and(|sid| granted_server_ids.contains(sid))
                     } else {
                         false
                     };

--- a/crates/core/src/managers/mcp_health.rs
+++ b/crates/core/src/managers/mcp_health.rs
@@ -42,7 +42,7 @@ pub(super) fn spawn_health_monitor(
                     check_and_restart_dead_servers(&manager, &setup_in_progress).await;
                     // Clean up responded callbacks older than 5 minutes (§13.4)
                     let cleaned = manager.events.cleanup_stale_callbacks(
-                        std::time::Duration::from_secs(300),
+                        std::time::Duration::from_mins(5),
                     );
                     if cleaned > 0 {
                         debug!(count = cleaned, "Cleaned up stale callbacks");

--- a/crates/core/src/managers/mcp_isolation.rs
+++ b/crates/core/src/managers/mcp_isolation.rs
@@ -166,20 +166,14 @@ fn apply_permission_upgrades(
 ) {
     for perm in permissions {
         match perm.as_str() {
-            "network.outbound" => {
-                if net_scope.rank() < NetworkScope::ProxyOnly.rank() {
-                    *net_scope = NetworkScope::ProxyOnly;
-                }
+            "network.outbound" if net_scope.rank() < NetworkScope::ProxyOnly.rank() => {
+                *net_scope = NetworkScope::ProxyOnly;
             }
-            "filesystem.write" => {
-                if fs_scope.rank() < FilesystemScope::Sandbox.rank() {
-                    *fs_scope = FilesystemScope::Sandbox;
-                }
+            "filesystem.write" if fs_scope.rank() < FilesystemScope::Sandbox.rank() => {
+                *fs_scope = FilesystemScope::Sandbox;
             }
-            "filesystem.read" => {
-                if fs_scope.rank() < FilesystemScope::Readonly.rank() {
-                    *fs_scope = FilesystemScope::Readonly;
-                }
+            "filesystem.read" if fs_scope.rank() < FilesystemScope::Readonly.rank() => {
+                *fs_scope = FilesystemScope::Readonly;
             }
             _ => {}
         }

--- a/crates/core/src/managers/mcp_lifecycle.rs
+++ b/crates/core/src/managers/mcp_lifecycle.rs
@@ -235,7 +235,7 @@ mod tests {
         assert_eq!(d6, Duration::from_millis(3200)); // 100 * 2^5
 
         let d7 = lm.calculate_backoff("s1", &policy);
-        assert_eq!(d7, Duration::from_millis(5000)); // capped at max
+        assert_eq!(d7, Duration::from_secs(5)); // capped at max
     }
 
     #[test]

--- a/crates/core/src/managers/mcp_transport.rs
+++ b/crates/core/src/managers/mcp_transport.rs
@@ -391,7 +391,7 @@ impl HttpTransport {
         validate_http_url(url)?;
 
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(60))
+            .timeout(std::time::Duration::from_mins(1))
             .build()
             .context("Failed to create HTTP client")?;
 

--- a/crates/core/src/managers/token_budget.rs
+++ b/crates/core/src/managers/token_budget.rs
@@ -26,7 +26,7 @@ use serde_json::Value;
 #[must_use]
 pub fn estimate_request_tokens(v: &Value) -> usize {
     // Serialize without pretty-printing; we're measuring raw payload size.
-    let bytes = serde_json::to_vec(v).map(|b| b.len()).unwrap_or(0);
+    let bytes = serde_json::to_vec(v).map_or(0, |b| b.len());
     bytes / 3
 }
 

--- a/crates/core/src/middleware.rs
+++ b/crates/core/src/middleware.rs
@@ -72,7 +72,7 @@ impl RateLimiter {
     /// Remove idle entries to prevent memory growth.
     /// M-04: Uses timestamp-based staleness instead of consuming tokens
     pub fn cleanup(&self) {
-        let idle_threshold = std::time::Duration::from_secs(600); // 10 minutes
+        let idle_threshold = std::time::Duration::from_mins(10); // 10 minutes
         self.limiters
             .retain(|_, (_, last_seen)| last_seen.elapsed() < idle_threshold);
     }


### PR DESCRIPTION
## Summary

- 19 baseline clippy errors from new Rust 1.95 lints
  (`duration_suboptimal_units`, `map_unwrap_or`) auto-fixed via
  `cargo clippy --fix`. Each is a stdlib-equivalent rewrite —
  `Duration::from_secs(60)` → `from_mins(1)` and
  `.map(f).unwrap_or(x)` → `.map_or(x, f)`. No semantic change.
- 1 manual fix for `doc_overindented_list_items` in `crates/core/src/db/llm.rs`
  (bullet continuation indented to 16 spaces, dropped to 4).
- `cargo fmt --all` applied to consolidate single-line match arms that
  `clippy --fix` had split.

## Context

Part of `Scope 4: ClotoCore baseline 修正` — Goal 17 of 3.

Goal 16 (Dashboard TS): #95 (already open).
Goal 18 (Issue Registry stale entries): pending — needs human content
review on bug-265/333/349/368.

## Verification

```bash
# Reproduces the CI invocation exactly:
cargo clippy --workspace --exclude app -- -D warnings \
  -A clippy::too-many-lines -A clippy::struct-excessive-bools \
  -A clippy::match-same-arms -A clippy::cast-possible-wrap \
  -A clippy::trivially-copy-pass-by-ref -A clippy::manual-let-else \
  -A clippy::option-if-let-else \
  -A clippy::case-sensitive-file-extension-comparisons \
  -A clippy::unwrap-used -A clippy::type-complexity
# → 0 errors, clean

cargo fmt --all -- --check
# → clean
```

## Test plan

- [x] `cargo clippy` (CI flags) — 0 errors
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI Lint goes green
- [ ] CI Test still passes (no semantic changes, but verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)