### PR TITLE
fix(0.6.4): Windows NSIS hotfix — kernel boot + wizard finish loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
         description: "Version to release (e.g., 0.2.0)"
         required: true
         type: string
+      draft_only:
+        description: "Build artifacts only — skip tag creation and Release publish (for pre-release verification)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -589,7 +594,7 @@ jobs:
             release-files/SHA256SUMS.txt
 
       - name: Create tag (workflow_dispatch only)
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.draft_only != 'true'
         run: |
           # M-26: Check for existing tag before creating
           if git ls-remote --tags origin | grep -q "refs/tags/v${{ steps.version.outputs.version }}$"; then
@@ -622,6 +627,7 @@ jobs:
           HEADER
 
       - name: Create GitHub Release
+        if: github.event.inputs.draft_only != 'true'
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -176,7 +176,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1153,6 +1153,7 @@ dependencies = [
  "criterion",
  "cron",
  "dashmap 6.1.0",
+ "dirs 5.0.1",
  "dotenvy",
  "flate2",
  "futures",
@@ -1815,11 +1816,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1830,8 +1852,8 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
- "windows-sys 0.59.0",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2240,7 +2262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4479,7 +4501,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4978,7 +5000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6032,6 +6054,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -6388,7 +6421,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6446,7 +6479,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7008,7 +7041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7548,7 +7581,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -7598,7 +7631,7 @@ checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -7820,7 +7853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -7985,7 +8018,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8471,7 +8504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -8512,7 +8545,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9193,7 +9226,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9883,7 +9916,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query 0.25.1",
  "dpi",
  "dunce",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -52,6 +52,7 @@ tar = "0.4"
 zip = "2"
 unicode-normalization = "0.1"
 lindera = { version = "2.3", features = ["embed-ipadic"] }
+dirs = "5"
 
 [dev-dependencies]
 http = "1.0"

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -13,6 +13,63 @@ pub fn exe_dir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
+/// Returns the directory used for mutable runtime data: SQLite DB, attachments,
+/// avatars, VRM files, MCP venv, etc.
+///
+/// Resolution order:
+/// 1. Dev layout (Cargo.toml found walking up from the current exe) →
+///    `<exe_dir>/data`. Preserves `cargo run` / `cargo tauri dev` and the dev DB
+///    at `target/debug/data/cloto_memories.db`.
+/// 2. Production: `<platform user-data dir>/cloto-system` via `dirs::data_dir()`.
+///    - Windows: `%APPDATA%\Roaming\cloto-system\`
+///    - macOS:   `~/Library/Application Support/cloto-system/`
+///    - Linux:   `~/.local/share/cloto-system/`
+/// 3. Fallback (no exe, no user-data dir): `<exe_dir>/data` (legacy behaviour).
+///
+/// bug-377: under NSIS install on Windows the exe lives in `C:\Program Files\…`
+/// which is not user-writable; `create_dir_all(<exe_dir>/data)` fails with
+/// `ERROR_ACCESS_DENIED (os error 5)` and the kernel exits on boot.
+#[must_use]
+pub fn data_dir() -> PathBuf {
+    if is_dev_layout() {
+        return exe_dir().join("data");
+    }
+    dirs::data_dir().map_or_else(|| exe_dir().join("data"), |d| d.join("cloto-system"))
+}
+
+/// True when running from a Cargo workspace (`cargo run`, `cargo test`,
+/// `cargo tauri dev`). Detected by walking up from the running exe and finding
+/// a `Cargo.toml`. Returns false in shipped binaries installed outside the repo.
+fn is_dev_layout() -> bool {
+    let Ok(exe) = std::env::current_exe() else {
+        return false;
+    };
+    let Some(start) = exe.parent() else {
+        return false;
+    };
+    let Ok(canonical) = std::fs::canonicalize(start) else {
+        return false;
+    };
+    // Strip Windows UNC prefix (\\?\) that canonicalize() adds.
+    let mut dir = {
+        let s = canonical.to_string_lossy();
+        if let Some(stripped) = s.strip_prefix(r"\\?\") {
+            PathBuf::from(stripped)
+        } else {
+            canonical
+        }
+    };
+    for _ in 0..10 {
+        if dir.join("Cargo.toml").exists() {
+            return true;
+        }
+        if !dir.pop() {
+            return false;
+        }
+    }
+    false
+}
+
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone)]
 pub struct AppConfig {
@@ -108,7 +165,7 @@ impl AppConfig {
     #[allow(clippy::too_many_lines)]
     pub fn load() -> anyhow::Result<Self> {
         let database_url = env::var("DATABASE_URL").unwrap_or_else(|_| {
-            let db_path = exe_dir().join("data").join("cloto_memories.db");
+            let db_path = data_dir().join("cloto_memories.db");
             format!("sqlite:{}", db_path.display())
         });
 
@@ -668,6 +725,51 @@ mod tests {
         assert!(
             config.admin_api_key.is_none(),
             "whitespace-only CLOTO_API_KEY must collapse to None"
+        );
+    }
+
+    /// bug-377: under `cargo test` the working tree contains `Cargo.toml`, so
+    /// `data_dir()` must take the dev branch and resolve to `<exe_dir>/data`.
+    /// This is the path that backs the dev DB at `target/debug/data/cloto_memories.db`.
+    #[test]
+    fn test_data_dir_dev_layout_uses_exe_dir() {
+        let resolved = data_dir();
+        let expected = exe_dir().join("data");
+        assert_eq!(
+            resolved,
+            expected,
+            "under cargo test data_dir() must equal exe_dir()/data (dev layout); got {} vs {}",
+            resolved.display(),
+            expected.display()
+        );
+    }
+
+    /// bug-377: `data_dir()` must always resolve to a non-empty path so the
+    /// caller can safely `create_dir_all` it. Guards against accidental empty
+    /// PathBuf regressions in the fallback chain.
+    #[test]
+    fn test_data_dir_is_non_empty() {
+        let resolved = data_dir();
+        assert!(
+            !resolved.as_os_str().is_empty(),
+            "data_dir() must not be empty"
+        );
+    }
+
+    /// bug-377: DATABASE_URL default fallback must route through `data_dir()`
+    /// (not raw `exe_dir().join("data")`), so production installs land in the
+    /// user-writable data dir rather than under `C:\Program Files\…`.
+    #[test]
+    fn test_database_url_default_uses_data_dir() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard("DATABASE_URL");
+        std::env::remove_var("DATABASE_URL");
+
+        let config = AppConfig::load().unwrap();
+        let expected = format!("sqlite:{}", data_dir().join("cloto_memories.db").display());
+        assert_eq!(
+            config.database_url, expected,
+            "DATABASE_URL default must equal sqlite:<data_dir>/cloto_memories.db"
         );
     }
 }

--- a/crates/core/src/handlers/agents.rs
+++ b/crates/core/src/handlers/agents.rs
@@ -791,7 +791,7 @@ pub async fn serve_speech_file(
         return Err(AppError::Validation("Invalid filename".to_string()));
     }
 
-    let speech_dir = crate::config::exe_dir().join("data").join("speech");
+    let speech_dir = crate::config::data_dir().join("speech");
     let file_path = speech_dir.join(&filename);
 
     // Ensure the resolved path is within the speech directory

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -59,7 +59,7 @@ const HTTP_READY_WAIT_SECS: u64 = 30;
 pub fn init_tracing() {
     use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-    let data_dir = config::exe_dir().join("data");
+    let data_dir = config::data_dir();
     // Best-effort: if we can't create the directory, fall back to stderr-only below.
     let file_layer = match std::fs::create_dir_all(&data_dir) {
         Ok(()) => {
@@ -380,8 +380,8 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
         }
     }
 
-    // 0b. Ensure storage directories exist (relative to exe_dir for Tauri compatibility)
-    let data_dir = config::exe_dir().join("data");
+    // 0b. Ensure storage directories exist (user-writable layout per bug-377).
+    let data_dir = config::data_dir();
     if let Err(e) = std::fs::create_dir_all(data_dir.join("attachments")) {
         tracing::warn!("Failed to create data/attachments directory: {}", e);
     }

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useCallback, useEffect, useState } from 'react';
+import React, { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import { useTranslation } from 'react-i18next';
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
@@ -40,9 +40,19 @@ function App() {
   const { connected } = useConnection();
   const { t } = useTranslation();
 
-  // Re-trigger setup wizard if backend reports setup incomplete (e.g. version upgrade)
+  // Re-trigger setup wizard if backend reports setup incomplete (e.g. version
+  // upgrade where the stored `cloto-setup-completed=1` predates the new kernel).
+  //
+  // Only check on the *initial* boot of the App component — not on every
+  // `setupDone` transition. After the user clicks Finish, `setupDone` flips
+  // false→true; if we re-ran the check there and the backend reports
+  // `setup_complete=false` for any reason, we would silently unmount the
+  // wizard and remount it at step 0 (bug-383).
+  const initialStatusCheckRef = useRef(true);
   useEffect(() => {
     if (!connected || !setupDone) return;
+    if (!initialStatusCheckRef.current) return;
+    initialStatusCheckRef.current = false;
     api
       .getSetupStatus()
       .then((status) => {

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -1753,10 +1753,12 @@
       "discovered": "2026-03-10T00:00:00Z",
       "version": "0.6.2",
       "commit": "8c09a10",
-      "file": "crates/core/migrations/20260302100000_add_agent_avatar.sql",
-      "pattern": "ADD COLUMN avatar_description",
+      "file": "crates/core/migrations/20260310000000_avatar_to_metadata.sql",
+      "pattern": "DROP COLUMN avatar_description",
       "expected": "present",
-      "status": "open"
+      "status": "fixed",
+      "fixed_in": "0.6.4",
+      "fix_note": "P4 compliance restored in the 20260310 migration (Phase 2 Data Sovereignty): the dedicated `avatar_description` column was dropped from the agents table and its values migrated into the `metadata.avatar_description` JSON key. Registry was stale because the entry still pointed at the historic ADD COLUMN migration. The fix marker tracks the DROP COLUMN line in the rollback migration."
     },
     {
       "id": "bug-297",
@@ -2777,6 +2779,20 @@
       "pattern": "not found in registry, skipping",
       "expected": "present",
       "status": "fixed"
+    },
+    {
+      "id": "bug-382",
+      "summary": "CRITICAL: kernel fails to boot on Windows NSIS install with 'Cloto Kernel failed to start: アクセスが拒否されました。(os error 5)' — DATABASE_URL default + storage dirs land under Program Files",
+      "severity": "CRITICAL",
+      "discovered": "2026-05-21T00:00:00Z",
+      "version": "0.6.3",
+      "commit": "d544035",
+      "file": "crates/core/src/config.rs",
+      "pattern": "pub fn data_dir\\(",
+      "expected": "present",
+      "status": "fixed",
+      "fixed_in": "0.6.4",
+      "fix_note": "DATABASE_URL fallback (config.rs) and the storage directories created at boot (lib.rs L62 tracing, L384 attachments/avatars/vrm/speech) were hard-coded to `exe_dir()/data/`. NSIS places `cloto-system.exe` under `C:\\Program Files\\cloto-system\\` which is not user-writable for standard accounts, so `create_dir_all` returned `ERROR_ACCESS_DENIED` and the FATAL `?` at lib.rs:370 crashed the kernel on first boot. Introduced `config::data_dir()` helper that takes a dev/prod split via `is_dev_layout()`: dev (Cargo.toml detected by walking up from current exe) keeps `<exe_dir>/data` to preserve `target/debug/data/cloto_memories.db`; production routes through `dirs::data_dir().join(\"cloto-system\")` giving `%APPDATA%\\Roaming\\cloto-system\\` on Windows, `~/Library/Application Support/cloto-system/` on macOS, `~/.local/share/cloto-system/` on Linux. handlers/agents.rs speech reader updated to match. MCP server bundle layout (mcp_venv.rs / managers/mcp.rs `<exe_dir>/data/mcp-servers/`) is a separate workflow tracked as follow-up."
     }
   ]
 }

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -2781,6 +2781,20 @@
       "status": "fixed"
     },
     {
+      "id": "bug-383",
+      "summary": "Setup Wizard finish button bounces user back to step 0 — useEffect re-checks setup status immediately after onComplete and unmounts the wizard when backend reports incomplete",
+      "severity": "HIGH",
+      "discovered": "2026-05-21T00:00:00Z",
+      "version": "0.6.3",
+      "commit": "d544035",
+      "file": "dashboard/src/main.tsx",
+      "pattern": "initialStatusCheckRef",
+      "expected": "present",
+      "status": "fixed",
+      "fixed_in": "0.6.4",
+      "fix_note": "main.tsx had a useEffect that re-ran `api.getSetupStatus()` every time `setupDone` flipped. The intent was the version-upgrade scenario (stale `cloto-setup-completed=1` in localStorage from an older kernel), but the effect also fired immediately after `onComplete()`, which sets `setupDone` false→true. If the backend reported `setup_complete=false` at that moment for any reason (e.g. Setup Wizard skipped install via the step-4 Skip path, or a transient Windows path quirk), `setSetupDone(false)` was called, unmounting the wizard and remounting it at step 0 — making the wizard appear unfinishable. Gated the re-check behind a `useRef` initialised to `true` and consumed on first eligible run, so the version-upgrade flow still triggers on the App's first mount but the finish click is trusted as a terminal user action. Exposed on Windows NSIS install (bug-382 hotfix unmasked the wizard which was previously unreachable due to kernel boot failure)."
+    },
+    {
       "id": "bug-382",
       "summary": "CRITICAL: kernel fails to boot on Windows NSIS install with 'Cloto Kernel failed to start: アクセスが拒否されました。(os error 5)' — DATABASE_URL default + storage dirs land under Program Files",
       "severity": "CRITICAL",


### PR DESCRIPTION
## Summary

- **bug-382 (CRITICAL)** — Kernel crashed on boot under NSIS install on Windows with `Cloto Kernel failed to start: アクセスが拒否されました。(os error 5)`. `DATABASE_URL` fallback and boot-time storage dirs were hard-coded to `<exe_dir>/data/`; NSIS places the exe under `C:\Program Files\…` which is not user-writable, so the FATAL `?` at `lib.rs:370` killed the kernel. Introduced `config::data_dir()` with a dev/prod split that resolves to `dirs::data_dir().join("cloto-system")` in production while preserving `target/debug/data/` for dev.
- **bug-383 (HIGH)** — Setup Wizard finish button (`Cloto を使い始める`) silently bounced the user back to step 0. `main.tsx`'s setup-status re-check fired both on initial mount *and* on the `setupDone` false→true transition triggered by `onComplete()`. Gated the re-check behind a `useRef`-tracked initial-mount flag so the version-upgrade case still re-opens the wizard on boot, but a freshly-clicked Finish is trusted.
- **bug-296 (HIGH)** — Closure: `avatar_description` column was dropped in the 20260310 schema migration (Phase 2 Data Sovereignty); the registry entry still pointed at the historic ADD COLUMN migration. Switched the fix marker to `DROP COLUMN avatar_description` in the rollback migration.
- **CI plumbing** — Added `draft_only` `workflow_dispatch` input to `release.yml` for hands-on pre-release verification builds (skips tag creation + Release publish, just uploads workflow artifacts). Used to validate this PR on a real Windows NSIS installer.

## Why now

Per Goal #49 plan (release cadence option ii confirmed yesterday): **0.6.4 = Scope #10 decouple + bug-382 hotfix + bug-296 housekeeping**. bug-382 was discovered immediately post-0.6.3 publish; the boot crash blocked every Windows NSIS user. bug-383 surfaced during hands-on verification of bug-382 — it had been latent because the kernel crash hid the wizard entirely.

Scope #10 (memory plugin decouple) is independent and remains on its own track per the Goal #49 sequencing; this PR is the hotfix slice.

## Out of scope (follow-up)

- The MCP server bundle layout at `mcp_venv.rs` and `managers/mcp.rs` still references `<exe_dir>/data/mcp-servers/` (read-only bundle path, never populated by NSIS). It's a separate workflow that doesn't gate kernel boot, but should be revisited so production installs can pick up bundled server source without the wizard's marketplace install path.
- Backend release builds log to stderr only; no rolling file output (`lib.rs:95`). Would simplify any future Windows-side debugging.

## Verification

- `cargo clippy --workspace --exclude app -- -D warnings -A clippy::too-many-lines -A clippy::struct-excessive-bools -A clippy::match-same-arms -A clippy::cast-possible-wrap -A clippy::trivially-copy-pass-by-ref -A clippy::manual-let-else -A clippy::option-if-let-else -A clippy::case-sensitive-file-extension-comparisons -A clippy::unwrap-used -A clippy::type-complexity` — green (CI-equivalent flags).
- `cargo test --workspace --exclude app` — 320 pass, including 4 new `config::tests` for `data_dir()` (dev-layout invariant, non-empty fallback, default DATABASE_URL routing through helper).
- `cd dashboard && npx biome check src/main.tsx` — clean.
- `cd dashboard && npm run build` — successful Vite build with the bug-383 change.
- `bash scripts/verify-issues.sh` — all green (`bug-382` [VERIFIED], `bug-383` [VERIFIED], `bug-296` [VERIFIED], 0 stale / 0 errors across 222 entries). pre-commit hook ran the same check before each commit.
- **Hands-on Windows NSIS smoke** — built two NSIS installers via the new `draft_only=true` workflow_dispatch path (runs [26214496662](https://github.com/Cloto-dev/ClotoCore/actions/runs/26214496662) and [26219327033](https://github.com/Cloto-dev/ClotoCore/actions/runs/26219327033)). First build verified bug-382 fix (kernel boots into Setup Wizard); second build verified bug-383 fix (finish button advances to the main app without re-opening the wizard). Both confirmed by hand on Windows.

## Commits

| SHA | Subject |
| --- | --- |
| `1bcbf22` | fix(boot): route DATABASE_URL + storage dirs through user-writable data_dir (bug-382) |
| `1951ef1` | ci(release): add draft_only flag for pre-release verification builds |
| `cfab725` | fix(setup-wizard): stop re-checking setup status after onComplete (bug-383) |

## Test plan

- [x] CI-equivalent local checks green
- [x] Pre-release Windows NSIS installer hand-tested (kernel boot + wizard finish)
- [ ] PR CI green
- [ ] Post-merge release build smoke on macOS / Linux (separate Goal #49 sequencing)