### PR TITLE
refactor(marketplace): cut RegistryEntry/EnvVarDef over to mgp-sdk v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,6 +1160,7 @@ dependencies = [
  "hex",
  "http",
  "lindera",
+ "mgp-sdk",
  "mgp-seal",
  "mime_guess",
  "rand 0.8.6",
@@ -4179,6 +4180,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mgp-sdk"
+version = "0.2.0"
+source = "git+https://github.com/Cloto-dev/mgp-rs?tag=mgp-sdk-v0.2.0#90ee3df7361f00cdda9f7cc7f0900a082c066268"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "url",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -42,6 +42,7 @@ clap = { version = "4", features = ["derive"] }
 rand = "0.8"
 subtle = "2"
 mgp-seal = { git = "https://github.com/Cloto-dev/mgp-rs", tag = "mgp-seal-v0.2.0" }
+mgp-sdk = { git = "https://github.com/Cloto-dev/mgp-rs", tag = "mgp-sdk-v0.2.0" }
 toml = "1.0"
 cron = "0.16"
 uuid.workspace = true

--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -23,66 +23,19 @@ const MARKETPLACE_REGISTRY_FETCH_TIMEOUT_SECS: u64 = 30;
 
 // ── Registry types ──────────────────────────────────────────────────
 
+/// Per-entry registry shape, sourced from `mgp-sdk` v0.2.0 so ClotoCore and
+/// the ClotoHub.dev catalog feed share one wire definition. The `install`
+/// field is `Option<InstallShape>` — `None` falls back to ClotoCore's
+/// legacy monorepo-tarball install path; `Some(_)` will branch on
+/// `install.source` once `run_install` is updated.
+pub use mgp_sdk::shape::{InstallShape, RegistryEntry};
+pub use mgp_sdk::types::EnvVarDef;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Registry {
     pub schema_version: u32,
     pub updated_at: String,
     pub servers: Vec<RegistryEntry>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RegistryEntry {
-    pub id: String,
-    pub name: String,
-    pub description: String,
-    pub category: String,
-    pub version: String,
-    #[serde(default)]
-    pub directory: String,
-    #[serde(default)]
-    pub dependencies: Vec<String>,
-    #[serde(default)]
-    pub env_vars: Vec<EnvVarDef>,
-    #[serde(default)]
-    pub optional_env_vars: Vec<EnvVarDef>,
-    #[serde(default)]
-    pub tags: Vec<String>,
-    #[serde(default = "default_trust_level")]
-    pub trust_level: String,
-    #[serde(default)]
-    pub auto_restart: bool,
-    #[serde(default)]
-    pub icon: Option<String>,
-    #[serde(default = "default_runtime")]
-    pub runtime: String,
-    #[serde(default)]
-    pub bin_name: Option<String>,
-    #[serde(default)]
-    pub changelog: Option<String>,
-    /// MGP Magic Seal in `sha256:HEX` form (MGP_ISOLATION_DESIGN.md §8 L0).
-    /// Populated by upstream `cloto-mcp-servers` via `cloto seal generate`;
-    /// flows through marketplace install into `McpServerConfig.seal` and
-    /// the persisted DB record. `None` triggers v0.6.3 §10 inv 3
-    /// force-untrusted at connect time.
-    #[serde(default)]
-    pub seal: Option<String>,
-}
-
-fn default_trust_level() -> String {
-    "standard".to_string()
-}
-
-fn default_runtime() -> String {
-    "python".to_string()
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EnvVarDef {
-    pub key: String,
-    #[serde(default)]
-    pub default: Option<String>,
-    #[serde(default)]
-    pub description: Option<String>,
 }
 
 // ── Catalog cache ───────────────────────────────────────────────────
@@ -1193,7 +1146,7 @@ async fn run_install(
     let mut env_map: HashMap<String, String> = HashMap::new();
     for var in &entry.env_vars {
         if let Some(default) = &var.default {
-            env_map.insert(var.key.clone(), default.clone());
+            env_map.insert(var.name.clone(), default.clone());
         }
     }
     for (k, v) in &env_overrides {
@@ -1980,7 +1933,7 @@ async fn run_batch_install(
         let mut env_map: HashMap<String, String> = HashMap::new();
         for var in &entry.env_vars {
             if let Some(default) = &var.default {
-                env_map.insert(var.key.clone(), default.clone());
+                env_map.insert(var.name.clone(), default.clone());
             }
         }
 


### PR DESCRIPTION
## Summary

Post-Phase-5c cutover (Goal #36, PR 4 / 5 in the chain). Drops the
locally-defined `RegistryEntry`, `EnvVarDef`, and `default_trust_level` /
`default_runtime` helpers from `handlers::marketplace` and pub-uses the
mgp-sdk v0.2.0 types instead, so ClotoCore and the ClotoHub.dev catalog
feed share one wire definition.

- `mgp_sdk::shape::{RegistryEntry, InstallShape}` — entry shape, now
  carrying an optional `install: Option<InstallShape>` for source-aware
  install. `None` keeps the existing legacy monorepo-tarball path; the
  branching on `entry.install.as_ref().map(|i| &i.source)` lands in the
  next PR.
- `mgp_sdk::types::EnvVarDef` — env-var descriptor. The serde wire name
  `key` is preserved via `#[serde(alias = "key")]` on the new type, so
  existing `registry.json` files continue to parse. Only the Rust field
  name changes (`var.key` → `var.name`, 2 call sites in this file).

`Registry` top-level wrapper and `CatalogEntry` response shape stay
ClotoCore-local — both are ClotoCore-specific (top-level feed envelope
and dashboard response model, respectively).

The mgp-rs lockstep comment (`shape/registry.rs:5-6`, "mirrors
ClotoCore's RegistryEntry — keep in lock-step until ClotoCore migrates")
is updated in a follow-up mgp-rs PR.

## Test plan

- [x] `cargo check --workspace --exclude app --all-targets` — green
- [x] `cargo test --workspace --exclude app` — 8 tests pass, 0 regressions
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --exclude app -- -D warnings` with the
  CI-equivalent `-A clippy::too-many-lines` etc. allowlist — clean
- [ ] CI green