### PR TITLE
chore(hooks): source-control .githooks/pre-commit and install-hooks.sh

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# pre-commit hook: if qa/issue-registry.json is in the staged diff, run
+# scripts/verify-issues.sh and block the commit when [STALE] / [UNFIXED] /
+# [ERROR] is reported. This prevents shipping a registry update that does
+# not match the codebase.
+#
+# Install via: bash scripts/install-hooks.sh  (sets core.hooksPath=.githooks)
+# Bypass      : git commit --no-verify  (do not use without explicit reason)
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+[[ -n "$REPO_ROOT" ]] || exit 0
+
+cd "$REPO_ROOT"
+
+# --- Check 1: git author identity ------------------------------------------
+# Public Cloto-dev repos MUST commit as the shared project identity.
+# (See repos/CLAUDE.md "Git Rules (shared across Cloto-dev repos)".)
+EXPECTED_NAME="ClotoCore Project"
+EXPECTED_EMAIL="ClotoCore@proton.me"
+ACTUAL_NAME="$(git config user.name || echo "")"
+ACTUAL_EMAIL="$(git config user.email || echo "")"
+
+if [[ "$ACTUAL_NAME" != "$EXPECTED_NAME" || "$ACTUAL_EMAIL" != "$EXPECTED_EMAIL" ]]; then
+  echo "[pre-commit] ERROR: git author identity mismatch."
+  echo "[pre-commit]   expected: $EXPECTED_NAME <$EXPECTED_EMAIL>"
+  echo "[pre-commit]   actual  : ${ACTUAL_NAME:-<unset>} <${ACTUAL_EMAIL:-<unset>}>"
+  echo "[pre-commit] Fix with:"
+  echo "    git config user.name  \"$EXPECTED_NAME\""
+  echo "    git config user.email \"$EXPECTED_EMAIL\""
+  echo "[pre-commit] Commit blocked. Use --no-verify to override intentionally."
+  exit 1
+fi
+
+# --- Check 2: registry verification ----------------------------------------
+# Only run when the registry is part of the staged diff.
+if ! git diff --cached --name-only | grep -qx 'qa/issue-registry.json'; then
+  exit 0
+fi
+
+if [[ ! -x scripts/verify-issues.sh && ! -f scripts/verify-issues.sh ]]; then
+  echo "[pre-commit] scripts/verify-issues.sh not found — skipping registry verification."
+  exit 0
+fi
+
+echo "[pre-commit] qa/issue-registry.json is staged — running scripts/verify-issues.sh..."
+if bash scripts/verify-issues.sh; then
+  echo "[pre-commit] Registry verification passed."
+  exit 0
+else
+  echo ""
+  echo "[pre-commit] Registry verification FAILED (stale / unfixed / error present)."
+  echo "[pre-commit] Fix the offending entries or the underlying code, then re-stage and re-commit."
+  echo "[pre-commit] To bypass after conscious review, use 'git commit --no-verify' (discouraged)."
+  exit 1
+fi

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# install-hooks.sh - Activate .githooks/ for this clone.
+#
+# Git hooks under .git/hooks/ are per-clone and not version-controlled.
+# This script points git at the version-controlled .githooks/ directory so
+# every contributor gets the same pre-commit / pre-push etc.
+#
+# Usage: bash scripts/install-hooks.sh
+# Idempotent: re-running only re-confirms the setting.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "[install-hooks] Not inside a git repository." >&2
+  exit 1
+fi
+cd "$REPO_ROOT"
+
+if [[ ! -d .githooks ]]; then
+  echo "[install-hooks] .githooks/ directory missing — nothing to install." >&2
+  exit 1
+fi
+
+git config core.hooksPath .githooks
+echo "[install-hooks] core.hooksPath set to .githooks"
+echo "[install-hooks] Installed hooks:"
+for h in .githooks/*; do
+  [[ -f "$h" ]] || continue
+  [[ -x "$h" ]] || chmod +x "$h"
+  echo "  - $(basename "$h")"
+done
+
+# Baseline check: warn the contributor if the registry already has stale/unfixed
+# entries. The pre-commit hook will block commits that touch qa/issue-registry.json
+# until those are resolved (or bypass with --no-verify).
+if [[ -f scripts/verify-issues.sh && -f qa/issue-registry.json ]]; then
+  echo ""
+  echo "[install-hooks] Running baseline check..."
+  if bash scripts/verify-issues.sh >/dev/null 2>&1; then
+    echo "[install-hooks] Baseline is clean — pre-commit will allow registry-touching commits."
+  else
+    echo ""
+    echo "[install-hooks] WARNING: qa/issue-registry.json baseline has [STALE] / [UNFIXED] / [ERROR] entries."
+    echo "[install-hooks] Until those are resolved, any commit that touches the registry will be blocked by pre-commit."
+    echo "[install-hooks] Review with: bash scripts/verify-issues.sh"
+    echo "[install-hooks] To override a single commit intentionally: git commit --no-verify (discouraged)."
+  fi
+fi
+
+echo ""
+echo "[install-hooks] Done. To disable: git config --unset core.hooksPath"


### PR DESCRIPTION
## Summary

Add `.githooks/pre-commit` (author validation + verify-issues blocking) and `scripts/install-hooks.sh` (one-step installer) to source control. Both files have lived on developer machines since 2026-04-24 but were never committed, so new clones run without the local guardrails.

After merge, the standard onboarding step is `bash scripts/install-hooks.sh` (sets `core.hooksPath=.githooks`).

## Test plan

- [x] Existing `core.hooksPath=.githooks` in this clone makes the new file run on commit — pre-commit passed for this very commit (author=`ClotoCore Project <ClotoCore@proton.me>` ✓, registry not modified ✓)
- [ ] Fresh clone + `bash scripts/install-hooks.sh` → commit attempt with wrong author rejected
- [ ] Fresh clone + `bash scripts/install-hooks.sh` → modify `qa/issue-registry.json` with `[STALE]` → commit blocked

## Counterpart

Cloto-dev/cloto-mcp-servers will receive the same two files in a parallel PR.