### PR TITLE
docs: translate ClotoCore small-touch Japanese strings to English (5 files)

### DIFF
--- a/docs/SECURITY_LAYER_AUDIT_20260404.md
+++ b/docs/SECURITY_LAYER_AUDIT_20260404.md
@@ -78,7 +78,7 @@ Phase 2 OS-level enforcement (cgroups, seccomp, iptables) is designed but deferr
 #### Layer 6: DNS Rebinding Protection
 - **IP validation**: `capabilities.rs:39-57` — blocks private, loopback, link-local, multicast
 - **Checked before request**: `capabilities.rs:104-124` — `lookup_host()` + IP validation
-- **Comment**: explicitly marked "DNS Rebinding対策"
+- **Comment**: source explicitly marked `"DNS Rebinding対策"` (= "DNS Rebinding mitigation")
 
 #### Layer 7: API Key Auth + Rate Limiting
 - **Auth**: `handlers.rs:83-139` — `X-API-Key` header, constant-time comparison (`subtle::ConstantTimeEq`)

--- a/docs/VRM_AVATAR_MOTION_DESIGN.md
+++ b/docs/VRM_AVATAR_MOTION_DESIGN.md
@@ -55,7 +55,7 @@ by MGP (Multi-Agent Gateway Protocol) rather than embedded in the kernel.
 
 Final bone transform = Layer 1 + Layer 2 + Layer 3 (additive blending)
 
-### 2.1 Layer 1: Vitality (生命感)
+### 2.1 Layer 1: Vitality
 
 Always-running procedural animation computed locally in the dashboard at 60fps.
 No per-frame MGP communication required.
@@ -99,7 +99,7 @@ Parameters are dynamically adjustable via MGP:
 The dashboard updates its procedural generation parameters; subsequent frames
 use the new values. No per-frame MGP messages are sent.
 
-### 2.2 Layer 2: Emotional Posture (感情姿勢) ★ Research Area ★
+### 2.2 Layer 2: Emotional Posture ★ Research Area ★
 
 Maps `persona.emotion` v1.0 emotion vectors to continuous body parameter adjustments.
 `persona.emotion` is a dedicated MCP server, independent from `memory.cpersona`.
@@ -160,7 +160,7 @@ ClotoCore's layered approach combines all three: procedural base (Layer 1),
 continuous emotion mapping (Layer 2), and hybrid gestures (Layer 3). The
 "invention" lies in Layer 2's continuous emotion-to-body mapping.
 
-### 2.3 Layer 3: Gesture (ジェスチャー)
+### 2.3 Layer 3: Gesture
 
 Discrete actions triggered by events, speech, or agent decisions.
 Uses D-3 Hybrid approach: procedural for head/neck, animation clips for arms/body.
@@ -308,7 +308,7 @@ The dashboard maintains a viseme schedule buffer:
 
 ---
 
-## 5. Look At (視線・頭部追跡)
+## 5. Look At
 
 ### 5.1 Three-Tier Fallback
 

--- a/docs/hn-prep/hn-plan-clotocore.md
+++ b/docs/hn-prep/hn-plan-clotocore.md
@@ -1,14 +1,14 @@
-# HN投稿 & リポジトリ整備計画（ClotoCore中心）
-## 2026-04-03 〜 04-10
+# HN Submission & Repo-Prep Plan (ClotoCore-centric)
+## 2026-04-03 to 04-10
 
 ---
 
-## 投稿対象
+## Submission target
 **ClotoCore** (https://github.com/Cloto-dev/ClotoCore)
-cpersonaはClotoCoreの一部として言及。単体投稿ではない。
+cpersona is mentioned as a part of ClotoCore. Not a standalone post.
 
-## キー数字
-| 指標 | 値 |
+## Key numbers
+| Metric | Value |
 |------|-----|
 | Rust LOC | ~34,000 |
 | TypeScript LOC | ~17,000 |
@@ -17,78 +17,78 @@ cpersonaはClotoCoreの一部として言及。単体投稿ではない。
 | Tools | 100+ |
 | Tests | 351 (Rust 234 + Python 117) |
 | Dev cost | $230 |
-| Dev period | 3ヶ月（2026年1月〜） |
+| Dev period | 3 months (since Jan 2026) |
 | Developer | Solo |
 
-## 訴求軸（2軸）
-1. **AIエージェント基盤** — Rustカーネル、MCPプラグイン、サンドボックス、GUIダッシュボード
-2. **$230ソロ開発** — AI-assisted developmentのdata point
+## Pitch axes (2)
+1. **AI agent platform** — Rust kernel, MCP plugins, sandbox, GUI dashboard
+2. **$230 solo dev** — a data point for AI-assisted development
 
 ---
 
-## 今日完了した作業
-- [x] cpersona専用README.md新規作成（HN経由の流入用）
-- [x] cloto-mcp-servers/README.md → v2.4.4対応更新
-- [x] ClotoCore/README.md → テスト数・embedding記述更新
-- [x] 3ファイル間の整合性検証
+## Completed today
+- [x] New cpersona-dedicated README.md (for HN-driven traffic)
+- [x] Updated cloto-mcp-servers/README.md to v2.4.4
+- [x] Updated ClotoCore/README.md (test counts, embedding sections)
+- [x] Cross-checked consistency between the 3 files
 
-## 残タスク
+## Remaining tasks
 
-### 博士側（手動）
-| タスク | 期限 |
+### Author side (manual)
+| Task | Due |
 |--------|------|
-| README内容レビュー | 4/4 |
-| git commit & push（cloto-mcp-servers + ClotoCore） | 4/4 |
-| GitHub Sponsors設置確認 | 4/6 |
-| テスト全通過確認 | 4/7 |
-| HN投稿文の最終レビュー・暗記 | 4/7 |
-| ダッシュボードスクリーンショット最新化（任意） | 4/7 |
+| README content review | 4/4 |
+| git commit & push (cloto-mcp-servers + ClotoCore) | 4/4 |
+| Confirm GitHub Sponsors setup | 4/6 |
+| Confirm full test suite passes | 4/7 |
+| Final review and memorization of HN post text | 4/7 |
+| Refresh dashboard screenshots (optional) | 4/7 |
 
-### 次のセッション
-| タスク | 説明 |
+### Next session
+| Task | Notes |
 |--------|------|
-| HN投稿文の最終磨き | 博士のフィードバック反映 |
-| Q&Aの追加・修正 | 実際のHN投稿例を参考に調整 |
-| self-commentの精査 | 4項目の優先順位・長さ調整 |
+| Final polish of HN post text | Apply author's feedback |
+| Add/refine Q&A | Tune based on actual HN post examples |
+| Tighten self-comment | Adjust priority and length of the 4 items |
 
 ---
 
-## タイムライン
+## Timeline
 
-| 日付 | タスク |
+| Date | Task |
 |------|--------|
-| 4/3 (木) | ✅ README整備 + HN投稿文ドラフト + Q&A完成 |
-| 4/4 (金) | 博士レビュー → commit & push |
-| 4/5 (土) | Q&A暗記 + 最終調整 |
-| 4/6 (日) | QRトラッキング案件締切対応 |
-| 4/7 (月) | 最終確認（テスト・Sponsors・スクショ） |
-| 4/8 (火) | **HN投稿** 🎯 JST 01:00-03:00 = US西海岸火曜午前 |
-| 4/9 (水) | HNコメント対応 |
-| 4/10 (木) | 予備日 |
+| 4/3 (Thu) | ✅ README prep + HN post draft + Q&A complete |
+| 4/4 (Fri) | Author review → commit & push |
+| 4/5 (Sat) | Q&A memorization + final adjustments |
+| 4/6 (Sun) | Handle the QR-tracking project deadline |
+| 4/7 (Mon) | Final checks (tests, Sponsors, screenshots) |
+| 4/8 (Tue) | **HN submission** 🎯 JST 01:00-03:00 = Tue morning US Pacific |
+| 4/9 (Wed) | Respond to HN comments |
+| 4/10 (Thu) | Buffer day |
 
 ---
 
-## 投稿前チェックリスト
+## Pre-submission checklist
 
-- [x] ClotoCore/README.md が最新かつ正確（ドキュメント監査完了 4/3）
-- [x] cloto-mcp-servers/README.md がv2.4.6と整合（監査完了 4/3）
-- [x] cpersona/README.md が存在しHN経由の流入に対応
-- [x] FUNDING.yml 設置済み（Sponsorsプロフィール申請は手動で必要）
-- [x] ライセンスファイル確認（ClotoCore=BSL 1.1, cpersona=MIT）
-- [x] テスト全通過確認（351: 234 Rust + 117 Python, 4/3確認）
-- [x] v0.6.3-beta.1 リリースビルド完了（24MB .exe, GitHub Release添付済み）
-- [ ] ダッシュボードGIF + スクリーンショット最新化（DaVinci Resolve編集予定）
-- [x] HN投稿文の最終レビュー完了（4/4）
-- [x] self-commentの準備完了
-- [ ] Q&A回答の暗記完了
+- [x] ClotoCore/README.md current and accurate (doc audit done 4/3)
+- [x] cloto-mcp-servers/README.md aligned with v2.4.6 (audit done 4/3)
+- [x] cpersona/README.md exists and serves HN-driven traffic
+- [x] FUNDING.yml in place (Sponsors profile registration still needs to be done manually)
+- [x] License files confirmed (ClotoCore=BSL 1.1, cpersona=MIT)
+- [x] Full test suite passes (351: 234 Rust + 117 Python, confirmed 4/3)
+- [x] v0.6.3-beta.1 release build complete (24MB .exe, attached to GitHub Release)
+- [ ] Refresh dashboard GIF + screenshots (planned in DaVinci Resolve)
+- [x] Final review of HN post text complete (4/4)
+- [x] Self-comment prepared
+- [ ] Q&A responses memorized
 
 ---
 
-## 成果物一覧
+## Deliverables
 
-| ファイル | 内容 |
+| File | Contents |
 |----------|------|
-| `hn-show-hn-clotocore.md` | HN投稿文ドラフト + self-comment + タイミング表 |
-| `hn-qa-clotocore.md` | 想定Q&A 18問（技術8 + 開発プロセス4 + ビジネス3 + 批判4） |
-| `hn-plan-clotocore.md` | この計画書 |
-| `servers/cpersona/README.md` | cpersona専用README（新規、リポジトリに直接書き込み済み） |
+| `hn-show-hn-clotocore.md` | HN post draft + self-comment + timing table |
+| `hn-qa-clotocore.md` | 18 anticipated Q&A (tech 8 + dev process 4 + business 3 + critique 4) |
+| `hn-plan-clotocore.md` | This planning doc |
+| `servers/cpersona/README.md` | Dedicated cpersona README (new, written directly into the repo) |

--- a/docs/hn-prep/hn-qa-clotocore.md
+++ b/docs/hn-prep/hn-qa-clotocore.md
@@ -1,8 +1,8 @@
-# HN想定Q&A — ClotoCore
+# HN Anticipated Q&A — ClotoCore
 
 ---
 
-## 技術・アーキテクチャ系
+## Technical & Architecture
 
 ### Q: Why Rust? Isn't that overkill for an AI agent framework?
 
@@ -56,7 +56,7 @@ Different trade-off: WASM is tighter per-call isolation. MGP is a security contr
 
 ---
 
-## 開発プロセス系
+## Development Process
 
 ### Q: "$230 total dev cost" — what does that actually mean?
 
@@ -78,7 +78,7 @@ This isn't about being frugal — it's evidence that the barrier to building non
 
 ---
 
-## ビジネス・ライセンス系
+## Business & License
 
 ### Q: BSL 1.1 — why not just MIT/Apache?
 
@@ -94,7 +94,7 @@ This isn't about being frugal — it's evidence that the barrier to building non
 
 ---
 
-## 批判・懐疑系
+## Criticism & Skepticism
 
 ### Q: How does this compare to OpenFang or OpenPawz?
 

--- a/docs/hn-prep/hn-show-hn-clotocore.md
+++ b/docs/hn-prep/hn-show-hn-clotocore.md
@@ -1,8 +1,8 @@
-# HN投稿ドラフト — ClotoCore
+# HN Submission Draft — ClotoCore
 
-## タイトル候補
+## Title candidates
 
-**A (推奨):**
+**A (recommended):**
 ```
 Show HN: ClotoCore – A Rust AI agent platform ($230 total dev cost, 50K LOC, solo dev)
 ```
@@ -19,7 +19,7 @@ Show HN: ClotoCore – Build AI agents with sandboxed MCP plugins, Rust kernel, 
 
 ---
 
-## 本文ドラフト
+## Body draft
 
 ```
 Hi HN,
@@ -96,7 +96,7 @@ in practice.
 
 ---
 
-## self-comment（投稿直後に自分で書くコメント）
+## Self-comment (posted by the author immediately after submission)
 
 ```
 A few notes on the development process:
@@ -144,23 +144,23 @@ Architecture doc: https://github.com/Cloto-dev/ClotoCore/blob/main/docs/ARCHITEC
 
 ---
 
-## 投稿タイミング
+## Submission timing
 
-| 候補 | 日本時間 | US西海岸時間 | 曜日 |
+| Candidate | JST | US Pacific | Day |
 |------|---------|-------------|------|
-| **第一候補** | 4/8 (水) 01:00-03:00 | 4/7 (火) 09:00-11:00 | 火曜 |
-| 予備1 | 4/9 (木) 01:00-03:00 | 4/8 (水) 09:00-11:00 | 水曜 |
-| 予備2 | 4/10 (金) 01:00-03:00 | 4/9 (木) 09:00-11:00 | 木曜 |
+| **Primary** | 4/8 (Wed) 01:00-03:00 | 4/7 (Tue) 09:00-11:00 | Tue |
+| Backup 1 | 4/9 (Thu) 01:00-03:00 | 4/8 (Wed) 09:00-11:00 | Wed |
+| Backup 2 | 4/10 (Fri) 01:00-03:00 | 4/9 (Thu) 09:00-11:00 | Thu |
 
 ---
 
-## トーンチェック
+## Tone check
 
-- [x] 「抑制された自信」— 事実を淡々と列挙
-- [x] 経済的困窮への言及なし
-- [x] $230は「data point」として中立的に提示
-- [x] "Built with Claude Code" はさらっと明記
-- [x] 過激表現なし（"revolutionary", "game-changing" 等の排除）
-- [x] Neuro-Samaへの言及はHN読者に文脈を提供（VTuberクロスオーバー層の関心）
-- [x] GitHub Sponsorsへの直接誘導なし（リポジトリ側で自然に導線）
-- [x] ライセンスの透明性（BSL 1.1の条件を明示）
+- [x] "Restrained confidence" — list facts plainly
+- [x] No mention of financial hardship
+- [x] $230 presented neutrally as a "data point"
+- [x] "Built with Claude Code" mentioned in passing
+- [x] No hyperbole (avoid "revolutionary", "game-changing", etc.)
+- [x] Neuro-Sama reference gives HN readers context (interest from the VTuber crossover audience)
+- [x] No direct GitHub Sponsors call-to-action (let the repo side handle that organically)
+- [x] License transparency (BSL 1.1 terms made explicit)


### PR DESCRIPTION
## Summary

Translate small-touch Japanese strings in ClotoCore docs to English per
the public-repo English-only documentation rule (parent CLAUDE.md,
2026-05-09). Five files, five focused commits within this PR.

### Translated (5 commits)

1. \`docs/VRM_AVATAR_MOTION_DESIGN.md\` — drop parenthetical Japanese
   from 4 section headers (Vitality / Emotional Posture / Gesture /
   Look At). The Japanese phonemes \`あ, い, う, え, お\` in the viseme
   table at line 258 are kept verbatim because they are reference
   data for the visemes themselves.
2. \`docs/SECURITY_LAYER_AUDIT_20260404.md\` — annotate the quoted code
   comment \`"DNS Rebinding対策"\` with an inline English gloss
   (\`= "DNS Rebinding mitigation"\`). The Japanese remains because it
   quotes the actual source comment in \`capabilities.rs\`; the source
   itself is Phase 3 scope (opportunistic source-comment migration).
3. \`docs/hn-prep/hn-qa-clotocore.md\` — translate 5 Japanese section
   headers to English; the Q&A content was already English.
4. \`docs/hn-prep/hn-show-hn-clotocore.md\` — translate metadata
   sections (title candidates header, body draft header, self-comment
   header, submission timing table, tone-check checklist). Actual HN
   post drafts inside fenced code blocks were already English.
5. \`docs/hn-prep/hn-plan-clotocore.md\` — translate the launch-plan
   prose end-to-end (timeline, key numbers, checklists, deliverables).

### No-change (intentional Japanese, verified in plan)

- \`CONTRIBUTING.md:144\` — \`日本語\` is the rule example itself
- \`README.md:353\` — \`VOICEVOX:ナースロボ＿タイプＴ\` is a product proper noun
- \`docs/CPERSONA_MEMORY_DESIGN.md\` — all 7 Japanese occurrences are
  linguistic examples (\`たぶんね\`, \`田中\`, \`パン\`, \`ラズベリーパイ\`)

## Test plan

- [x] \`grep -P '[\\p{Hiragana}\\p{Katakana}\\p{Han}]' <each translated file>\` returns 0 (or only intentional residue per above)
- [x] \`bash scripts/verify-issues.sh\` -> all green (89 verified + 132 fixed, 0 errors)
- [x] No dashboard/src files touched -> biome / Tailwind not affected
- [x] Markdown renders correctly (tables align, code blocks intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)