### PR TITLE
fix(qa): retarget bug-356 pattern after clippy from_secs→from_mins rewrite

### DIFF
--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -2458,7 +2458,7 @@
       "version": "0.6.3-beta.8",
       "commit": "ccfbc25",
       "file": "crates/core/src/managers/mcp_transport.rs",
-      "pattern": "timeout\\(std::time::Duration::from_secs\\(60\\)\\)",
+      "pattern": "timeout\\(std::time::Duration::from_mins\\(1\\)\\)",
       "expected": "present",
       "status": "open"
     },


### PR DESCRIPTION
## Summary

Late side-effect from #96. The clippy `duration_suboptimal_units` cleanup
rewrote `crates/core/src/managers/mcp_transport.rs:394` from
`Duration::from_secs(60)` to `Duration::from_mins(1)` — semantically
identical, but the bug-356 registry entry was still grepping the old
textual form, so master CI now reports it as `[STALE]`.

This PR updates the registry pattern to the new wording. **Nothing else
changes** — bug-356 is still `open`, `expected: present`, and the
underlying issue (HTTP transport has only a global 60s timeout, no
per-message timeout) is unchanged.

## Verification

```
$ bash scripts/verify-issues.sh
=== Summary ===
Total issues:  221
Verified:      89
Stale:         0
Fixed:         132
Errors:        0

All issues verified successfully.
```

## Why this slipped through #96 review

Each PR's CI ran against its own branch, so #96 only saw `from_secs(60)`
in the registry against its rewritten `from_mins(1)` in the code, and the
pattern matched neither — but the entry's pre-existing `[VERIFIED]` state
was based on a different code site and so the regression didn't surface
until both PRs landed on master. Going forward, any `cargo clippy --fix`
on rust files should be cross-checked against `qa/issue-registry.json`
patterns before commit.

## Test plan

- [x] `bash scripts/verify-issues.sh` exits 0 locally
- [x] `.githooks/pre-commit` accepted the commit
- [ ] CI Issue Registry on master goes green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)