### PR TITLE
feat(dashboard): show Magic Seal verified/unverified badge on MarketplaceCard

### DIFF
--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -116,6 +116,12 @@ pub struct CatalogEntry {
     pub icon: Option<String>,
     pub runtime: String,
     pub changelog: Option<String>,
+    /// MGP Magic Seal in `sha256:HEX` form (registry-side, before install).
+    /// `None` means the upstream registry did not ship a seal — at runtime
+    /// the kernel will force trust_level=untrusted (MGP v0.6.3 §10 inv 3).
+    /// Surfaced to the dashboard so MarketplaceCard can show a verified /
+    /// unverified badge before the user installs.
+    pub seal: Option<String>,
     // Merged local state
     pub installed: bool,
     pub installed_version: Option<String>,
@@ -210,6 +216,7 @@ pub async fn catalog_handler(
                 icon: entry.icon.clone(),
                 runtime: entry.runtime.clone(),
                 changelog: entry.changelog.clone(),
+                seal: entry.seal.clone(),
                 installed,
                 installed_version,
                 update_available,

--- a/dashboard/src/compiled-tailwind.css
+++ b/dashboard/src/compiled-tailwind.css
@@ -1797,6 +1797,10 @@ video {
   border-color: rgb(245 158 11 / 0.2);
 }
 
+.border-amber-500\/25 {
+  border-color: rgb(245 158 11 / 0.25);
+}
+
 .border-amber-500\/30 {
   border-color: rgb(245 158 11 / 0.3);
 }
@@ -1862,6 +1866,10 @@ video {
 
 .border-emerald-500\/20 {
   border-color: rgb(16 185 129 / 0.2);
+}
+
+.border-emerald-500\/25 {
+  border-color: rgb(16 185 129 / 0.25);
 }
 
 .border-emerald-500\/30 {

--- a/dashboard/src/components/mcp/MarketplaceCard.tsx
+++ b/dashboard/src/components/mcp/MarketplaceCard.tsx
@@ -13,6 +13,8 @@ import {
   Monitor,
   Package,
   Search,
+  ShieldAlert,
+  ShieldCheck,
   Sparkles,
   Terminal,
   Wrench,
@@ -40,6 +42,38 @@ const ICON_MAP: Record<string, LucideIcon> = {
   'message-circle': MessageCircle,
 };
 
+// Static class map (Tailwind is pre-compiled, so tone keys must resolve to
+// fully-literal class strings — no `bg-${tone}-500/15` interpolation).
+const BADGE_TONE = {
+  orange: 'bg-orange-500/15 text-orange-400 border-orange-500/25',
+  emerald: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/25',
+  amber: 'bg-amber-500/15 text-amber-400 border-amber-500/25',
+} as const;
+
+type BadgeTone = keyof typeof BADGE_TONE;
+
+function Badge({
+  icon: BadgeIcon,
+  label,
+  tone,
+  title,
+}: {
+  icon?: LucideIcon;
+  label: string;
+  tone: BadgeTone;
+  title?: string;
+}) {
+  return (
+    <span
+      title={title}
+      className={`inline-flex items-center gap-1 text-[10px] font-mono px-1.5 py-0.5 rounded border ${BADGE_TONE[tone]}`}
+    >
+      {BadgeIcon && <BadgeIcon size={11} aria-hidden="true" />}
+      {label}
+    </span>
+  );
+}
+
 interface MarketplaceCardProps {
   entry: MarketplaceCatalogEntry;
   onInstall: (entry: MarketplaceCatalogEntry) => void;
@@ -61,14 +95,29 @@ export function MarketplaceCard({ entry, onInstall, onUninstall, actionsDisabled
       <div className="flex items-center gap-2">
         <Icon size={14} className="text-brand shrink-0" />
         <span className="text-[13px] font-sans font-bold text-content-primary truncate">{entry.name}</span>
-        {entry.runtime === 'rust' && (
-          <span className="text-[9px] font-mono px-1 rounded bg-orange-500/15 text-orange-400 border border-orange-500/25 shrink-0">
-            Rust
-          </span>
-        )}
         <span className="ml-auto text-[11px] font-sans px-1.5 rounded bg-surface-secondary text-content-tertiary uppercase shrink-0">
           {entry.category}
         </span>
+      </div>
+
+      {/* Badge row (runtime + Magic Seal verification) */}
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {entry.runtime === 'rust' && <Badge label="Rust" tone="orange" />}
+        {entry.seal ? (
+          <Badge
+            icon={ShieldCheck}
+            label={t('marketplace.seal_verified')}
+            tone="emerald"
+            title={t('marketplace.seal_verified_tooltip')}
+          />
+        ) : (
+          <Badge
+            icon={ShieldAlert}
+            label={t('marketplace.seal_unverified')}
+            tone="amber"
+            title={t('marketplace.seal_unverified_tooltip')}
+          />
+        )}
       </div>
 
       {/* Description */}

--- a/dashboard/src/locales/en/mcp.json
+++ b/dashboard/src/locales/en/mcp.json
@@ -127,6 +127,10 @@
     "uninstall_error": "Failed to uninstall server",
     "install_success": "{{name}} installed successfully",
     "uninstall_success": "{{name}} uninstalled successfully",
-    "rust_notice": "This server requires the Rust toolchain (cargo). First build may take 5-10 minutes."
+    "rust_notice": "This server requires the Rust toolchain (cargo). First build may take 5-10 minutes.",
+    "seal_verified": "Verified",
+    "seal_verified_tooltip": "Magic Seal present — kernel will honor the declared trust level.",
+    "seal_unverified": "Unverified",
+    "seal_unverified_tooltip": "No Magic Seal — kernel will force trust level to untrusted at runtime (MGP v0.6.3 §10 invariant 3)."
   }
 }

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -271,6 +271,10 @@ export interface MarketplaceCatalogEntry {
   auto_restart: boolean;
   icon?: string;
   runtime: string;
+  /** MGP Magic Seal in `sha256:HEX` form. `null` / `undefined` = unverified
+   * (registry shipped without seal). Used by MarketplaceCard to render a
+   * verified / unverified badge. See MGP v0.6.3 §10 invariant 3. */
+  seal?: string | null;
   installed: boolean;
   installed_version?: string;
   update_available: boolean;


### PR DESCRIPTION
## Summary

Step C-UI of MGP v0.6.3 Phase 1 (Scope 2 Goal 10). Surfaces the runtime
force-untrusted decision shipped in PR #100 at the **marketplace catalog**
level so users can see, before installing, which servers will be downgraded
to `trust_level=untrusted` by the kernel at connect time.

- Adds `seal: Option<String>` to `CatalogEntry` and threads `entry.seal.clone()` through `catalog_handler`. Mirrors the field already present on `RegistryEntry` / `McpServerRecord` / `McpServerConfig` from #102 (Step D-1).
- New `Badge` helper component with a static `BADGE_TONE` class map inside `MarketplaceCard.tsx`. Tailwind in this dashboard is pre-compiled, so tone keys must resolve to literal class strings (no `bg-${tone}-500/15` interpolation). Refactor folds the existing Rust runtime badge into the same helper, removing the previous 3-way duplication.
- Moves the runtime/seal badge row out of the header line — long server names were getting compressed to `Termi…` / `Embe…` on first paint.
- Renders **emerald `Verified`** (ShieldCheck) when `seal` is present, **amber `Unverified`** (ShieldAlert) when absent. With current upstream `cloto-mcp-servers` (no seals shipped yet — D-2 was deferred to Scope 3 Goal 19, the ClotoHub.dev MVP), every connector currently shows the amber badge, which matches the kernel's runtime behaviour.

i18n: `marketplace.seal_{verified,unverified}{,_tooltip}` added to `locales/en/mcp.json`. The Japanese pack is loaded from external language packs (`Documents/ClotoCore/languages/`) per `dashboard/src/i18n.ts`, so no in-repo `ja/mcp.json` to update.

## Test plan

- [x] `npx biome check src/components/mcp/MarketplaceCard.tsx src/types.ts src/locales/en/mcp.json`
- [x] `cargo clippy --workspace --exclude app -- -D warnings -A clippy::too-many-lines …` (CI flag set, ci.yml:44)
- [x] `cargo test --workspace --exclude app` — all green
- [x] `npm run build` — typecheck + Vite build clean
- [x] `bash scripts/verify-issues.sh` — 89 verified / 132 fixed / 0 stale / 0 errors
- [x] `cargo fmt --all -- --check` — clean
- [x] Visual confirmation via `npx tauri dev` with 16 installed servers — all show amber `Unverified` badge in the new dedicated badge row, no header compression, tooltip emits the §10 inv 3 explanation. Header / Rust badge interaction also re-verified after the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)