### PR TITLE
feat(marketplace): implement install_from_docker for SourceSpec::Docker

### DIFF
--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -1811,12 +1811,12 @@ async fn install_from_docker(
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
-            .status(),
+            .output(),
     )
     .await;
 
     match docker_check {
-        Ok(Ok(status)) if status.success() => {
+        Ok(Ok(output)) if output.status.success() => {
             emit(
                 tx,
                 SetupProgressEvent::StepComplete {

--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -770,19 +770,8 @@ async fn run_install(
         Some(SourceSpec::Pypi(spec)) => {
             install_from_pypi(state, entry, spec, env_overrides, auto_start).await
         }
-        Some(SourceSpec::Docker(_)) => {
-            emit(
-                &state.setup_progress_tx,
-                SetupProgressEvent::StepError {
-                    step: "check_source".into(),
-                    error: format!(
-                        "Connector '{}' uses source.type=docker, which is not yet supported by ClotoCore's marketplace install path.",
-                        entry.id
-                    ),
-                    recoverable: false,
-                },
-            );
-            Ok(())
+        Some(SourceSpec::Docker(spec)) => {
+            install_from_docker(state, entry, spec, env_overrides, auto_start).await
         }
         None => install_from_monorepo_tarball(state, entry, env_overrides, auto_start).await,
     }
@@ -1773,6 +1762,176 @@ async fn install_from_pypi(
         entry,
         "python".to_string(),
         vec!["-m".to_string(), module],
+        env_overrides,
+        auto_start,
+    )
+    .await
+}
+
+/// Install a marketplace server whose `install.source` is a Docker image.
+/// Verifies the `docker` CLI is on `PATH`, pulls the image, and registers
+/// the server as `docker run --rm -i [-e KEY ...] <image>:<tag>`. Env vars
+/// declared in `entry.env_vars` plus any `env_overrides` are exposed to the
+/// container via `-e KEY` flags (no inline `=VALUE` form, so secrets do not
+/// leak into the process listing — values flow through the parent env that
+/// `register_server` configures on the docker CLI process).
+async fn install_from_docker(
+    state: &AppState,
+    entry: &RegistryEntry,
+    spec: &mgp_sdk::adapters::DockerSpec,
+    env_overrides: HashMap<String, String>,
+    auto_start: bool,
+) -> anyhow::Result<()> {
+    let tx = &state.setup_progress_tx;
+
+    if let Err(msg) = spec.check() {
+        emit(
+            tx,
+            SetupProgressEvent::StepError {
+                step: "check_source".into(),
+                error: format!("Invalid docker source for '{}': {msg}", entry.id),
+                recoverable: false,
+            },
+        );
+        return Ok(());
+    }
+
+    emit(
+        tx,
+        SetupProgressEvent::StepStart {
+            step: "check_docker".into(),
+            description: "Checking docker CLI".into(),
+        },
+    );
+
+    let docker_check = tokio::time::timeout(
+        Duration::from_secs(CHILD_PROCESS_TIMEOUT_SECS),
+        tokio::process::Command::new("docker")
+            .arg("--version")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .status(),
+    )
+    .await;
+
+    match docker_check {
+        Ok(Ok(status)) if status.success() => {
+            emit(
+                tx,
+                SetupProgressEvent::StepComplete {
+                    step: "check_docker".into(),
+                },
+            );
+        }
+        _ => {
+            emit(
+                tx,
+                SetupProgressEvent::StepError {
+                    step: "check_docker".into(),
+                    error: "`docker` not found on PATH. Install Docker Desktop or a compatible OCI CLI and retry.".into(),
+                    recoverable: true,
+                },
+            );
+            return Ok(());
+        }
+    }
+
+    let reference = spec.canonical_reference();
+    emit(
+        tx,
+        SetupProgressEvent::StepStart {
+            step: "pull_image".into(),
+            description: format!("Pulling {reference}"),
+        },
+    );
+
+    let pull_result = tokio::time::timeout(
+        Duration::from_secs(TARBALL_DOWNLOAD_TIMEOUT_SECS),
+        tokio::process::Command::new("docker")
+            .args(["pull", &reference])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output(),
+    )
+    .await;
+
+    match pull_result {
+        Ok(Ok(output)) if output.status.success() => {
+            emit(
+                tx,
+                SetupProgressEvent::StepComplete {
+                    step: "pull_image".into(),
+                },
+            );
+        }
+        Ok(Ok(output)) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let last_line = stderr.lines().last().unwrap_or("unknown error");
+            emit(
+                tx,
+                SetupProgressEvent::StepError {
+                    step: "pull_image".into(),
+                    error: format!("docker pull {reference} failed: {last_line}"),
+                    recoverable: true,
+                },
+            );
+            return Ok(());
+        }
+        Ok(Err(e)) => {
+            emit(
+                tx,
+                SetupProgressEvent::StepError {
+                    step: "pull_image".into(),
+                    error: format!("Failed to run docker pull: {e}"),
+                    recoverable: true,
+                },
+            );
+            return Ok(());
+        }
+        Err(_) => {
+            emit(
+                tx,
+                SetupProgressEvent::StepError {
+                    step: "pull_image".into(),
+                    error: format!(
+                        "docker pull {reference} timed out after {TARBALL_DOWNLOAD_TIMEOUT_SECS}s"
+                    ),
+                    recoverable: true,
+                },
+            );
+            return Ok(());
+        }
+    }
+
+    // Dedup env keys from entry.env_vars (with defaults) ∪ env_overrides
+    // so the docker run arg list carries each `-e KEY` once. Values reach
+    // the container through the parent env that register_server attaches
+    // to the docker CLI process — no `KEY=VALUE` in argv keeps secrets
+    // out of `ps`.
+    let mut env_keys: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for var in &entry.env_vars {
+        if var.default.is_some() {
+            env_keys.insert(var.name.clone());
+        }
+    }
+    for k in env_overrides.keys() {
+        env_keys.insert(k.clone());
+    }
+
+    let mut args = vec!["run".to_string(), "--rm".to_string(), "-i".to_string()];
+    for key in &env_keys {
+        args.push("-e".to_string());
+        args.push(key.clone());
+    }
+    args.push(reference);
+
+    register_server(
+        state,
+        entry,
+        "docker".to_string(),
+        args,
         env_overrides,
         auto_start,
     )

--- a/crates/core/src/managers/mcp_transport.rs
+++ b/crates/core/src/managers/mcp_transport.rs
@@ -52,7 +52,7 @@ impl McpTransport {
 }
 
 /// Allowed commands for MCP server execution (security whitelist)
-const ALLOWED_COMMANDS: &[&str] = &["npx", "node", "python", "python3", "deno", "bun"];
+const ALLOWED_COMMANDS: &[&str] = &["npx", "node", "python", "python3", "deno", "bun", "docker"];
 
 /// Buffer size for MCP stdio channel (request and response).
 const MCP_CHANNEL_BUFFER_SIZE: usize = 100;


### PR DESCRIPTION
## Summary

Replaces the `SourceSpec::Docker` stub in `run_install` with a real materializer:

- Validates `DockerSpec` via `spec.check()` (image non-empty, no whitespace)
- Verifies `docker` is on `PATH` (`docker --version`, recoverable StepError on miss)
- Pulls the image (`docker pull <image>:<tag>`, falls back to `latest` per `canonical_reference()`)
- Registers the server as `docker run --rm -i [-e KEY ...] <image>:<tag>`

Env vars from `entry.env_vars` (with defaults) ∪ `env_overrides` are deduped via `BTreeSet` and exposed to the container via `-e KEY` flags — the no-value form keeps secrets out of `ps`; values flow through the parent env that `register_server` attaches to the docker CLI process.

Also adds `"docker"` to `mcp_transport::ALLOWED_COMMANDS` so the post-install spawn passes the bare-command whitelist.

Resolves Goal #39 (mgp-sdk install.source `docker` variant — last remaining `SourceSpec` arm after PR #122 landed Git / RawUrl / Pypi).

## Bug fix included (fa90295)

Initial `check_docker` used `Command::status()` with `Stdio::piped()` for both stdout and stderr; the kernel buffer filled and the child died with SIGPIPE (raw wait status 13) before exit. Switching to `.output()` drains the pipes to EOF and lets the child exit normally. `pull_image` already used `.output()` so the fix is symmetric. **Caught by the smoke below, not in CI** — kept as a separate commit for visibility; admin squash collapses to one on land.

## Test plan

Headless E2E smoke (colima + docker CLI on macOS, sandbox under \`/tmp/docker-smoke/\`):

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --exclude app -- -D warnings -A clippy::too-many-lines ...\` (CI flags)
- [x] \`cargo test --workspace --exclude app\` (all green)
- [x] \`bash scripts/verify-issues.sh\` (89 verified / 132 fixed / 0 stale / 0 errors)
- [x] SSE: \`check_docker → pull_image → finalize\` all StepComplete + terminal Complete
- [x] DB row: \`name=docker-smoke-test, command=docker, args=["run","--rm","-i","hello-world:latest"], source=dynamic, version=0.0.1, trust_level=standard\`
- [x] Hello-world container connection attempts fail by design (not an MCP server) — install steps themselves are exercised end-to-end
- [x] Uninstall removes the DB row; docker image is preserved (per Goal #39 design)

Unit tests for the function body are deferred — the path depends on an external docker CLI. `DockerSpec::check()` and `canonical_reference()` are already covered by `mgp-sdk` tests (`adapters_test.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)