### PR TITLE
fix(qa): resolve 4 baseline issue-registry entries (1 ERROR + 3 STALE)

### DIFF
--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -1372,8 +1372,8 @@
       "commit": "b60f329",
       "file": "dashboard/src/components/CustomCursor.tsx",
       "pattern": "\\}, \\[\\]\\);",
-      "expected": "present",
-      "status": "wontfix",
+      "expected": "absent",
+      "status": "fixed",
       "github_issue": 36
     },
     {
@@ -2195,7 +2195,7 @@
       "commit": "08fc0e1",
       "file": "crates/core/src/lib.rs",
       "pattern": "CRITICAL: Failed to parse MCP config file",
-      "expected": "present",
+      "expected": "absent",
       "status": "fixed"
     },
     {
@@ -2375,7 +2375,7 @@
       "commit": "ccfbc25",
       "file": "crates/core/src/managers/mcp_transport.rs",
       "pattern": "stdout silent for 120s",
-      "expected": "present",
+      "expected": "absent",
       "status": "fixed"
     },
     {
@@ -2603,8 +2603,8 @@
       "commit": "0d03c1a",
       "file": "crates/core/src/handlers/marketplace.rs",
       "pattern": "Python dependency installation failed",
-      "expected": "present",
-      "status": "open"
+      "expected": "absent",
+      "status": "fixed"
     },
     {
       "id": "bug-369",


### PR DESCRIPTION
## Summary

Reconcile four `qa/issue-registry.json` entries with the actual codebase so the
Issue Registry CI check goes green:

| ID | Severity | Was | Now | Why |
|---|---|---|---|---|
| `bug-265` | LOW | `wontfix` / `expected: present` | `fixed` / `expected: absent` | Target file `dashboard/src/components/CustomCursor.tsx` was removed in commit `5492aac` (dead-code sweep). `verify-issues.sh` treats `expected: absent` + missing file as "File deleted (pattern trivially absent)" → `[FIXED]`. |
| `bug-333` | MEDIUM | `fixed` / `expected: present` | `fixed` / `expected: absent` | `status` already said fixed; `expected` was contradictory. Pattern no longer present in `crates/core/src/lib.rs` (CI confirmed "Pattern NOT found"). |
| `bug-349` | CRITICAL | `fixed` / `expected: present` | `fixed` / `expected: absent` | Same shape as 333. Pattern absent from `crates/core/src/managers/mcp_transport.rs`. |
| `bug-368` | HIGH | `open` / `expected: present` | `fixed` / `expected: absent` | The "unified pip install" path in `crates/core/src/handlers/marketplace.rs` has been rewritten — it now installs each Python server individually via `spawn_uv_streaming`, with explicit per-server error isolation ("Continue to next server — error isolation") and surfaces uv's stderr last-line as the failure detail. The original generic error message no longer exists. |

No production code changes. Patterns are preserved as historical evidence; only the
expected/status fields are reconciled.

## Context

Part of `Scope 4: ClotoCore baseline 修正` — Goal 18 of 3.

- Goal 16 (Dashboard TypeScript / a11y): #95
- Goal 17 (Lint clippy 19 errors): #96

After all three merge, master's CI should be fully green (Dashboard / Lint /
Issue Registry / Test / Security Audit) for the first time since the
Rust 1.95 + biome rule updates introduced new baseline failures.

## Verification

```
$ bash scripts/verify-issues.sh
=== Summary ===
Total issues:  221
Verified:      89
Stale:         0
Fixed:         132
Errors:        0

All issues verified successfully.
```

## Test plan

- [x] `bash scripts/verify-issues.sh` exits 0 locally
- [x] `.githooks/pre-commit` accepted the commit (verify-issues passed)
- [ ] CI Issue Registry goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)