### PR TITLE
docs(mgp): retarget MGP_SPEC.md pointer to mgp-spec repo

### DIFF
--- a/docs/MGP_SPEC.md
+++ b/docs/MGP_SPEC.md
@@ -1,35 +1,31 @@
-# MGP — Multi-Agent Gateway Protocol
+# MGP — Moved to mgp-spec
 
-**Version:** 0.6.0-draft
-**Status:** Draft
-**Authors:** ClotoCore Project
-**Date:** 2026-03-06
+The canonical MGP specification has been split out to its own repository (MIT, independent):
+**https://github.com/Cloto-dev/mgp-spec**
 
-The canonical MGP specification is maintained in the
-[cloto-mcp-servers](https://github.com/Cloto-dev/cloto-mcp-servers)
-repository, alongside the server implementations and the detailed
-specification documents. This file is a pointer — see the canonical
-documents below.
+This file remains as a stub to keep `Mandatory Reads` paths in CLAUDE.md working and to redirect any in-tree references.
 
-## Canonical Documents
+## Canonical Documents (mgp-spec)
 
 | File | Sections | Content |
 |------|----------|---------|
-| [MGP_SPEC.md](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_SPEC.md) | §1 | Overview, Architecture, Migration Policy |
-| [MGP_SECURITY.md](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_SECURITY.md) | §2-§7 | Capability Negotiation, Permissions, Tool Security, Access Control, Audit, Code Safety |
-| [MGP_COMMUNICATION.md](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_COMMUNICATION.md) | §11-§14 | Lifecycle, Streaming, Bidirectional Communication, Errors |
-| [MGP_DISCOVERY.md](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_DISCOVERY.md) | §15-§16 | Discovery, Dynamic Tool Discovery |
-| [MGP_GUIDE.md](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_GUIDE.md) | §17-§20 | Implementation, History, Patterns |
-| [MGP_ISOLATION_DESIGN.md](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_ISOLATION_DESIGN.md) | (§8-§10 reserved) | OS-Level Isolation |
+| [docs/MGP_SPEC.md](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_SPEC.md) | §1 | Overview, Architecture, Migration Policy |
+| [docs/MGP_SECURITY.md](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_SECURITY.md) | §2-§7 | Capability Negotiation, Permissions, Tool Security, Access Control, Audit, Code Safety |
+| [docs/MGP_COMMUNICATION.md](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_COMMUNICATION.md) | §11-§14 | Lifecycle, Streaming, Bidirectional Communication, Errors |
+| [docs/MGP_DISCOVERY.md](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_DISCOVERY.md) | §15-§16 | Discovery, Dynamic Tool Discovery |
+| [docs/MGP_GUIDE.md](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_GUIDE.md) | §17-§20 | Implementation, History, Patterns |
+| [docs/MGP_ISOLATION_DESIGN.md](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_ISOLATION_DESIGN.md) | (§8-§10 reserved) | OS-Level Isolation |
+
+## Migration
+
+- Migration date: **2026-05-07**
+- mgp-spec head: **v0.6.1-draft** (sanity-aligned with cloto-mcp-servers/docs/MGP_SPEC.md history through 2026-04-22)
+- License: MIT (independent from ClotoCore's BSL → MIT 2028)
 
 ## ClotoCore as the Reference Implementation
 
-ClotoCore is the reference implementation of MGP. ClotoCore-specific
-kernel tool extensions that are not part of the MGP specification
-(e.g., `create_mcp_server`, `gui.map`, `gui.read`) are documented in:
+ClotoCore is the reference implementation of MGP. ClotoCore-specific kernel tool extensions that are not part of the MGP specification (e.g., `create_mcp_server`, `gui.map`, `gui.read`) are documented in:
 
 - [MCP_PLUGIN_ARCHITECTURE.md §3.2](./MCP_PLUGIN_ARCHITECTURE.md#32-clotocore-specific-extensions-custom-methods)
 
-For the mapping of MGP specification sections to ClotoCore source-code
-locations, see
-[MGP_GUIDE.md §17.3](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_GUIDE.md#173-relationship-to-clotocore).
+For the mapping of MGP specification sections to ClotoCore source-code locations, see [MGP_GUIDE.md §17.3](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_GUIDE.md#173-relationship-to-clotocore).


### PR DESCRIPTION
## Summary

Re-do of #93 (which was reverted in ece6ed5 after an unrelated kernel
commit got bundled into the squash). This PR contains **only** the
intended docs change.

- All six `MGP_*.md` document links in `docs/MGP_SPEC.md` now point at
  https://github.com/Cloto-dev/mgp-spec instead of cloto-mcp-servers.
- Adds a Migration metadata block: date (2026-05-07), mgp-spec head
  (v0.6.1-draft), and the licensing rationale (MIT, independent of
  ClotoCore's BSL → MIT 2028).
- Retains the "ClotoCore as the Reference Implementation" section so the
  in-tree link to `MCP_PLUGIN_ARCHITECTURE.md` and the §17.3 reference
  continue to resolve (now pointing at mgp-spec).

## Context

Part of the ClotoHub roadmap, Scope 2 (`MGP-spec 独立化と 0.6.3-draft 拡張`),
Goal 9 — Phase 0. The matching stub change in cloto-mcp-servers already
landed (master e6ea096). After this merges, both consumer repos point at
the same canonical location and Phase 1 (MGP 0.6.3-draft + ClotoCore
reference impl + 22 server seal + uv migration) can begin.

## Diff verify

```
$ gh pr view <this> --json files,additions,deletions,changedFiles
{"additions": 19, "changedFiles": 1, "deletions": 23,
 "files": [{"path": "docs/MGP_SPEC.md", ...}]}
```

Single file, no contamination. (#93 had 11 files because it accidentally
included an unrelated branch's work — the PR diff verify guardrail in
`feedback_pr_diff_verify.md` exists to catch that.)

## Test plan

- [x] Stage 1: `git fetch && git status -sb` — local master = origin/master, no divergence
- [x] Stage 2: PR diff = 1 file / +19 / -23, matches expectation
- [ ] CI passes (no Rust / Dashboard / Issue Registry impact since this is docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)