### PR TITLE
feat(marketplace): Phase 5d-2 — flip catalog source to hub.cloto.dev

### DIFF
--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -48,15 +48,21 @@ pub struct CatalogCache {
 
 const CACHE_TTL: Duration = Duration::from_hours(1); // 1 hour
 
-/// Default upstream catalog URL. Overridable via `CLOTO_CATALOG_URL` so
-/// Phase 5 can flip the marketplace fetch source from raw GitHub to
-/// ClotoHub.dev without a code change.
-const DEFAULT_CATALOG_URL: &str =
-    "https://raw.githubusercontent.com/Cloto-dev/cloto-mcp-servers/master/registry.json";
+/// Default upstream catalog URL. Phase 5d-2 flipped this from the
+/// legacy `raw.githubusercontent.com/Cloto-dev/cloto-mcp-servers/...`
+/// path to the curated ClotoHub.dev catalog endpoint. Overridable via
+/// `CLOTO_CATALOG_URL` (e.g. to point a dev build at a local server,
+/// or to pin a release to the legacy GitHub-served registry).
+const DEFAULT_CATALOG_URL: &str = "https://hub.cloto.dev/api/catalog";
 
-/// Default tarball URL template. `{ref}` is replaced with the git ref
-/// (currently always `master`). Overridable via
-/// `CLOTO_TARBALL_URL_TEMPLATE` for the same Phase 5 cutover.
+/// Default tarball URL template for the *legacy* monorepo install path
+/// (`install.source.kind == "monorepo_directory"` entries). `{ref}` is
+/// replaced with the git ref (currently always `master`). Catalog
+/// entries served by ClotoHub.dev dispatch through `run_install`
+/// (`install.source: Git/RawUrl/Pypi/Docker`) and never hit this
+/// template — it is preserved only so a `CLOTO_CATALOG_URL` override
+/// pointing back at the legacy `cloto-mcp-servers` registry still
+/// resolves correctly. Overridable via `CLOTO_TARBALL_URL_TEMPLATE`.
 const DEFAULT_TARBALL_URL_TEMPLATE: &str =
     "https://api.github.com/repos/Cloto-dev/cloto-mcp-servers/tarball/{ref}";
 


### PR DESCRIPTION
## Summary

- Flip `DEFAULT_CATALOG_URL` in `crates/core/src/handlers/marketplace.rs` from the legacy `raw.githubusercontent.com/Cloto-dev/cloto-mcp-servers/master/registry.json` path to the curated ClotoHub endpoint `https://hub.cloto.dev/api/catalog`.
- `CLOTO_CATALOG_URL` env override remains in place for dev builds and rollback.
- `DEFAULT_TARBALL_URL_TEMPLATE` is **intentionally left** at GitHub: it only feeds the legacy monorepo install path (`install.source.kind == "monorepo_directory"`), which is dead in the ClotoHub-served catalog (those entries dispatch through `run_install` on `install.source: Git | RawUrl | Pypi | Docker` per PR #122).

## Phase 5d positioning

This is the second sub-segment of Phase 5d (ClotoHub MVP production cutover):

- **Phase 5d-1** ✅ — LXC `clotohub` (CT 102) + cloudflared tunnel `hub.cloto.dev` + Litestream R2 + production master keyset (PR clotohub-web#21 `955cbca`)
- **Phase 5d-1.5** ✅ — clotohub-web static SPA serving via `WEB_STATIC_DIR` (PR clotohub-web#20 `16922ab`)
- **Phase 5d-2** ← *this PR* — ClotoCore default URL flip
- **Phase 5d-3** — clotohub-api binary deploy + smoke E2E (next session)

## Impact window

Between this PR landing and Phase 5d-3 completing, any **locally-built ClotoCore master binary that does not set `CLOTO_CATALOG_URL`** will see catalog fetches return HTTP 502 (cloudflared tunnel up, origin not yet running). The `Stale { cached, error }` fallback added in PR #102 keeps the Marketplace UI usable from cache, and the env override is the documented escape hatch. **Released ClotoCore binaries are unaffected** — they ship with their compile-time default already baked.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude app -- -D warnings -A clippy::too-many-lines -A clippy::struct-excessive-bools -A clippy::match-same-arms -A clippy::cast-possible-wrap -A clippy::trivially-copy-pass-by-ref -A clippy::manual-let-else -A clippy::option-if-let-else -A clippy::case-sensitive-file-extension-comparisons -A clippy::unwrap-used -A clippy::type-complexity` clean
- [x] `cargo test --workspace --exclude app` all green (incl. `marketplace_fetch_test` 3 cases — env override path)
- [x] `bash scripts/verify-issues.sh` 89 verified / 132 fixed / 0 stale / 0 error
- [ ] Smoke verify after Phase 5d-3 deploy: fresh master build with no env override hits `https://hub.cloto.dev/api/catalog` and renders catalog entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)