### PR TITLE
fix(0.6.5): bug-385 — Tauri Updater plugin proper integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "base64 0.21.7",
  "cloto_core",
@@ -1139,7 +1139,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cloto_core"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "cloto_shared"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 authors = ["ClotoCore <ClotoCore@proton.me>"]
 license = "BSL-1.1"

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloto_dashboard",
-  "version": "0.6.3",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloto_dashboard",
-      "version": "0.6.3",
+      "version": "0.6.5",
       "dependencies": {
         "@pixiv/three-vrm": "^3.5.0",
         "@pixiv/three-vrm-animation": "^3.5.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloto_dashboard",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard/src-tauri/capabilities/default.json
+++ b/dashboard/src-tauri/capabilities/default.json
@@ -17,16 +17,6 @@
     "core:webview:allow-webview-close",
     "core:window:allow-destroy",
     "shell:allow-open",
-    {
-      "identifier": "shell:allow-execute",
-      "allow": [
-        {
-          "name": "cloto_system",
-          "cmd": "cloto_system",
-          "args": true
-        }
-      ]
-    },
     "notification:default",
     "updater:default",
     "dialog:default",

--- a/dashboard/src-tauri/tauri.conf.json
+++ b/dashboard/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "cloto-system",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "identifier": "com.cloto.app",
   "build": {
     "frontendDist": "../dist",

--- a/dashboard/src/lib/tauri.ts
+++ b/dashboard/src/lib/tauri.ts
@@ -223,80 +223,63 @@ export interface UpdateInfo {
 }
 
 /**
- * Parse a semver string into [major, minor, patch] + optional pre-release tag.
- * Stable releases are considered NEWER than pre-releases of the same version.
+ * Check for updates via the Tauri Updater plugin. Reads `latest.json` from the
+ * GitHub release endpoint configured in `tauri.conf.json`. Browser mode is a
+ * no-op (returns `available: false`).
+ *
+ * The endpoint resolves through GitHub's `/releases/latest/download/` URL, which
+ * always points to the latest STABLE release — pre-release channel discovery is
+ * deferred to a future feature.
  */
-function parseSemver(v: string): { nums: number[]; pre: string | null } {
-  const [core, ...preParts] = v.split('-');
-  const nums = core.split('.').map((n) => Number.parseInt(n, 10) || 0);
-  const pre = preParts.length > 0 ? preParts.join('-') : null;
-  return { nums, pre };
-}
-
-function isNewerVersion(current: string, latest: string): boolean {
-  const c = parseSemver(current);
-  const l = parseSemver(latest);
-  // Compare major.minor.patch
-  for (let i = 0; i < 3; i++) {
-    if ((l.nums[i] || 0) !== (c.nums[i] || 0)) return (l.nums[i] || 0) > (c.nums[i] || 0);
-  }
-  // Same major.minor.patch — compare pre-release
-  // stable (null) > pre-release ("alpha.2")
-  if (c.pre !== null && l.pre === null) return true; // current is pre, latest is stable → upgrade
-  if (c.pre === null && l.pre !== null) return false; // current is stable, latest is pre → no downgrade
-  if (c.pre === null && l.pre === null) return false; // both stable, same version
-  // Both pre-release: compare segments (e.g. alpha.4 vs alpha.5)
-  const cParts = c.pre!.split('.');
-  const lParts = l.pre!.split('.');
-  const len = Math.max(cParts.length, lParts.length);
-  for (let i = 0; i < len; i++) {
-    if (cParts[i] === undefined) return true; // latest has more segments → newer
-    if (lParts[i] === undefined) return false;
-    const cn = Number(cParts[i]);
-    const ln = Number(lParts[i]);
-    if (!Number.isNaN(cn) && !Number.isNaN(ln)) {
-      if (ln !== cn) return ln > cn;
-    } else if (lParts[i] !== cParts[i]) {
-      return lParts[i] > cParts[i];
-    }
-  }
-  return false;
-}
-
 export async function checkForUpdates(): Promise<UpdateInfo> {
   const current = __APP_VERSION__;
-  const isCurrentPreRelease = parseSemver(current).pre !== null;
-
-  const resp = await fetch('https://api.github.com/repos/Cloto-dev/ClotoCore/releases?per_page=30', {
-    headers: { Accept: 'application/vnd.github.v3+json' },
-  });
-  if (!resp.ok) throw new Error(`GitHub API error: ${resp.status}`);
-  const releases: Array<{ tag_name: string; prerelease: boolean; draft: boolean; published_at: string; body: string }> =
-    await resp.json();
-
-  // Pre-release users: newest overall. Stable users: newest stable only.
-  const published = releases.filter((r) => !r.draft);
-  const target = isCurrentPreRelease ? published[0] : published.find((r) => !r.prerelease);
-
-  if (!target) {
+  if (!isTauri) {
     return { available: false, currentVersion: current, latestVersion: current };
   }
-
-  const latest = (target.tag_name || '').replace(/^v/, '');
+  const { check } = await import('@tauri-apps/plugin-updater');
+  const update = await check();
+  if (!update) {
+    return { available: false, currentVersion: current, latestVersion: current };
+  }
   return {
-    available: isNewerVersion(current, latest),
-    currentVersion: current,
-    latestVersion: latest,
-    releaseDate: target.published_at,
-    releaseNotes: target.body,
+    available: true,
+    currentVersion: update.currentVersion,
+    latestVersion: update.version,
+    releaseDate: update.date,
+    releaseNotes: update.body,
   };
 }
 
+/**
+ * Download and install the available update, then relaunch the app.
+ * Throws when not in desktop mode or no update is available.
+ *
+ * On Windows (NSIS), the installer terminates the running process and starts
+ * the new exe itself, so the `relaunch()` call may reject — that is expected
+ * and is swallowed. On macOS / Linux (.AppImage), `relaunch()` performs the
+ * restart explicitly.
+ */
 export async function applyUpdate(): Promise<string> {
   if (!isTauri) throw new Error('Update can only be applied in desktop mode');
-  const { Command } = await import('@tauri-apps/plugin-shell');
-  const cmd = Command.create('cloto_system', ['update', '--yes']);
-  const output = await cmd.execute();
-  if (output.code !== 0) throw new Error(output.stderr || 'Update failed');
-  return output.stdout;
+  const { check } = await import('@tauri-apps/plugin-updater');
+  const { relaunch } = await import('@tauri-apps/plugin-process');
+  const update = await check();
+  if (!update) throw new Error('No update available');
+  let downloaded = 0;
+  let contentLength = 0;
+  await update.downloadAndInstall((event) => {
+    if (event.event === 'Started') {
+      contentLength = event.data.contentLength ?? 0;
+    } else if (event.event === 'Progress') {
+      downloaded += event.data.chunkLength;
+    }
+  });
+  const sizeBytes = contentLength || downloaded;
+  const sizeMb = sizeBytes / 1_048_576;
+  try {
+    await relaunch();
+  } catch {
+    // NSIS installer may have already killed the process
+  }
+  return `Updated to v${update.version} (${sizeMb.toFixed(1)} MB). Restarting…`;
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,18 @@ Versioning follows the project's phase scheme: Alpha (A), Beta (βX.Y = 0.X.Y), 
 
 ---
 
+## [0.6.5] — 2026-05-24
+
+CRITICAL hotfix release. Restores the auto-update path for all installer-based ClotoCore installs by switching the dashboard from a broken sidecar shell-out to the configured Tauri Updater plugin. Cumulative since v0.6.4 (2026-05-23).
+
+### Fixed
+- **bug-385 (CRITICAL — Auto-update)** — `applyUpdate()` in `dashboard/src/lib/tauri.ts` shelled out to a sidecar named `cloto_system` via `@tauri-apps/plugin-shell`, but the binary was never bundled into the NSIS / DMG / `.deb` installer (`bundle.externalBin` is unset in `tauri.conf.json` and the release workflow never copies the standalone kernel binary into the app bundle). Every "Update Now" click failed at `Command.create()` with a program-not-found error which the UI surfaced as the default "Failed to apply update" message — affecting all installer-based ClotoCore installs since v0.6.3. The Tauri Updater plugin itself was already fully configured (pubkey + endpoint pointing at `latest.json` + `createUpdaterArtifacts: "v1Compatible"`), and the release workflow generates a valid `latest.json` per release — the dashboard simply never invoked it. `checkForUpdates()` now uses `@tauri-apps/plugin-updater` `check()` (replacing direct GitHub API calls and freeing the path from the 60-request/hour unauthenticated rate limit); `applyUpdate()` calls `check()` + `update.downloadAndInstall()` + `@tauri-apps/plugin-process` `relaunch()` (with `try/catch` around `relaunch()` for NSIS install paths where the new installer kills the running process). The now-dead `shell:allow-execute cloto_system` entry was removed from `capabilities/default.json`. Existing v0.6.3 / v0.6.4 users must download v0.6.5 manually one last time to recover the in-app auto-update flow.
+
+### Known limitations
+- `latest.json` resolves through GitHub's `/releases/latest/download/` URL which only points to stable releases. Pre-release channel discovery (previously approximated by reading 30 release entries via the GitHub API) is deferred to a future feature — pre-release users on v0.6.X-beta.Y will not receive in-app upgrade prompts for v0.6.X-beta.Z.
+
+---
+
 ## [0.6.3] — 2026-05-20
 
 First stable release of the 0.6.3 line. Promotes `0.6.3-beta.14` after coordinated Discord T1 session-continuity work and CRITICAL Setup Wizard fixes. Cumulative since v0.6.3-beta.13.

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -2824,6 +2824,20 @@
       "fixed_in": "0.6.4",
       "fix_note": "DATABASE_URL fallback (config.rs) and the storage directories created at boot (lib.rs L62 tracing, L384 attachments/avatars/vrm/speech) were hard-coded to `exe_dir()/data/`. NSIS places `cloto-system.exe` under `C:\\Program Files\\cloto-system\\` which is not user-writable for standard accounts, so `create_dir_all` returned `ERROR_ACCESS_DENIED` and the FATAL `?` at lib.rs:370 crashed the kernel on first boot. Introduced `config::data_dir()` helper that takes a dev/prod split via `is_dev_layout()`: dev (Cargo.toml detected by walking up from current exe) keeps `<exe_dir>/data` to preserve `target/debug/data/cloto_memories.db`; production routes through `dirs::data_dir().join(\"cloto-system\")` giving `%APPDATA%\\Roaming\\cloto-system\\` on Windows, `~/Library/Application Support/cloto-system/` on macOS, `~/.local/share/cloto-system/` on Linux. handlers/agents.rs speech reader updated to match. MCP server bundle layout (mcp_venv.rs / managers/mcp.rs `<exe_dir>/data/mcp-servers/`) is a separate workflow tracked as follow-up.",
       "github_issue": 130
+    },
+    {
+      "id": "bug-385",
+      "summary": "CRITICAL: 'Failed to apply update' — applyUpdate spawns non-existent sidecar 'cloto_system' via @tauri-apps/plugin-shell, bypassing the configured Tauri Updater plugin",
+      "severity": "CRITICAL",
+      "discovered": "2026-05-24T00:00:00Z",
+      "version": "0.6.4",
+      "commit": "a420e01",
+      "file": "dashboard/src/lib/tauri.ts",
+      "pattern": "Command\\.create\\('cloto_system'",
+      "expected": "absent",
+      "status": "fixed",
+      "fixed_in": "0.6.5",
+      "fix_note": "applyUpdate() shelled out to a sidecar binary `cloto_system` via @tauri-apps/plugin-shell, but the binary is never bundled into the NSIS / DMG / .deb installer — `bundle.externalBin` is unset in tauri.conf.json and the release.yml build-tauri jobs do not copy the standalone cloto_system bin into the app bundle. Every Update Now click failed at Command.create() with a 'program not found' style error, which the UI surfaced as the default 'Failed to apply update' message. Compounded by checkForUpdates() using GitHub API directly (rate-limited 60 req/h unauth) instead of the configured Tauri Updater endpoint. The Tauri Updater plugin itself was fully wired up (pubkey + endpoint=latest.json + createUpdaterArtifacts:'v1Compatible'), and CI generated a valid latest.json per release — the dashboard simply never invoked it. Switched applyUpdate() to @tauri-apps/plugin-updater check() + downloadAndInstall() and @tauri-apps/plugin-process relaunch(); unified checkForUpdates() to the same check() API to drop the GitHub API path; removed the now-dead shell:allow-execute cloto_system entry from capabilities/default.json. Affects all installer paths from 0.6.3 onward — existing 0.6.3 / 0.6.4 users must manually download 0.6.5 to recover the auto-update flow. Known limitation: latest.json resolves via GitHub `/releases/latest/download/` which only points to stable releases; pre-release channel discovery is deferred to a future feature."
     }
   ]
 }


### PR DESCRIPTION
## Summary

CRITICAL hotfix for all installer-based ClotoCore installs since v0.6.3. The in-app auto-update flow ("今すぐアップデート" / "Update Now") failed with "Failed to apply update" because `applyUpdate()` shelled out to a sidecar binary (`cloto_system`) that was never bundled into the NSIS / DMG / .deb installer.

- Switched `applyUpdate()` and `checkForUpdates()` to the proper `@tauri-apps/plugin-updater` API (`check()` + `downloadAndInstall()` + `@tauri-apps/plugin-process` `relaunch()`).
- Removed the now-dead `shell:allow-execute cloto_system` capability entry.
- Added bug-385 to `qa/issue-registry.json` (verifies as [FIXED]).
- Version bump 0.6.4 → 0.6.5 (3-file sync + lockfiles), CHANGELOG section added.

The Tauri Updater plugin itself was already fully configured (pubkey + endpoint pointing at `latest.json` + `createUpdaterArtifacts: "v1Compatible"`), and the release workflow generates a valid `latest.json` per release — the dashboard simply never invoked it. Infrastructure was complete; only the consumer was wrong.

Existing v0.6.3 / v0.6.4 users must download v0.6.5 manually one last time to recover the in-app auto-update flow.

## Root cause (`dashboard/src/lib/tauri.ts:295-302` before fix)

```ts
const cmd = Command.create('cloto_system', ['update', '--yes']);
const output = await cmd.execute();
```

- `dashboard/src-tauri/tauri.conf.json` has no `bundle.externalBin` declaration.
- `.github/workflows/release.yml`'s `build-tauri*` jobs never copy the standalone `cloto_system-{triple}` binary into the app bundle.
- Result: `Command.create()` fails with a program-not-found error on every installer-based install, which surfaces as the default "Failed to apply update" message in `AboutSection.tsx:45`.

## Known limitation

`latest.json` resolves through GitHub's `/releases/latest/download/` URL, which only points to stable releases. Pre-release channel discovery (previously approximated by reading 30 release entries via the GitHub API) is deferred to a future feature — pre-release users on v0.6.X-beta.Y will not receive in-app upgrade prompts for v0.6.X-beta.Z.

## Test plan

- [x] `npx biome lint src/` (dashboard, CI-equivalent) — clean
- [x] `npm run build` (dashboard) — `@tauri-apps/plugin-updater` / `plugin-process` imports resolve
- [x] `cargo fmt --all -- --check` — clean (no Rust changes)
- [x] `bash scripts/verify-issues.sh` — bug-385 marked [FIXED]
- [x] Pre-commit hook (`scripts/verify-issues.sh` integrated) passed before commit
- [ ] Windows Sandbox end-to-end: install 0.6.4 NSIS → check / apply 0.6.5 update flow (deferred to post-merge verification using `release.yml draft_only=true` if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)