### PR TITLE
feat(mcp): force-untrusted on missing seal (MGP v0.6.3 §10 inv 3)

### DIFF
--- a/crates/core/src/managers/mcp.rs
+++ b/crates/core/src/managers/mcp.rs
@@ -871,8 +871,14 @@ impl McpClientManager {
             }
         }
 
-        // ──── Seal Verification (MGP §8 L0) ────
-        let trust_level = config
+        // ──── Seal Verification (MGP_ISOLATION_DESIGN.md §4.0 / §10, v0.6.3+) ────
+        //
+        // v0.6.3 universalized Security Invariant 3: an unsealed server is
+        // downgraded to `untrusted` regardless of declared tier, replacing the
+        // prior `core`-only rule. We compute `effective_trust_level` here and
+        // hand it to `derive_isolation_profile` below, so the isolation profile
+        // matches what the kernel actually trusts — not what the server claimed.
+        let declared_trust_level = config
             .mgp
             .as_ref()
             .and_then(|m| m.trust_level.as_deref())
@@ -884,12 +890,12 @@ impl McpClientManager {
             .transpose()
             .unwrap_or(None)
             .unwrap_or(super::mcp_mgp::TrustLevel::Standard);
+        let mut effective_trust_level = declared_trust_level;
 
         if is_http_transport {
-            // HTTP transport: skip seal verification and isolation (external server)
+            // HTTP transport: skip seal verification and isolation (external server).
             debug!(id = %id, "HTTP transport — skipping seal and isolation checks");
-        } else if let Some(ref seal_value) = config.seal {
-            // Seal is present in config — verify the entry point binary.
+        } else {
             let entry_point = std::path::Path::new(&config.command);
             if entry_point.exists() {
                 let seal_key = super::mcp_seal::load_or_generate_seal_key(
@@ -898,8 +904,8 @@ impl McpClientManager {
                         .unwrap_or(std::path::Path::new("data")),
                 )?;
                 let status = super::mcp_seal::check_seal(
-                    &trust_level,
-                    Some(seal_value.as_str()),
+                    &declared_trust_level,
+                    config.seal.as_deref(),
                     entry_point,
                     &seal_key,
                     self.allow_unsigned,
@@ -909,6 +915,7 @@ impl McpClientManager {
                         info!(id = %id, "Magic Seal verified for MCP server");
                     }
                     super::mcp_seal::SealStatus::Failed => {
+                        // Tampering detected — block startup unconditionally.
                         let msg = format!(
                             "MCP server '{}': Magic Seal verification failed — binary may be tampered",
                             id
@@ -916,19 +923,59 @@ impl McpClientManager {
                         self.set_server_error(&id, &msg).await;
                         return Err(anyhow::anyhow!("{}", msg));
                     }
-                    _ => {}
+                    super::mcp_seal::SealStatus::Unsigned
+                        if declared_trust_level != super::mcp_mgp::TrustLevel::Untrusted =>
+                    {
+                        // v0.6.3 §10 inv 3: force the effective trust_level to
+                        // Untrusted so the isolation profile is pinned to the
+                        // untrusted baseline. Surface as TRUST_LEVEL_DOWNGRADED_NO_SEAL
+                        // (MGP_SECURITY.md §6.4) — keep the field names stable so
+                        // log/audit consumers can match on `event_type`.
+                        warn!(
+                            event_type = "TRUST_LEVEL_DOWNGRADED_NO_SEAL",
+                            server_id = %id,
+                            declared_trust_level = ?declared_trust_level,
+                            effective_trust_level = ?super::mcp_mgp::TrustLevel::Untrusted,
+                            "MCP server has no Magic Seal — forcing trust_level to Untrusted (MGP_ISOLATION_DESIGN.md §10 inv 3, v0.6.3)"
+                        );
+                        effective_trust_level = super::mcp_mgp::TrustLevel::Untrusted;
+                    }
+                    super::mcp_seal::SealStatus::Unsigned => {
+                        // Declared was already Untrusted — no downgrade needed.
+                        debug!(id = %id, "Untrusted server with no seal — starting under untrusted profile");
+                    }
+                    super::mcp_seal::SealStatus::Skipped => {
+                        // Dev-mode bypass: CLOTO_ALLOW_UNSIGNED=true. Keep declared.
+                        warn!(
+                            id = %id,
+                            "CLOTO_ALLOW_UNSIGNED=true — keeping declared trust_level without seal verification (development only)"
+                        );
+                    }
                 }
             } else {
-                debug!(id = %id, "Seal configured but entry point is not a file path — skipping seal check");
+                // Entry point is not a literal file path (e.g. interpreter binary
+                // resolved from PATH). We cannot HMAC something we cannot read,
+                // so we fall back to the same v0.6.3 force-untrusted rule.
+                if declared_trust_level != super::mcp_mgp::TrustLevel::Untrusted
+                    && !self.allow_unsigned
+                {
+                    warn!(
+                        event_type = "TRUST_LEVEL_DOWNGRADED_NO_SEAL",
+                        server_id = %id,
+                        declared_trust_level = ?declared_trust_level,
+                        effective_trust_level = ?super::mcp_mgp::TrustLevel::Untrusted,
+                        reason = "entry_point_not_a_file",
+                        "MCP server entry point is not a sealable file — forcing trust_level to Untrusted"
+                    );
+                    effective_trust_level = super::mcp_mgp::TrustLevel::Untrusted;
+                } else {
+                    debug!(id = %id, "Entry point is not a file path — skipping seal check");
+                }
             }
-        } else if trust_level == super::mcp_mgp::TrustLevel::Untrusted && !self.allow_unsigned {
-            let msg = format!(
-                "MCP server '{}': Untrusted servers require a Magic Seal in production mode",
-                id
-            );
-            self.set_server_error(&id, &msg).await;
-            return Err(anyhow::anyhow!("{}", msg));
         }
+        // For backwards compatibility with the rest of this function (which
+        // historically used a binding called `trust_level`), shadow it here.
+        let trust_level = effective_trust_level;
 
         // ──── Isolation Profile Derivation (MGP §8-10) ────
         let isolation_profile = if is_http_transport {

--- a/crates/core/src/managers/mcp_seal.rs
+++ b/crates/core/src/managers/mcp_seal.rs
@@ -73,16 +73,32 @@ pub fn verify_seal(file_path: &Path, expected_seal: &str, key: &[u8]) -> anyhow:
 
 /// Check seal status based on trust level and configuration.
 ///
-/// Behavior matrix (from MGP Section 4.0):
+/// This function only computes the cryptographic outcome. Translating the
+/// outcome into a startup decision (block / start under untrusted profile /
+/// start under declared profile) is the caller's job — see the v0.6.3
+/// behavior table below.
 ///
-/// | Trust Level   | Seal Present | Seal Absent | Invalid Seal |
-/// |--------------|-------------|-------------|-------------|
-/// | Core         | Verify      | Allow       | WARN + Block |
-/// | Standard     | Verify      | Allow       | WARN + Block |
-/// | Experimental | Verify      | Allow       | Block        |
-/// | Untrusted    | Verify      | Block*      | Block        |
+/// Behavior matrix (MGP_ISOLATION_DESIGN.md §4.0, v0.6.3+):
 ///
-/// * Unless `allow_unsigned=true` (development mode), then WARN + Allow.
+/// | Trust Level   | Seal Present | Seal Absent       | Seal Invalid |
+/// |---------------|--------------|-------------------|--------------|
+/// | Core          | Verify       | Force `untrusted` | Block        |
+/// | Standard      | Verify       | Force `untrusted` | Block        |
+/// | Experimental  | Verify       | Force `untrusted` | Block        |
+/// | Untrusted     | Verify       | Allow*            | Block        |
+///
+/// "Force `untrusted`" means: this function returns [`SealStatus::Unsigned`];
+/// the caller MUST override the effective trust_level to `Untrusted` (so the
+/// isolation profile is pinned to the untrusted baseline) and emit a
+/// `TRUST_LEVEL_DOWNGRADED_NO_SEAL` audit event (MGP_SECURITY.md §6.4).
+///
+/// * `Untrusted` + seal absent: returns [`SealStatus::Skipped`] when
+///   `allow_unsigned=true` (dev mode), [`SealStatus::Unsigned`] otherwise.
+///   Either way the effective trust_level is already `Untrusted`, so no
+///   override is needed; the caller still allows startup.
+///
+/// `Seal invalid` (tampering) returns [`SealStatus::Failed`] across all tiers
+/// — the caller MUST block startup. v0.6.3 only relaxed the `Seal absent` row.
 pub fn check_seal(
     trust_level: &TrustLevel,
     seal_value: Option<&str>,
@@ -104,20 +120,19 @@ pub fn check_seal(
         }
         None => {
             // Seal absent — behavior depends on trust level.
-            match trust_level {
-                TrustLevel::Core | TrustLevel::Standard | TrustLevel::Experimental => {
-                    // Higher trust levels allow unsigned binaries.
-                    Ok(SealStatus::Unsigned)
-                }
-                TrustLevel::Untrusted => {
-                    if allow_unsigned {
-                        // Development mode: allow but caller should log a warning.
-                        Ok(SealStatus::Skipped)
-                    } else {
-                        // Production: block unsigned untrusted servers.
-                        Ok(SealStatus::Failed)
-                    }
-                }
+            //
+            // v0.6.3: every tier returns `Unsigned` here; the caller forces the
+            // effective trust_level to `Untrusted` regardless of declared tier.
+            // Prior to v0.6.3 we returned `Failed` for `Untrusted` in production
+            // (which blocked startup); v0.6.3 §4.0 relaxed that so an unsealed
+            // `Untrusted` server starts under the same untrusted profile it
+            // would have anyway. `Skipped` is reserved for dev-mode bypass.
+            if matches!(trust_level, TrustLevel::Untrusted) && allow_unsigned {
+                // Dev-mode bypass for already-untrusted: caller may keep the
+                // declared profile. Emitted only for parity with prior versions.
+                Ok(SealStatus::Skipped)
+            } else {
+                Ok(SealStatus::Unsigned)
             }
         }
     }
@@ -413,11 +428,14 @@ mod tests {
     }
 
     #[test]
-    fn check_seal_untrusted_absent_blocks() {
+    fn check_seal_untrusted_absent_allows_v063() {
+        // v0.6.3 §4.0 relaxation: an unsealed `Untrusted` server starts under
+        // the same untrusted profile it would have anyway. Prior to v0.6.3
+        // this returned `Failed` (Block); now it returns `Unsigned` (Allow).
         let file = temp_file_with(b"binary");
         let status =
             check_seal(&TrustLevel::Untrusted, None, file.path(), TEST_KEY, false).unwrap();
-        assert_eq!(status, SealStatus::Failed);
+        assert_eq!(status, SealStatus::Unsigned);
     }
 
     // --- Untrusted + allow_unsigned ---


### PR DESCRIPTION
## Summary

Step C of ClotoHub Phase 1. Reflect MGP v0.6.3-draft Security Invariant 3
(merged in [mgp-spec#1](https://github.com/Cloto-dev/mgp-spec/pull/1) /
e834c98) in the kernel: an MCP server without a valid Magic Seal is
downgraded to `untrusted` regardless of its declared tier, instead of being
blocked outright. The isolation profile is pinned to the untrusted baseline
and a `TRUST_LEVEL_DOWNGRADED_NO_SEAL` audit event is emitted.

## Behavior change (v0.6.1 → v0.6.3)

| Declared tier | Seal absent (v0.6.1) | Seal absent (v0.6.3, this PR) |
|---|---|---|
| `core` | Allow at declared tier | **Force `untrusted`** + audit event |
| `standard` | Allow at declared tier | **Force `untrusted`** + audit event |
| `experimental` | Allow at declared tier | **Force `untrusted`** + audit event |
| `untrusted` | Block in production | **Allow at `untrusted`** (no downgrade needed) |

`Seal invalid` (tampering) continues to **Block** unconditionally — v0.6.3
only relaxed the `Seal absent` row.

## Files

- `crates/core/src/managers/mcp_seal.rs`
  - `check_seal` docstring updated to v0.6.3 behavior table.
  - `Untrusted + None + !allow_unsigned` returns `Unsigned` instead of `Failed`.
  - Test renamed `check_seal_untrusted_absent_blocks` → `..._allows_v063`,
    expectation inverted.
- `crates/core/src/managers/mcp.rs`
  - Seal Verification block in `start_server` rewritten:
    - Always go through `check_seal` (not only when `config.seal` is set)
      so the force-untrusted rule fires uniformly.
    - On `SealStatus::Unsigned` with declared tier ≠ Untrusted, override
      `effective_trust_level = Untrusted` and emit a `tracing::warn!` with
      `event_type = "TRUST_LEVEL_DOWNGRADED_NO_SEAL"` and structured fields
      (`server_id`, `declared_trust_level`, `effective_trust_level`) so
      audit consumers can match on event type.
    - `derive_isolation_profile` then receives `effective_trust_level`,
      pinning the isolation profile to the untrusted baseline.
  - Edge case: when the entry point is not a sealable file (interpreter
    from PATH), apply the same force-untrusted rule unless dev mode.

## Why `tracing::warn!` for the audit event

The kernel doesn't yet expose a typed audit bus reachable from this call
site. The structured `event_type` field gives stdout / log file / future
audit subscriber the same information at a single emission point.
Promoting to a typed audit event is a small follow-up (Step C-UI / Step F).

## Out of scope (deliberate)

- Dashboard "unverified" badge — pending separate PR (Step C-UI). Spec
  says Marketplace UI MUST surface this, but the data path needs the
  badge state to flow from server registration to the catalog API; that
  touches more files than belongs in this PR.
- `cloto seal generate/verify` CLI — Step B (next).
- Issuing seals to the 22 existing servers — Step D (after CLI).

## Verification

- `cargo test --workspace --exclude app --lib` → 257 + 8 + 23 = **288 passing, 0 failed**
- `cargo clippy --workspace --exclude app -- -D warnings <CI -A flags>` → clean
- `cargo fmt --all -- --check` → clean
- `bash scripts/verify-issues.sh` → exit 0 (89 verified / 132 fixed / 0 stale / 0 errors)
- Cross-checked all 20 issue-registry entries that reference `mcp.rs`/`mcp_seal.rs`
  — none collide with the edited regions (`feedback_auto_fix_registry_cross_check.md` guardrail)

## Diff verify

- 2 files / +105 / -40, both under `crates/core/src/managers/` — no contamination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)