### PR TITLE
chore(deps): cut mgp-seal source from mgp-seal repo to mgp-rs workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,6 +1545,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "daachorse"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,6 +1987,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2296,12 @@ checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -4125,14 +4183,17 @@ dependencies = [
 
 [[package]]
 name = "mgp-seal"
-version = "0.1.0"
-source = "git+https://github.com/Cloto-dev/mgp-seal?tag=v0.1.0#e8dd703b082c09c9f4073aef74831c685a1638a7"
+version = "0.2.0"
+source = "git+https://github.com/Cloto-dev/mgp-rs?tag=mgp-seal-v0.2.0#6e62471116f27977929c3e791de1c5baa7e64589"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
+ "ed25519-dalek",
  "hex",
  "hmac",
  "rand 0.8.6",
  "serde",
+ "serde_json",
  "sha2",
  "subtle",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -41,7 +41,7 @@ argon2 = "0.5"
 clap = { version = "4", features = ["derive"] }
 rand = "0.8"
 subtle = "2"
-mgp-seal = { git = "https://github.com/Cloto-dev/mgp-seal", tag = "v0.1.0" }
+mgp-seal = { git = "https://github.com/Cloto-dev/mgp-rs", tag = "mgp-seal-v0.2.0" }
 toml = "1.0"
 cron = "0.16"
 uuid.workspace = true


### PR DESCRIPTION
## Summary

Phase 5c — completes the mgp-rs workspace migration on the consumer side. ClotoCore's `mgp-seal` git source switches from the pre-workspace `Cloto-dev/mgp-seal` repo (top-level layout, tag `v0.1.0`) to the new `Cloto-dev/mgp-rs` cargo workspace (tag `mgp-seal-v0.2.0`, crate at `crates/mgp-seal`).

- API surface used by ClotoCore (`TrustLevel`, `SealStatus`, `load_or_generate_seal_key`, `check_seal`) is unchanged between v0.1.0 and v0.2.0; v0.2.0 only adds the `ed25519` module (Tier 2 asymmetric signing) which ClotoCore does not consume. `SealStatus` variants (`Verified` / `Failed` / `Unsigned` / `Skipped`) match exactly.
- Cargo.lock cleanly drops the old git source and pulls in the new one. Ed25519 transitive deps (`curve25519-dalek`, `ed25519-dalek`) are introduced because mgp-seal v0.2.0 links them unconditionally — this is acceptable for the cutover.

## Diff

- `crates/core/Cargo.toml`: 1 line — `git` URL + `tag` updated.
- `Cargo.lock`: 64 lines — old git source removed, new git source added, ed25519 transitive deps appended.

## Test plan

- [x] `cargo check --workspace --exclude app` — green
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace --exclude app` — 234 unit + integration suites all pass, 0 failures
- [x] `bash scripts/verify-issues.sh` — 89 VERIFIED + 132 FIXED + 0 STALE + 0 ERROR
- [ ] CI on this PR is green

The pre-existing baseline clippy warning in `crates/core/tests/tool_rejection_smoke.rs:69` (`too_many_lines`) is unrelated to this PR and tracked separately under the master baseline issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)