### PR TITLE
fix(marketplace): probe the right directory for empty install.directory entries

### DIFF
--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -210,9 +210,21 @@ pub async fn catalog_handler(
                 .find(|r| r.marketplace_id.as_deref() == Some(&entry.id));
             // Installed if: DB marketplace record is active, OR server files
             // exist on disk (covers Config servers installed by batch setup).
+            // When `entry.directory` is empty (the new source-spec install
+            // path treats empty as "use entry.id as the dir name"), `join("")`
+            // would degenerate to the `mcp-servers/` parent itself, which
+            // exists as soon as any other server is installed — flipping the
+            // catalog UI's installed badge to true for every empty-directory
+            // entry. Mirror the install fallback (entry.id) here so the on-
+            // disk probe targets the same path the installer would write to.
             let db_installed = mp_record.is_some_and(|r| r.is_active);
             let files_installed = {
-                let server_dir = state.data_dir.join("mcp-servers").join(&entry.directory);
+                let effective_dir = if entry.directory.is_empty() {
+                    entry.id.as_str()
+                } else {
+                    entry.directory.as_str()
+                };
+                let server_dir = state.data_dir.join("mcp-servers").join(effective_dir);
                 server_dir.is_dir()
             };
             let installed = db_installed || files_installed;


### PR DESCRIPTION
## Summary

Patch a false-positive in the marketplace catalog UI surfaced by PR #122's smoke run.

`catalog_handler` decides whether a connector is installed by joining \`state.data_dir / "mcp-servers" / entry.directory\` and probing \`is_dir()\`. When \`entry.directory\` is the empty string — the case the new source-spec install path hits whenever the connector manifest's \`install.directory\` is unset, falling back to \`entry.id\` for the on-disk dir name — \`PathBuf::join("")\` collapses to the parent \`mcp-servers/\` itself, which exists as soon as any other server is installed. Every empty-directory catalog entry was therefore flipped to \`installed: true\` on a fresh ClotoCore install with no real install.

The fix mirrors the install fallback (\`entry.id\` when \`entry.directory\` is empty) so the probe targets the same path the installer writes to. DB-side detection (\`mp_record.is_some_and(|r| r.is_active)\`) is unchanged.

## Discovery

Caught during PR #122 ([\`a4e5f33\`](https://github.com/Cloto-dev/ClotoCore/commit/a4e5f33)) end-to-end smoke for \`Cloto-dev/cpersona\` (empty \`install.directory\`, id=\`cpersona\`). The catalog reported \`installed: true\` before the install ran, because \`target/debug/data/mcp-servers/\` already existed from the legacy \`memory.cpersona\` install.

## Test plan

- [x] \`cargo build -p cloto_core\`
- [x] \`cargo fmt --all -- --check\`
- [x] CI clippy line passes
- [x] \`cargo test --test marketplace_fetch_test\` (3 pass)
- [x] Manual catalog probe (against post-smoke disk state):
  - Empty-directory entry with no matching id-dir → \`installed: false\` ✅ (was \`true\`)
  - Empty-directory entry whose id-dir exists → \`installed: true\` (unchanged in result, correct path now)
  - Non-empty entry.directory → behavior unchanged

## Follow-ups (out of scope)

- \`uninstall_handler\` uses a different fallback (\`server_id.replace('.', "-")\`) — diverges from install/catalog's \`entry.id\`. Should consolidate.
- Three sites (catalog, install_from_git, install_from_raw_url) inline the empty-directory fallback. A shared \`effective_install_dir(entry)\` helper would keep them in lock-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)