### PR TITLE
feat(mcp): thread RegistryEntry.seal through to DB and runtime config (Step D-1)

### DIFF
--- a/crates/core/migrations/20260508000000_add_mcp_server_seal.sql
+++ b/crates/core/migrations/20260508000000_add_mcp_server_seal.sql
@@ -1,0 +1,6 @@
+-- Add Magic Seal column to mcp_servers (MGP_ISOLATION_DESIGN.md §8 L0).
+-- NULL ⇒ unsealed; the kernel forces effective trust_level to `untrusted`
+-- on connect (MGP v0.6.3 §10 inv 3, see crates/core/src/managers/mcp.rs).
+-- Existing rows stay NULL, so the v0.6.3 force-untrusted path activates
+-- immediately after migration without operator action.
+ALTER TABLE mcp_servers ADD COLUMN seal TEXT NULL;

--- a/crates/core/src/db/mcp.rs
+++ b/crates/core/src/db/mcp.rs
@@ -103,6 +103,10 @@ pub struct McpServerRecord {
     /// MGP trust level ('core' | 'standard' | 'experimental' | 'untrusted').
     /// NULL ⇒ isolation falls back to the Standard default at `mcp.rs:867`.
     pub trust_level: Option<String>,
+    /// MGP Magic Seal in `sha256:HEX` form (MGP_ISOLATION_DESIGN.md §8 L0).
+    /// NULL ⇒ kernel forces `effective_trust_level = untrusted` on connect
+    /// per v0.6.3 §10 inv 3 and emits `TRUST_LEVEL_DOWNGRADED_NO_SEAL`.
+    pub seal: Option<String>,
     pub is_active: bool,
     pub created_at: i64,
     pub updated_at: Option<i64>,
@@ -125,6 +129,7 @@ impl Default for McpServerRecord {
             marketplace_id: None,
             installed_version: None,
             trust_level: None,
+            seal: None,
             is_active: true,
             created_at: 0,
             updated_at: None,
@@ -138,8 +143,8 @@ pub async fn save_mcp_server(pool: &SqlitePool, record: &McpServerRecord) -> any
             "INSERT INTO mcp_servers \
              (name, command, args, env, transport, directory, display_name, auto_restart, \
               script_content, description, default_policy, marketplace_id, installed_version, \
-              trust_level, is_active, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+              trust_level, seal, is_active, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
              ON CONFLICT(name) DO UPDATE SET \
                command = excluded.command, \
                args = excluded.args, \
@@ -153,6 +158,7 @@ pub async fn save_mcp_server(pool: &SqlitePool, record: &McpServerRecord) -> any
                marketplace_id = COALESCE(excluded.marketplace_id, mcp_servers.marketplace_id), \
                installed_version = COALESCE(excluded.installed_version, mcp_servers.installed_version), \
                trust_level = COALESCE(excluded.trust_level, mcp_servers.trust_level), \
+               seal = COALESCE(excluded.seal, mcp_servers.seal), \
                is_active = excluded.is_active, \
                updated_at = unixepoch()",
         )
@@ -170,6 +176,7 @@ pub async fn save_mcp_server(pool: &SqlitePool, record: &McpServerRecord) -> any
         .bind(&record.marketplace_id)
         .bind(&record.installed_version)
         .bind(&record.trust_level)
+        .bind(&record.seal)
         .bind(record.is_active)
         .bind(record.created_at)
         .bind(record.updated_at)
@@ -184,7 +191,7 @@ pub async fn load_active_mcp_servers(pool: &SqlitePool) -> anyhow::Result<Vec<Mc
         sqlx::query_as::<_, McpServerRecord>(
             "SELECT name, command, args, env, transport, directory, display_name, auto_restart, \
              script_content, description, default_policy, marketplace_id, installed_version, \
-             trust_level, is_active, created_at, updated_at \
+             trust_level, seal, is_active, created_at, updated_at \
              FROM mcp_servers WHERE is_active = 1 ORDER BY created_at ASC",
         )
         .fetch_all(pool),

--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -59,6 +59,13 @@ pub struct RegistryEntry {
     pub bin_name: Option<String>,
     #[serde(default)]
     pub changelog: Option<String>,
+    /// MGP Magic Seal in `sha256:HEX` form (MGP_ISOLATION_DESIGN.md §8 L0).
+    /// Populated by upstream `cloto-mcp-servers` via `cloto seal generate`;
+    /// flows through marketplace install into `McpServerConfig.seal` and
+    /// the persisted DB record. `None` triggers v0.6.3 §10 inv 3
+    /// force-untrusted at connect time.
+    #[serde(default)]
+    pub seal: Option<String>,
 }
 
 fn default_trust_level() -> String {
@@ -1107,7 +1114,9 @@ async fn run_install(
     // Use add_server() for proper lifecycle integration:
     // creates ServerConfig → connect_server() (spawn + register) → save to DB.
     // The registry's trust_level is threaded through as MgpServerConfig so
-    // isolation derivation at next boot picks up the correct level.
+    // isolation derivation at next boot picks up the correct level. The
+    // registry's `seal` flows through unchanged so the kernel can verify
+    // it at connect time (MGP_ISOLATION_DESIGN.md §8 L0).
     let mgp = Some(crate::managers::mcp_mgp::MgpServerConfig {
         trust_level: Some(entry.trust_level.clone()),
     });
@@ -1120,6 +1129,7 @@ async fn run_install(
             None,
             Some(entry.description.clone()),
             mgp,
+            entry.seal.clone(),
             env_map,
         )
         .await
@@ -1896,6 +1906,7 @@ async fn run_batch_install(
                 None,
                 Some(entry.description.clone()),
                 mgp,
+                entry.seal.clone(),
                 env_map,
             )
             .await

--- a/crates/core/src/handlers/mcp.rs
+++ b/crates/core/src/handlers/mcp.rs
@@ -425,7 +425,9 @@ pub async fn create_mcp_server(
             (command, args, None)
         };
 
-    // Add server via McpClientManager (handles connection + DB persistence)
+    // Add server via McpClientManager (handles connection + DB persistence).
+    // Dynamic servers added via this API path have no upfront seal — the
+    // kernel applies v0.6.3 §10 inv 3 force-untrusted on connect.
     let tool_names = state
         .mcp_manager
         .add_server(
@@ -436,6 +438,7 @@ pub async fn create_mcp_server(
             body.get("description")
                 .and_then(|v| v.as_str())
                 .map(String::from),
+            None,
             None,
             std::collections::HashMap::new(),
         )

--- a/crates/core/src/managers/mcp.rs
+++ b/crates/core/src/managers/mcp.rs
@@ -390,6 +390,7 @@ impl McpClientManager {
                     .map(|tl| super::mcp_mgp::MgpServerConfig {
                         trust_level: Some(tl),
                     }),
+                seal: r.seal.clone(),
                 ..Default::default()
             })
             .collect();
@@ -685,9 +686,14 @@ impl McpClientManager {
                 auto_restart: Some(true),
                 required_permissions: Vec::new(),
                 display_name: None,
-                mgp: None,
+                mgp: record
+                    .trust_level
+                    .clone()
+                    .map(|tl| super::mcp_mgp::MgpServerConfig {
+                        trust_level: Some(tl),
+                    }),
                 restart_policy: None,
-                seal: None,
+                seal: record.seal.clone(),
                 isolation: None,
             });
         }
@@ -2355,6 +2361,13 @@ impl McpClientManager {
     // ============================================================
 
     /// Add a new dynamic MCP server, connect, and persist to DB.
+    ///
+    /// `seal`: optional `sha256:HEX` Magic Seal for the entry point. Threaded
+    /// from registry.json (`RegistryEntry.seal`) through marketplace install
+    /// into both the live `McpServerConfig` and the persisted record so the
+    /// kernel can verify it on connect (MGP_ISOLATION_DESIGN.md §8 L0).
+    /// `None` triggers v0.6.3 §10 inv 3 force-untrusted at connect time.
+    #[allow(clippy::too_many_arguments)]
     pub async fn add_server(
         &self,
         id: String,
@@ -2363,6 +2376,7 @@ impl McpClientManager {
         script_content: Option<String>,
         description: Option<String>,
         mgp: Option<super::mcp_mgp::MgpServerConfig>,
+        seal: Option<String>,
         env: HashMap<String, String>,
     ) -> Result<Vec<String>> {
         let config = McpServerConfig {
@@ -2378,14 +2392,15 @@ impl McpClientManager {
             display_name: None,
             mgp,
             restart_policy: None,
-            seal: None,
+            seal: seal.clone(),
             isolation: None,
         };
 
         // Persist to DB first (so server is always tracked even if connect fails).
-        // trust_level flows from the MgpServerConfig the caller built (e.g., from
-        // registry.json during marketplace install) into the DB so subsequent
-        // boots can derive the correct isolation profile before handshake.
+        // trust_level + seal flow from the MgpServerConfig + RegistryEntry the
+        // caller built (e.g., from registry.json during marketplace install)
+        // into the DB so subsequent boots can derive the correct isolation
+        // profile before handshake and verify the seal on connect.
         let trust_level = config.mgp.as_ref().and_then(|m| m.trust_level.clone());
         let record = crate::db::McpServerRecord {
             name: id.clone(),
@@ -2395,6 +2410,7 @@ impl McpClientManager {
             script_content,
             description,
             trust_level,
+            seal,
             created_at: chrono::Utc::now().timestamp(),
             is_active: true,
             ..Default::default()

--- a/crates/core/src/managers/mcp_kernel_tool.rs
+++ b/crates/core/src/managers/mcp_kernel_tool.rs
@@ -496,7 +496,12 @@ if __name__ == "__main__":
         }
     }
 
-    // Register and connect the server
+    // Register and connect the server.
+    //
+    // Agent-authored servers ship without a Magic Seal — they are generated at
+    // runtime, so there's nothing for the operator to sign ahead of time.
+    // Passing `seal=None` lets v0.6.3 §10 inv 3 take effect (already declared
+    // untrusted above, so the kernel keeps it under the untrusted profile).
     let mgp_config = Some(super::mcp_mgp::MgpServerConfig {
         trust_level: Some("untrusted".to_string()),
     });
@@ -508,6 +513,7 @@ if __name__ == "__main__":
             Some(script),
             Some(description.to_string()),
             mgp_config,
+            None,
             env,
         )
         .await


### PR DESCRIPTION
## Summary

Step D-1 of ClotoHub Phase 1. Connects the data path between
`cloto seal generate` (Step B, #101) and the kernel's seal verifier
(Step C, #100). Without this, `RegistryEntry.seal` would be parsed from
registry.json but silently dropped, leaving `McpServerConfig.seal`
permanently `None` — so v0.6.3 §10 inv 3 would force-untrust every
server, even sealed ones.

## Migration

`crates/core/migrations/20260508000000_add_mcp_server_seal.sql` adds
`seal TEXT NULL` to `mcp_servers`. Existing rows stay NULL, which matches
v0.6.3 unsealed-server semantics (force-untrusted on connect), so this
migration is **backwards-compatible** — deployments without reissued seals
keep running under untrusted profiles, exactly as v0.6.3 promises.

File is CRLF-encoded per the SQLx Migration Rules in CLAUDE.md (auto-
normalized by the `crlf-migrations-auto` PostToolUse hook on Write).

## Type changes

| File | Change |
|------|--------|
| `crates/core/src/handlers/marketplace.rs` | `RegistryEntry.seal: Option<String>`, `#[serde(default)]` so old registry.json still parses. |
| `crates/core/src/db/mcp.rs` | `McpServerRecord.seal: Option<String>` + Default + INSERT/UPDATE/SELECT/COALESCE updates in `save_mcp_server` and `load_active_mcp_servers`. |

## Flow changes

- `mcp.rs:391` (record → config in DB load → priority/deferred partition):
  threads `seal: r.seal.clone()`.
- `mcp.rs:677` (record → config in static-config branch): same change.
  Also corrected a pre-existing oversight where `mgp` was hard-coded to
  `None` here, dropping the trust_level on this code path; now it derives
  `MgpServerConfig.trust_level` from the record like its sibling.
- `McpClientManager::add_server`: new `seal: Option<String>` parameter
  threaded into both `McpServerConfig` and the persisted record.
  4 call sites updated:
  - `handlers/marketplace.rs::run_install` — passes `entry.seal.clone()`
  - `handlers/marketplace.rs::run_batch_install` — same
  - `managers/mcp_kernel_tool.rs::create_mcp_server` — passes `None`
    (agent-authored servers; declared untrusted, force-untrusted is a no-op)
  - `handlers/mcp.rs::add_mcp_server` — passes `None` (admin REST API for
    ad-hoc server registration; no seal at call time)

## Verification

```
cargo check --workspace --exclude app                               # clean
cargo test  --workspace --exclude app --lib                         # 265 passing, 0 failed
cargo clippy --workspace --exclude app -- -D warnings <CI -A flags> # clean
cargo fmt --all -- --check                                          # clean
bash scripts/verify-issues.sh                                       # exit 0
file crates/core/migrations/20260508000000_add_mcp_server_seal.sql  # CRLF
```

## Diff scope

6 files / +61 / -12. New migration + small surgical edits across one DB
module, one core flow module, and three handler call sites — no churn
elsewhere.

## Out of scope

- **Step D-2**: issuing seals to the 22 cloto-mcp-servers (next, in
  `cloto-mcp-servers` repo — runs `cloto seal generate` over each Python
  entry point and writes the values into `registry.json`).
- **Rust servers (avatar / discord)**: sealing build artifacts requires
  release-pipeline changes; tracked as Step F follow-up.
- **Dashboard "unverified" badge**: Step C-UI, can run in parallel with
  D-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)