### PR TITLE
docs: translate MCP_STARTUP_PERFORMANCE analysis to English

### DIFF
--- a/docs/MCP_STARTUP_PERFORMANCE.md
+++ b/docs/MCP_STARTUP_PERFORMANCE.md
@@ -1,11 +1,11 @@
 # MCP Server Startup Performance Analysis
 
-**分析日**: 2026-03-17
-**対象**: カーネル起動時の MCP サーバー接続フロー
+**Analysis date**: 2026-03-17
+**Subject**: MCP server connection flow during kernel startup
 
-## サーバー構成 (mcp.toml)
+## Server lineup (mcp.toml)
 
-| サーバーID | カテゴリ | auto_restart | 起動対象 |
+| Server ID | Category | auto_restart | Startup tier |
 |-----------|---------|-------------|---------|
 | tool.terminal | Tool | true | Priority |
 | tool.agent_utils | Tool | true | Priority |
@@ -23,160 +23,160 @@
 | tool.imagegen | Tool | false | Deferred |
 | voice.stt | Voice | false | Deferred |
 
-**合計**: 15サーバー (11 Priority / 4 Deferred)
-**全サーバー**: Python stdio
+**Total**: 15 servers (11 Priority / 4 Deferred)
+**All servers**: Python stdio
 
-## 接続ライフサイクル (per server)
+## Connection lifecycle (per server)
 
-`connect_server()` (`mcp.rs:462-1065`) の各ステップ:
+Steps inside `connect_server()` (`mcp.rs:462-1065`):
 
-| # | ステップ | 所要時間 | タイムアウト | ブロッキング |
+| # | Step | Duration | Timeout | Blocking |
 |---|---------|---------|------------|-------------|
-| 1 | コマンド検証 | <1ms | — | No |
+| 1 | Command validation | <1ms | — | No |
 | 2 | Permission Gate D | 0-500ms (YOLO) | DB 10s | Yes |
-| 3 | Seal検証 | 0-500ms | — | Conditional |
+| 3 | Seal verification | 0-500ms | — | Conditional |
 | 4 | Isolation Profile | <5ms | — | No |
-| 5 | **プロセス起動** | **500ms-2s** | — | **Yes** |
+| 5 | **Process spawn** | **500ms-2s** | — | **Yes** |
 | 6 | **Initialize RPC** | **1-5s** | **120s** | **Yes** |
 | 7 | MGP Negotiation | <1ms | — | No |
 | 8 | MGP Permission Flow | 0-500ms (YOLO) | 120s | Conditional |
-| 9 | Initialized通知 | <1ms | — | No |
+| 9 | Initialized notification | <1ms | — | No |
 | 10 | **tools/list RPC** | **100-500ms** | **120s** | **Yes** |
 | 11 | Cloto Handshake | 100-500ms | 120s | Optional |
-| 12 | 登録 + インデックス | <50ms | — | No |
+| 12 | Registration + indexing | <50ms | — | No |
 | 13 | Capability Dispatcher | 10-50ms | — | No |
 | 14 | Audit/Lifecycle | <1ms | — | No (spawn) |
 
-**1サーバーあたり正常時**: 2-8秒
-**1サーバーあたり最悪時**: 360秒 (3回リトライ × 120秒タイムアウト)
+**Per server, normal case**: 2-8 seconds
+**Per server, worst case**: 360 seconds (3 retries × 120 s timeout)
 
-## 起動タイムライン
+## Startup timeline
 
-### シナリオ A: 初回起動 (venv未作成)
+### Scenario A: Cold start (venv missing)
 
 ```
-  0s ─── カーネル起動、Config/DB初期化
-  2s ─── Plugin Manager 初期化
-  5s ─── ensure_mcp_venv() 開始
-         ├── python -m venv 作成: 1-3s
+  0s ─── Kernel start, Config/DB initialization
+  2s ─── Plugin Manager initialization
+  5s ─── ensure_mcp_venv() begins
+         ├── python -m venv create: 1-3s
          ├── pip upgrade: 2-10s
-         └── 15サーバー依存 pip install (順次): 30-75s ← ★最大ボトルネック
- 80s ─── Priority MCP接続 (11台並列) ← join_all で並列化済み
-         ├── プロセス起動: ~2s (最も遅い1台)
+         └── 15-server pip install (sequential): 30-75s ← ★ biggest bottleneck
+ 80s ─── Priority MCP connect (11 servers in parallel) ← already join_all parallelized
+         ├── Process spawn: ~2s (slowest one)
          ├── Initialize RPC: ~2s
          └── tools/list: ~1s
- 86s ─── HTTP サーバー起動 → ダッシュボードアクセス可能
- 86s ─── Deferred MCP接続 (4台バックグラウンド)
- 92s ─── 全サーバー接続完了
+ 86s ─── HTTP server up → dashboard reachable
+ 86s ─── Deferred MCP connect (4 in background)
+ 92s ─── All servers connected
 ```
 
-**合計**: **80-95秒** (ボトルネック: venv依存インストール)
+**Total**: **80-95 seconds** (bottleneck: venv dependency install)
 
-### シナリオ B: 通常起動 (venv既存)
-
-```
-  0s ─── カーネル起動、Config/DB初期化
-  2s ─── Plugin Manager 初期化
-  5s ─── ensure_mcp_venv() — venv検出 + 依存sync
-         └── pip install --quiet × 15 (no-op): 15-30s ← ★ボトルネック
- 35s ─── Priority MCP接続 (11台並列)
-         └── 並列接続: ~5s
- 40s ─── HTTP サーバー起動
- 46s ─── 全サーバー接続完了
-```
-
-**合計**: **35-46秒** (ボトルネック: pip no-op チェック)
-
-### シナリオ C: 理想的起動 (venv最適化後)
+### Scenario B: Normal start (venv present)
 
 ```
-  0s ─── カーネル起動
+  0s ─── Kernel start, Config/DB initialization
+  2s ─── Plugin Manager initialization
+  5s ─── ensure_mcp_venv() — venv detected + dependency sync
+         └── pip install --quiet × 15 (no-op): 15-30s ← ★ bottleneck
+ 35s ─── Priority MCP connect (11 in parallel)
+         └── Parallel connect: ~5s
+ 40s ─── HTTP server up
+ 46s ─── All servers connected
+```
+
+**Total**: **35-46 seconds** (bottleneck: pip no-op check)
+
+### Scenario C: Ideal start (after venv optimization)
+
+```
+  0s ─── Kernel start
   2s ─── Config/DB
-  5s ─── venv確認のみ (pip install スキップ)
-  6s ─── Priority MCP接続 (11台並列): ~5s
- 11s ─── HTTP サーバー起動
- 17s ─── 全サーバー接続完了
+  5s ─── venv check only (skip pip install)
+  6s ─── Priority MCP connect (11 in parallel): ~5s
+ 11s ─── HTTP server up
+ 17s ─── All servers connected
 ```
 
-**合計**: **11-17秒**
+**Total**: **11-17 seconds**
 
-## ボトルネック分析
+## Bottleneck analysis
 
-### CRITICAL: venv依存同期 (`mcp_venv.rs:116-165`)
+### CRITICAL: venv dependency sync (`mcp_venv.rs:116-165`)
 
 ```rust
-// install_server_deps() — 全サーバーを順次 pip install
+// install_server_deps() — sequentially pip-install every server
 for entry in entries.flatten() {
-    pip install <server_path> --quiet  // 2-5秒/サーバー × 15 = 30-75秒
+    pip install <server_path> --quiet  // 2-5 s/server × 15 = 30-75 s
 }
 ```
 
-- **毎回起動時に実行** (no-op でも pip の依存解決に 2-3秒/サーバー)
-- **順次実行** — 並列化されていない
-- **全サーバー対象** — auto_restart=false のサーバーも含む
+- **Runs on every startup** (even no-op pip dependency resolution takes 2-3 s/server)
+- **Sequential** — not parallelized
+- **All servers** — including the auto_restart=false ones
 
-### HIGH: リクエストタイムアウト 120秒 (`config.rs:302-310`)
+### HIGH: 120 s request timeout (`config.rs:302-310`)
 
 ```rust
-CLOTO_MCP_REQUEST_TIMEOUT_SECS = 120  // デフォルト
+CLOTO_MCP_REQUEST_TIMEOUT_SECS = 120  // default
 ```
 
-- Initialize RPC, tools/list, permission RPC 全てに適用
-- 1台のサーバーが応答しないだけで 120秒ブロック
-- リトライ3回で最大 360秒
+- Applied to Initialize RPC, tools/list, permission RPC, all of them
+- A single unresponsive server blocks for 120 s
+- With 3 retries, up to 360 s
 
-### HIGH: Python インタープリタ起動 (per server)
+### HIGH: Python interpreter spawn (per server)
 
-- Python venv の `python.exe` 起動: 500ms-2s
-- import 解決 (共通ライブラリ含む): 追加 500ms-1s
-- 11台並列でも最も遅い1台が全体を律速
+- Python venv `python.exe` spawn: 500ms-2s
+- Import resolution (including shared libs): additional 500ms-1s
+- Even with 11 parallel spawns, the slowest one paces the whole batch
 
 ### MODERATE: tools/list RPC
 
-- サーバーのツール登録数に依存
-- 通常 100-500ms だが、大規模ツールセットでは 1-5s
+- Depends on the server's number of registered tools
+- Usually 100-500ms; large tool sets may take 1-5s
 
-## 推奨最適化
+## Recommended optimizations
 
-### 優先度 HIGH
+### Priority HIGH
 
-| # | 施策 | 削減効果 | 実装コスト |
+| # | Action | Expected savings | Implementation cost |
 |---|------|---------|-----------|
-| 1 | **venv依存syncをauto_restartサーバーのみに限定** | -15-30s | 低 |
-| 2 | **pip install を並列化** (tokio::spawn × N) | -20-50s | 低 |
-| 3 | **venv syncをバックグラウンド化** (HTTP起動後) | 体感 -30-75s | 中 |
-| 4 | **初回後の依存syncスキップ** (ハッシュベースキャッシュ) | -15-30s | 中 |
+| 1 | **Limit venv dependency sync to auto_restart servers** | -15-30s | low |
+| 2 | **Parallelize pip install** (tokio::spawn × N) | -20-50s | low |
+| 3 | **Move venv sync to background** (after HTTP up) | perceived -30-75s | medium |
+| 4 | **Skip dependency sync after first install** (hash-based cache) | -15-30s | medium |
 
-### 優先度 MEDIUM
+### Priority MEDIUM
 
-| # | 施策 | 削減効果 | 実装コスト |
+| # | Action | Expected savings | Implementation cost |
 |---|------|---------|-----------|
-| 5 | **接続タイムアウトを 30s に短縮** (起動時のみ) | 最悪時 -270s | 低 |
-| 6 | **tool schema キャッシュ** (DB保存、変更時のみ再取得) | -1-5s | 中 |
-| 7 | **Python プロセスプール** (事前起動) | -5-10s | 高 |
+| 5 | **Shorten connection timeout to 30s** (startup only) | worst-case -270s | low |
+| 6 | **Tool schema cache** (DB-backed, refetch only on change) | -1-5s | medium |
+| 7 | **Python process pool** (pre-spawned) | -5-10s | high |
 
-### 優先度 LOW
+### Priority LOW
 
-| # | 施策 | 削減効果 | 実装コスト |
+| # | Action | Expected savings | Implementation cost |
 |---|------|---------|-----------|
-| 8 | Seal検証の並列化 | <1s | 低 |
-| 9 | Permission Gate Dのバッチ化 | <1s | 中 |
+| 8 | Parallelize seal verification | <1s | low |
+| 9 | Batch Permission Gate D | <1s | medium |
 
-## タイムアウト設定一覧
+## Timeout settings reference
 
-| 設定 | デフォルト | 用途 | ファイル |
+| Setting | Default | Purpose | File |
 |------|-----------|------|---------|
-| `CLOTO_MCP_REQUEST_TIMEOUT_SECS` | 120s | 全RPC (initialize, tools/list等) | config.rs:302 |
-| `CLOTO_DB_TIMEOUT_SECS` | 10s | Permission DBチェック | config.rs:269 |
-| `CLOTO_MEMORY_TIMEOUT_SECS` | 5s | メモリプラグイン | config.rs |
-| `CLOTO_TOOL_TIMEOUT_SECS` | 30s | ツール実行 | config.rs |
-| リトライバックオフ | 1s, 2s | connect_server リトライ | mcp.rs:681 |
+| `CLOTO_MCP_REQUEST_TIMEOUT_SECS` | 120s | All RPCs (initialize, tools/list, etc.) | config.rs:302 |
+| `CLOTO_DB_TIMEOUT_SECS` | 10s | Permission DB check | config.rs:269 |
+| `CLOTO_MEMORY_TIMEOUT_SECS` | 5s | Memory plugins | config.rs |
+| `CLOTO_TOOL_TIMEOUT_SECS` | 30s | Tool execution | config.rs |
+| Retry backoff | 1s, 2s | connect_server retries | mcp.rs:681 |
 
-## 関連ファイル
+## Related files
 
-- 起動オーケストレーション: `crates/core/src/lib.rs:400-590`
-- サーバー接続: `crates/core/src/managers/mcp.rs:311-356, 462-1065`
-- MCP クライアント: `crates/core/src/managers/mcp_client.rs:56-270`
-- トランスポート: `crates/core/src/managers/mcp_transport.rs:111-249`
-- Venv管理: `crates/core/src/managers/mcp_venv.rs:116-267`
-- タイムアウト設定: `crates/core/src/config.rs:269-310`
+- Startup orchestration: `crates/core/src/lib.rs:400-590`
+- Server connect: `crates/core/src/managers/mcp.rs:311-356, 462-1065`
+- MCP client: `crates/core/src/managers/mcp_client.rs:56-270`
+- Transport: `crates/core/src/managers/mcp_transport.rs:111-249`
+- Venv management: `crates/core/src/managers/mcp_venv.rs:116-267`
+- Timeout configuration: `crates/core/src/config.rs:269-310`


### PR DESCRIPTION
## Summary

Translate the 2026-03-17 MCP server startup performance analysis
(\`docs/MCP_STARTUP_PERFORMANCE.md\`) to English per the public-repo
English-only documentation rule (parent CLAUDE.md, 2026-05-09).

Section headers, table column headers, scenario narratives
(cold / normal / ideal start), bottleneck analysis, recommended
optimizations table, and the timeout-settings reference are all
translated.

Code blocks and code references (file:line citations, env var names,
function signatures) are preserved verbatim.

\`docs/RECALL_CONTAMINATION_AB_2026-04-24.md\` was reviewed in the same
plan but is intentionally **not** modified — its narrative is already
English; the 32 Japanese lines that remain are CPersona contamination
bug evidence (user queries, sample CPersona output, memory contents,
A/B test result-table query column) that must be preserved verbatim
to retain forensic value.

## Test plan

- [x] \`grep -P '[\\p{Hiragana}\\p{Katakana}\\p{Han}]' docs/MCP_STARTUP_PERFORMANCE.md\` returns 0 hits
- [x] \`bash scripts/verify-issues.sh\` -> all green
- [x] Markdown renders correctly (tables align, code blocks intact, file:line citations preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)