### PR TITLE
dashboard: unify MGP server identification (catalog origin axis + remove legacy)

### DIFF
--- a/crates/core/src/managers/mcp.rs
+++ b/crates/core/src/managers/mcp.rs
@@ -391,6 +391,7 @@ impl McpClientManager {
                         trust_level: Some(tl),
                     }),
                 seal: r.seal.clone(),
+                marketplace_id: r.marketplace_id.clone(),
                 ..Default::default()
             })
             .collect();
@@ -695,6 +696,7 @@ impl McpClientManager {
                 restart_policy: None,
                 seal: record.seal.clone(),
                 isolation: None,
+                marketplace_id: record.marketplace_id.clone(),
             });
         }
 
@@ -1552,6 +1554,7 @@ impl McpClientManager {
                 transport: (h.config.transport != "stdio").then(|| h.config.transport.clone()),
                 url: h.config.url.clone(),
                 has_unresolved_env: has_unresolved_env_vars(&h.config.env),
+                marketplace_id: h.config.marketplace_id.clone(),
             })
             .collect()
     }
@@ -2394,6 +2397,7 @@ impl McpClientManager {
             restart_policy: None,
             seal: seal.clone(),
             isolation: None,
+            marketplace_id: None,
         };
 
         // Persist to DB first (so server is always tracked even if connect fails).
@@ -2672,6 +2676,7 @@ impl McpClientManager {
             restart_policy: None,
             seal: None,
             isolation: None,
+            marketplace_id: record.marketplace_id.clone(),
         };
 
         self.connect_server(config).await

--- a/crates/core/src/managers/mcp_discovery.rs
+++ b/crates/core/src/managers/mcp_discovery.rs
@@ -321,6 +321,7 @@ pub(super) async fn execute_discovery_register(
         restart_policy: None,
         seal: None,
         isolation: None,
+        marketplace_id: None,
     };
 
     info!(id = %id, command = %command, "Registering dynamic server via mgp.discovery.register");

--- a/crates/core/src/managers/mcp_protocol.rs
+++ b/crates/core/src/managers/mcp_protocol.rs
@@ -277,6 +277,13 @@ pub struct McpServerConfig {
     /// Per-server isolation config overrides (MGP §8-10).
     #[serde(default)]
     pub isolation: Option<super::mcp_isolation::IsolationConfig>,
+    /// ClotoHub catalog connector id when this server was installed via
+    /// `/api/marketplace/install`. NULL ⇒ manually registered (CLI / API / mcp.toml).
+    /// Surfaced in `McpServerInfo.marketplace_id` so the dashboard can render
+    /// the MGP purple card for catalog-originated servers even when unsigned
+    /// (per MGP §10 inv 3: seal absence demotes trust_level, not MGP membership).
+    #[serde(default)]
+    pub marketplace_id: Option<String>,
 }
 
 fn default_transport() -> String {
@@ -300,6 +307,7 @@ impl Default for McpServerConfig {
             restart_policy: None,
             seal: None,
             isolation: None,
+            marketplace_id: None,
         }
     }
 }

--- a/crates/core/src/managers/mcp_types.rs
+++ b/crates/core/src/managers/mcp_types.rs
@@ -82,6 +82,12 @@ pub struct McpServerInfo {
     /// True when the server config contains env vars that reference unset variables.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub has_unresolved_env: bool,
+    /// ClotoHub catalog connector id when the server was installed via marketplace.
+    /// NULL ⇒ manually registered. The dashboard uses this together with
+    /// `mgp_supported` to render the MGP purple card (catalog-origin OR
+    /// protocol-negotiated), separate from the seal-based Verified badge.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub marketplace_id: Option<String>,
 }
 
 #[must_use]

--- a/crates/core/tests/migration_test.rs
+++ b/crates/core/tests/migration_test.rs
@@ -214,4 +214,33 @@ async fn test_set_marketplace_fields_persists_trust_level() {
         .unwrap();
     assert_eq!(row.trust_level.as_deref(), Some("core"));
     assert_eq!(row.installed_version.as_deref(), Some("1.2.3"));
+    // marketplace_id must persist so it can flow into McpServerConfig and
+    // McpServerInfo.marketplace_id, gating the dashboard's MGP purple card
+    // for catalog-originated servers (lib/mgp.ts isMgpServer).
+    assert_eq!(row.marketplace_id.as_deref(), Some("test.marketplace"));
+}
+
+/// Manually-registered (non-marketplace) servers must persist `marketplace_id`
+/// as NULL so the dashboard distinguishes them from catalog-origin servers
+/// in `lib/mgp.ts isMgpServer()` / `isVerified()`.
+#[tokio::test]
+async fn test_manual_register_leaves_marketplace_id_null() {
+    let pool = fresh_pool().await;
+    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        .await
+        .unwrap();
+
+    let record = make_record("test.manual", None);
+    cloto_core::db::save_mcp_server(&pool, &record)
+        .await
+        .unwrap();
+
+    let loaded = cloto_core::db::load_active_mcp_servers(&pool)
+        .await
+        .unwrap();
+    let row = loaded.iter().find(|r| r.name == "test.manual").unwrap();
+    assert!(
+        row.marketplace_id.is_none(),
+        "manual register must leave marketplace_id NULL"
+    );
 }

--- a/dashboard/src/components/ServerAccessSection.tsx
+++ b/dashboard/src/components/ServerAccessSection.tsx
@@ -1,6 +1,7 @@
 import { Layers, Plus, Server, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { displayServerId } from '../lib/format';
+import { isMgpServer } from '../lib/mgp';
 import { detectPreset, SERVER_PRESETS } from '../lib/presets';
 import type { McpServerInfo } from '../types';
 import { StatusDot, type StatusDotStatus } from './ui/StatusDot';
@@ -12,13 +13,6 @@ function mcpStatusToDot(server: McpServerInfo): StatusDotStatus {
   if (server.status === 'Error' && server.has_unresolved_env) return 'degraded';
   if (server.status === 'Error') return 'error';
   return 'offline';
-}
-
-function isMgpServer(server: McpServerInfo): boolean {
-  return (
-    (server.mgp_supported || server.id.startsWith('io.') || server.id.startsWith('output.')) &&
-    server.status === 'Connected'
-  );
 }
 
 function serverStatusLabel(server: McpServerInfo, t: (key: string) => string): string {

--- a/dashboard/src/lib/mgp.ts
+++ b/dashboard/src/lib/mgp.ts
@@ -1,0 +1,27 @@
+import type { McpServerInfo } from '../types';
+
+/**
+ * MGP server identification (single source of truth, replaces inline duplicates
+ * in `ServerAccessSection.tsx` and `McpServersPage.tsx`).
+ *
+ * A server is rendered as MGP (purple card branding) when *either*:
+ *   (a) `mgp_supported` — kernel handshake negotiated `capabilities.mgp`
+ *       (protocol-level MGP, per MGP_SPEC §2.3), or
+ *   (b) `marketplace_id` is set — the server was installed via the ClotoHub
+ *       catalog (`POST /api/marketplace/install`), regardless of whether the
+ *       seal was present (per MGP §10 invariant 3: seal absence demotes
+ *       `trust_level` to `untrusted` but does not revoke MGP membership).
+ *
+ * Runtime connection state (`status`) is intentionally NOT gated — MGP
+ * membership is an install-time property, not a runtime attribute. A disconnected
+ * MGP server still renders purple.
+ *
+ * Legacy `id.startsWith('io.')` / `id.startsWith('output.')` hardcoding was
+ * removed: `io.discord` and `output.avatar` both declare `capabilities.mgp`
+ * v0.6.0 since the 2026-04-22 PR, so handshake negotiation covers them.
+ * Hardcoded ID prefixes violated ARCHITECTURE.md §1.2 ("Not who it is, but
+ * what it can do").
+ */
+export function isMgpServer(server: McpServerInfo): boolean {
+  return Boolean(server.mgp_supported) || Boolean(server.marketplace_id);
+}

--- a/dashboard/src/pages/McpServersPage.tsx
+++ b/dashboard/src/pages/McpServersPage.tsx
@@ -11,6 +11,7 @@ import { useAsyncAction } from '../hooks/useAsyncAction';
 import { useMcpServers } from '../hooks/useMcpServers';
 import { extractError } from '../lib/errors';
 import { displayServerId } from '../lib/format';
+import { isMgpServer } from '../lib/mgp';
 import type { McpServerInfo } from '../types';
 
 function mcpStatusToDot(server: McpServerInfo): StatusDotStatus {
@@ -225,10 +226,7 @@ export function McpServersPage() {
 
             <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-3">
               {sortedServers.map((server) => {
-                // MGP servers: negotiated, or I/O bridge / output servers (bidirectional by design)
-                const isMgp =
-                  (server.mgp_supported || server.id.startsWith('io.') || server.id.startsWith('output.')) &&
-                  server.status === 'Connected';
+                const isMgp = isMgpServer(server);
                 const isTransitioning =
                   server.status === 'Connecting' || server.status === 'Restarting' || server.status === 'Registered';
                 const shimmer = isTransitioning ? (isMgp ? 'shimmer-active-mgp' : 'shimmer-active') : '';

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -214,6 +214,11 @@ export interface McpServerInfo {
   transport?: string;
   url?: string;
   has_unresolved_env?: boolean;
+  /** ClotoHub catalog connector id when the server was installed via the
+   * marketplace (`POST /api/marketplace/install`). Absent ⇒ manually
+   * registered (CLI / API / mcp.toml). Used together with `mgp_supported`
+   * by `isMgpServer()` in `lib/mgp.ts` to render the MGP purple card. */
+  marketplace_id?: string | null;
 }
 
 export interface AccessControlEntry {


### PR DESCRIPTION
## Summary

Unifies the MGP purple card identification logic across the dashboard into a single helper at `dashboard/src/lib/mgp.ts`. A server is now rendered as MGP (purple branding) when **either**:

- `mgp_supported` — kernel handshake negotiated `capabilities.mgp` (protocol-level), **or**
- `marketplace_id` is set — the server was installed via the ClotoHub catalog (origin-level)

The seal-based **✓ Verified** badge on `MarketplaceCard` remains a separate axis. Catalog-originated servers without a seal still render purple, matching **MGP v0.6.3 §10 invariant 3**: seal absence demotes `effective_trust_level` to `untrusted` but does not revoke MGP membership.

## Design

| Server state | Purple (MGP) | ✓ Verified |
|---|---|---|
| ClotoHub catalog install + seal verified | ◯ | ◯ |
| ClotoHub catalog install + no seal (untrusted) | ◯ | ✗ |
| Manual install + `capabilities.mgp` declared | ◯ | ✗ |
| Manual install + no MGP capability | ✗ | ✗ |

Set relationship: purple ⊇ Verified.

## Changes

### Backend
- Surface the existing `mcp_servers.marketplace_id` column through `McpServerConfig` and `McpServerInfo`. **No schema change** — the column was added by migration `20260315000000_add_marketplace_fields.sql` and is already populated by `set_marketplace_fields` on every marketplace install.
- Thread the field through all four `McpServerConfig` construction sites + the dynamic-server registration path in `mcp_discovery.rs`.

### Dashboard
- New `dashboard/src/lib/mgp.ts` with `isMgpServer(server)` as the single source of truth.
- `ServerAccessSection.tsx` and `McpServersPage.tsx` now import the helper, eliminating two inline duplicates.
- **Removed the legacy `id.startsWith('io.')` / `id.startsWith('output.')` prefix hardcoding** (ARCHITECTURE.md §1.2 violation). Both surviving prefix-matched servers (`io.discord`, `output.avatar`) declare `capabilities.mgp` v0.6.0 since 2026-04-22, so handshake negotiation covers them.
- **Removed the `status === 'Connected'` gate** on MGP membership: MGP is an install-time property, not a runtime attribute. A disconnected MGP server now retains its purple card.

### Tests
- Extended `test_set_marketplace_fields_persists_trust_level` with a `marketplace_id` assertion.
- New `test_manual_register_leaves_marketplace_id_null` asserts the inverse boundary.

## Test plan

- [x] `cargo clippy --workspace --exclude app -- -D warnings -A clippy::too-many-lines -A clippy::struct-excessive-bools -A clippy::match-same-arms -A clippy::cast-possible-wrap -A clippy::trivially-copy-pass-by-ref -A clippy::manual-let-else -A clippy::option-if-let-else -A clippy::case-sensitive-file-extension-comparisons -A clippy::unwrap-used -A clippy::type-complexity` (CI flags) — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace --exclude app` — all green, both new tests pass
- [x] `cd dashboard && ./node_modules/.bin/tsc --noEmit` — clean
- [x] `cd dashboard && npx biome lint src/` (CI flags) — clean
- [x] `cd dashboard && npm run build` — success
- [x] `bash scripts/verify-issues.sh` — all green (89 verified / 134 fixed / 0 stale)
- [ ] Dev launch UI verification:
  - (a) ClotoHub catalog install + seal verified → purple ◯ + Verified ◯
  - (b) Manual install with `capabilities.mgp` → purple ◯ + Verified ✗
  - (c) ClotoHub catalog install, no seal → purple ◯ + Verified ✗
  - (d) Disconnected MGP server keeps purple
  - (e) `io.discord` / `output.avatar` still render purple after prefix hardcode removal

## Release

Targets 0.6.4 (alongside Scope #10 memory plugin decouple, per project planning).