### PR TITLE
0.6.4: Setup Wizard loop follow-up (bug-384) + version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "base64 0.21.7",
  "cloto_core",
@@ -1139,7 +1139,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cloto_core"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "cloto_shared"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 authors = ["ClotoCore <ClotoCore@proton.me>"]
 license = "BSL-1.1"

--- a/crates/core/src/handlers/setup.rs
+++ b/crates/core/src/handlers/setup.rs
@@ -84,6 +84,19 @@ fn resolve_root() -> Option<std::path::PathBuf> {
     crate::managers::McpClientManager::detect_project_root(&exe)
 }
 
+/// Returns true when the `agents` table has at least one row.
+///
+/// Used as the bug-384 minimum-proof-of-setup fallback in `status_handler`.
+/// On any unexpected SQL error, returns false — the caller falls through to
+/// the wizard, which is the safe default for an unhealthy DB.
+async fn db_has_agents(pool: &sqlx::SqlitePool) -> bool {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM agents")
+        .fetch_one(pool)
+        .await
+        .map(|count| count > 0)
+        .unwrap_or(false)
+}
+
 // ── Endpoints ────────────────────────────────────────────────────────
 
 /// GET /api/setup/status — lightweight check (no auth required, like health_handler).
@@ -132,15 +145,19 @@ pub async fn status_handler(State(state): State<Arc<AppState>>) -> Json<serde_js
         }
     }
 
-    // Fallback: if JSON missing but servers + DB agents exist, treat as complete (bug-378)
-    if !setup_complete && mcp_servers_present && venv_exists {
-        let agent_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agents")
-            .fetch_one(&state.pool)
-            .await
-            .unwrap_or(0);
-        if agent_count > 0 {
-            setup_complete = true;
-        }
+    // Fallback: DB initialization alone is sufficient proof of a usable setup.
+    //
+    // `mcp_servers_present` and `venv_exists` are quality-of-life indicators
+    // surfaced to the dashboard via the SetupStatus fields; they are not
+    // invariants of `setup_complete`. Requiring them in the fallback (bug-378
+    // shape) re-prompted Skip-path users — who intentionally bypassed the
+    // marketplace install — through the wizard on every launch (bug-384).
+    // The kernel's minimum proof of "usable setup" is a healthy `agents` row,
+    // which `init_db` seeds on first boot via the migration suite. A version
+    // upgrade that genuinely needs re-install is handled separately by the
+    // batch installer's stale-version cleanup (marketplace.rs).
+    if !setup_complete && db_has_agents(&state.pool).await {
+        setup_complete = true;
     }
 
     let in_progress = state
@@ -509,5 +526,22 @@ mod tests {
         let file: SetupCompleteFile = serde_json::from_str(json).unwrap();
         assert_eq!(file.server_count, 10);
         assert!(file.uv_version.is_none());
+    }
+
+    /// bug-384: the post-init fallback treats a single agent row as proof of
+    /// usable setup, even when `setup-complete.json` and the MCP bundle are
+    /// absent (the Skip-path case). The first migration seed inserts
+    /// `agent.cloto_default` unconditionally, so this is true from the very
+    /// first kernel boot.
+    #[tokio::test]
+    async fn test_db_has_agents_after_init() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        // Sanity: empty pool reports no agents.
+        assert!(!db_has_agents(&pool).await);
+        // After init_db, the cloto_default seed row exists.
+        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+            .await
+            .unwrap();
+        assert!(db_has_agents(&pool).await);
     }
 }

--- a/crates/core/src/handlers/setup.rs
+++ b/crates/core/src/handlers/setup.rs
@@ -93,8 +93,7 @@ async fn db_has_agents(pool: &sqlx::SqlitePool) -> bool {
     sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM agents")
         .fetch_one(pool)
         .await
-        .map(|count| count > 0)
-        .unwrap_or(false)
+        .is_ok_and(|count| count > 0)
 }
 
 // ── Endpoints ────────────────────────────────────────────────────────

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloto_dashboard",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard/src-tauri/tauri.conf.json
+++ b/dashboard/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "cloto-system",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "identifier": "com.cloto.app",
   "build": {
     "frontendDist": "../dist",

--- a/dashboard/src/components/SetupWizard.tsx
+++ b/dashboard/src/components/SetupWizard.tsx
@@ -343,9 +343,18 @@ export function SetupWizard({ onComplete }: Props) {
       es.onerror = () => {
         es.close();
         installingRef.current = false;
+        // bug-384 Prong 2(b): if the SSE stream errors out before we received a
+        // `Complete` event, the install genuinely did not finish. Surface this
+        // as a retry-able error instead of silently auto-advancing to step 6,
+        // which would let the user reach Finish on top of an incomplete
+        // install and (combined with backend `setup_complete=false`) bounce
+        // them back through the wizard on next launch.
         if (!installComplete) {
-          setInstallComplete(true);
-          setTimeout(() => next(), 1000);
+          setInstallError(
+            t('install_error_stream_disconnected', {
+              defaultValue: 'Install progress stream disconnected. Please retry.',
+            }),
+          );
         }
       };
     } catch (e) {

--- a/dashboard/src/locales/en/wizard.json
+++ b/dashboard/src/locales/en/wizard.json
@@ -50,6 +50,7 @@
   "step_install_preparing": "Preparing installation...",
   "install_elapsed": "Elapsed: {{time}}",
   "install_estimate": "Estimated: {{min}}–{{max}} min",
+  "install_error_stream_disconnected": "Install progress stream disconnected. Please retry.",
   "quick_guide": "Quick Guide",
   "guide_agents": "Chat with AI agents, create new ones, and manage their settings.",
   "guide_mcp": "Connect and manage MCP server plugins for extended capabilities.",

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -40,19 +40,25 @@ function App() {
   const { connected } = useConnection();
   const { t } = useTranslation();
 
-  // Re-trigger setup wizard if backend reports setup incomplete (e.g. version
-  // upgrade where the stored `cloto-setup-completed=1` predates the new kernel).
+  // Re-trigger the setup wizard ONLY when the session began with a stored
+  // completion flag and the backend disagrees — i.e. the version-upgrade
+  // scenario where the stored `cloto-setup-completed=1` predates the new
+  // kernel. We capture the *mount-time* value of `setupDone` once; if the
+  // session started with no flag (fresh install), this effect never runs at
+  // all, so a Finish click never bounces.
   //
-  // Only check on the *initial* boot of the App component — not on every
-  // `setupDone` transition. After the user clicks Finish, `setupDone` flips
-  // false→true; if we re-ran the check there and the backend reports
-  // `setup_complete=false` for any reason, we would silently unmount the
-  // wizard and remount it at step 0 (bug-383).
-  const initialStatusCheckRef = useRef(true);
+  // bug-384: bug-383's `useRef(true)` still consumed the gate on the first
+  // false→true transition of `setupDone` (i.e. right after onComplete on a
+  // fresh install), which could bounce the user back to step 0 if the backend
+  // momentarily reported `setup_complete=false`. Capturing `setupDone` itself
+  // is the correct gate — `useRef` only reads its initial argument on the
+  // first render, so a later `setSetupDone(true)` cannot retroactively open
+  // this guard.
+  const checkOnUpgradeRef = useRef<boolean>(setupDone);
   useEffect(() => {
     if (!connected || !setupDone) return;
-    if (!initialStatusCheckRef.current) return;
-    initialStatusCheckRef.current = false;
+    if (!checkOnUpgradeRef.current) return;
+    checkOnUpgradeRef.current = false;
     api
       .getSetupStatus()
       .then((status) => {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -89,6 +89,15 @@ Always review this list before making code changes and adhere to the constraints
 | Process facial images | Do not save or externally transmit raw facial video | Prevents biometric data leakage. Stream coordinate data only |
 | Share gaze data | Do not stream gaze data to non-permitted domains | "What someone is looking at" is itself sensitive information |
 
+### 1.9 Setup State: Minimum Proof of Boot
+
+**Goal**: Treat `setup_complete` as a single, narrow contract — "the kernel can boot and serve a usable agent" — so that frontend gates do not re-prompt users who have intentionally bypassed optional install paths.
+
+| Step | DO NOT | Reason |
+| :--- | :--- | :--- |
+| Compute `setup_complete` in `handlers/setup.rs::status_handler` | Do not require MCP-server bundles or a Python venv as invariants of `setup_complete` | The Setup Wizard's Skip path produces no install artefacts on disk; requiring them would loop the user through the wizard on every launch (bug-384). MCP-bundle presence is surfaced separately via the `mcp_servers_present` / `venv_exists` fields for the dashboard's quality-of-life signals |
+| Detect version-upgrade re-setup needs | Do not rely on the `status_handler` fallback to force a wizard re-show on version mismatch | The batch installer (`handlers/marketplace.rs::run_batch_install`) owns stale-version cleanup; the status fallback's role is "is the kernel usable?", not "should the user re-run the wizard?" |
+
 ---
 
 ## 2. Current Refactoring Status

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -2781,6 +2781,21 @@
       "status": "fixed"
     },
     {
+      "id": "bug-384",
+      "summary": "Setup Wizard still bounces on first finish click and re-appears on next launch after fresh install — bug-383's `useRef(true)` consumed the gate at the post-onComplete transition, not at App mount; backend `setup_complete=false` on the Skip and SSE-failure paths compounds the issue across sessions",
+      "severity": "HIGH",
+      "discovered": "2026-05-23T00:00:00Z",
+      "version": "0.6.4",
+      "commit": "7946f69",
+      "file": "dashboard/src/main.tsx",
+      "pattern": "checkOnUpgradeRef",
+      "expected": "present",
+      "status": "fixed",
+      "fixed_in": "0.6.4",
+      "fix_note": "Three-prong bundle. (Prong 1, main.tsx) replace `useRef(true)` with `useRef<boolean>(setupDone)` so the version-upgrade re-check fires only when the session began with a stored completion flag — on a fresh install the gate starts `false` and the effect can never bounce the post-onComplete transition. (Prong 2b, SetupWizard.tsx) when the install-progress `EventSource` errors before a `Complete` payload, surface a retry-able error via the existing `installError` UI instead of auto-advancing the wizard to step 6 with no install artefacts. (Prong 2c, handlers/setup.rs) relax the bug-378 fallback to require only an `agents` row, so users who explicitly Skip the marketplace install are not re-prompted through the wizard on every launch — DEVELOPMENT.md §1.9 documents the new doctrine that `setup_complete` is the kernel's minimum-proof-of-boot contract, not a check on optional install artefacts. bug-383 remains marked `fixed` (its useRef-based gate was the right shape, just initialised wrong) and its `pattern` is updated to the corrected call form that ships with this PR.",
+      "github_issue": null
+    },
+    {
       "id": "bug-383",
       "summary": "Setup Wizard finish button bounces user back to step 0 — useEffect re-checks setup status immediately after onComplete and unmounts the wizard when backend reports incomplete",
       "severity": "HIGH",
@@ -2788,11 +2803,11 @@
       "version": "0.6.3",
       "commit": "d544035",
       "file": "dashboard/src/main.tsx",
-      "pattern": "initialStatusCheckRef",
+      "pattern": "useRef<boolean>\\(setupDone\\)",
       "expected": "present",
       "status": "fixed",
       "fixed_in": "0.6.4",
-      "fix_note": "main.tsx had a useEffect that re-ran `api.getSetupStatus()` every time `setupDone` flipped. The intent was the version-upgrade scenario (stale `cloto-setup-completed=1` in localStorage from an older kernel), but the effect also fired immediately after `onComplete()`, which sets `setupDone` false→true. If the backend reported `setup_complete=false` at that moment for any reason (e.g. Setup Wizard skipped install via the step-4 Skip path, or a transient Windows path quirk), `setSetupDone(false)` was called, unmounting the wizard and remounting it at step 0 — making the wizard appear unfinishable. Gated the re-check behind a `useRef` initialised to `true` and consumed on first eligible run, so the version-upgrade flow still triggers on the App's first mount but the finish click is trusted as a terminal user action. Exposed on Windows NSIS install (bug-382 hotfix unmasked the wizard which was previously unreachable due to kernel boot failure).",
+      "fix_note": "main.tsx had a useEffect that re-ran `api.getSetupStatus()` every time `setupDone` flipped. The intent was the version-upgrade scenario (stale `cloto-setup-completed=1` in localStorage from an older kernel), but the effect also fired immediately after `onComplete()`, which sets `setupDone` false→true. If the backend reported `setup_complete=false` at that moment for any reason (e.g. Setup Wizard skipped install via the step-4 Skip path, or a transient Windows path quirk), `setSetupDone(false)` was called, unmounting the wizard and remounting it at step 0 — making the wizard appear unfinishable. Gated the re-check behind a `useRef` initialised to `true` and consumed on first eligible run, so the version-upgrade flow still triggers on the App's first mount but the finish click is trusted as a terminal user action. Exposed on Windows NSIS install (bug-382 hotfix unmasked the wizard which was previously unreachable due to kernel boot failure). NOTE: superseded by bug-384 — the `useRef(true)` initialisation still consumed the gate on the first eligible run, which on a fresh install is the post-onComplete transition the fix was meant to skip; bug-384's `useRef<boolean>(setupDone)` captures the correct mount-time state. The `pattern` for this entry is updated to track the corrected call shape so the registry remains [VERIFIED] without changing the historical record of bug-383 itself.",
       "github_issue": 129
     },
     {


### PR DESCRIPTION
## Summary

Three-prong follow-up to bug-383 closing the residual Setup Wizard loop reported on 2026-05-23, plus the 0.6.4 version bump that cumulates this PR with the bug-382 / bug-383 / MGP-identification / draft_only changes already on master since v0.6.3.

- **Prong 1** (`dashboard/src/main.tsx`): replace `useRef(true)` with `useRef<boolean>(setupDone)` so the setup-status re-check gates on mount-time state, not on the first eligible run. Fresh-install users no longer bounce on the first "Cloto を使い始める" click; version-upgrade users still get the wizard re-shown if the backend reports incomplete.
- **Prong 2(b)** (`dashboard/src/components/SetupWizard.tsx`): when the install-progress `EventSource` errors before a `Complete` payload, surface a localized retry-able error via the existing `installError` UI instead of silently auto-advancing to step 6. Adds `install_error_stream_disconnected` to `locales/en/wizard.json`.
- **Prong 2(c)** (`crates/core/src/handlers/setup.rs`): relax the bug-378 fallback to require only an `agents` row, not MCP-bundle + venv presence. Skip-path users (who intentionally bypass the marketplace install) are no longer re-prompted through the wizard on every launch. New `db_has_agents` helper + `test_db_has_agents_after_init` covering the empty-pool and post-`init_db` paths. Documents the new doctrine in `docs/DEVELOPMENT.md` §1.9 "Setup State: Minimum Proof of Boot".

bug-384 is registered in `qa/issue-registry.json` (pattern `checkOnUpgradeRef`); bug-383's `pattern` is updated to the corrected call shape `useRef<boolean>\(setupDone\)` so the registry stays [VERIFIED] without rewriting the historical record. `verify-issues.sh`: 224 total / 90 VERIFIED / 134 FIXED / 0 STALE / 0 ERROR.

## Cumulative 0.6.4 release notes (since v0.6.3)

- **bug-382 (CRITICAL)** — Windows NSIS kernel boot crash with `ERROR_ACCESS_DENIED`. `config::data_dir()` now routes DATABASE_URL + storage dirs through `dirs::data_dir().join("cloto-system")` in production.
- **bug-383 (HIGH)** — Setup Wizard finish-button bounce loop on fresh install. (Initial fix in PR #128; this PR closes the residual gap as bug-384.)
- **bug-384 (HIGH)** — Setup Wizard still re-displays on next launch after fresh install. Three-prong fix above.
- **bug-296** — closed (avatar_description column dropped in 20260310 migration; registry entry was stale).
- **Dashboard MGP server identification (PR #131)** — 2-axis purple (`mgp_supported || marketplace_id != null`) + Verified (signed by ClotoHub key), legacy `io.` / `output.` prefix and Connected gating removed per MGP §10 inv 3.
- **release.yml `draft_only` flag** — pre-release artifact verification on any branch without polluting tag history.

## Test plan

- [x] `npx biome lint src/` (130 files, 0 errors — CI equivalent)
- [x] `npm run build` (vite build succeeds)
- [x] `npm test` (vitest: 19/19 passed)
- [x] `cargo test -p cloto_core --lib` (252/252 passed including new `test_db_has_agents_after_init`)
- [x] `cargo clippy --workspace --exclude app -- -D warnings ...` with CI flags (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `bash scripts/verify-issues.sh` (224 total / 90 VERIFIED / 134 FIXED / 0 STALE / 0 ERROR)
- [ ] Manual Windows NSIS smoke (fresh install + Skip path) — requires CI artifact build
- [ ] Manual Mac .dmg smoke (fresh install + Skip path) — requires CI artifact build

🤖 Generated with [Claude Code](https://claude.com/claude-code)