### PR TITLE
0.6.6: decouple memory plugin Phase A+B

### DIFF
--- a/crates/core/benches/database_operations.rs
+++ b/crates/core/benches/database_operations.rs
@@ -26,7 +26,7 @@ fn json_serialization_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("set_json", size), &json_data, |b, data| {
             b.to_async(&runtime).iter(|| async {
                 let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-                cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+                cloto_core::db::init_db(&pool, "sqlite::memory:", None)
                     .await
                     .unwrap();
 
@@ -50,7 +50,7 @@ fn get_json_benchmark(c: &mut Criterion) {
     c.bench_function("db_get_json", |b| {
         b.to_async(&runtime).iter(|| async {
             let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-            cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+            cloto_core::db::init_db(&pool, "sqlite::memory:", None)
                 .await
                 .unwrap();
             let store = SqliteDataStore::new(pool);
@@ -73,7 +73,7 @@ fn get_all_json_benchmark(c: &mut Criterion) {
     c.bench_function("db_get_all_json", |b| {
         b.to_async(&runtime).iter(|| async {
             let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-            cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+            cloto_core::db::init_db(&pool, "sqlite::memory:", None)
                 .await
                 .unwrap();
             let store = SqliteDataStore::new(pool);

--- a/crates/core/benches/helpers/mod.rs
+++ b/crates/core/benches/helpers/mod.rs
@@ -17,7 +17,7 @@ use tokio::sync::{broadcast, mpsc, Notify, RwLock};
 #[allow(dead_code)]
 pub async fn create_bench_app_state() -> Arc<AppState> {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -142,9 +142,20 @@ pub struct AppConfig {
     pub attachment_inline_threshold: usize,
     /// Default max iterations for cron jobs.
     pub cron_default_max_iterations: u8,
-    /// Default memory plugin ID for DB config initialization.
-    /// Overridable via CLOTO_MEMORY_PLUGIN_ID env var.
-    pub memory_plugin_id: String,
+    /// Legacy memory plugin ID seed for `plugin_configs.database_url`.
+    ///
+    /// In the modern design, `agent.metadata.preferred_memory` is the single
+    /// source of truth for each agent's memory plugin selection (handled by
+    /// `handlers::system::recall` via `registry.find_memory()` capability
+    /// discovery + per-agent metadata override). This field only seeds the
+    /// legacy embedded-plugin `database_url` config row for backward
+    /// compatibility with pre-0.6.6 installations where the env default was
+    /// the only source of memory binding.
+    ///
+    /// Overridable via `CLOTO_MEMORY_PLUGIN_ID` env var. Empty / unset → `None`
+    /// (= kernel boots with no embedded-plugin seeding; agent metadata drives
+    /// memory selection exclusively).
+    pub memory_plugin_id: Option<String>,
     /// Default API host whitelist for SafeHttpClient.
     /// Overridable via CLOTO_ALLOWED_API_HOSTS env var (comma-separated).
     pub default_allowed_api_hosts: Vec<String>,
@@ -541,8 +552,13 @@ impl AppConfig {
             );
         }
 
-        let memory_plugin_id =
-            env::var("CLOTO_MEMORY_PLUGIN_ID").unwrap_or_else(|_| "memory.cpersona".to_string());
+        // Decoupled from kernel knowledge: modern installs populate
+        // agent.metadata.preferred_memory via Setup Wizard / marketplace
+        // install path. Env override remains for users running the kernel
+        // without the dashboard (CLI-only / service-mode).
+        let memory_plugin_id = env::var("CLOTO_MEMORY_PLUGIN_ID")
+            .ok()
+            .filter(|s| !s.is_empty());
 
         // P1: Configurable API host whitelist (default providers included for compatibility)
         let default_allowed_api_hosts = env::var("CLOTO_ALLOWED_API_HOSTS").map_or_else(

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -281,7 +281,7 @@ impl PluginDataStore for ScopedDataStore {
 pub async fn init_db(
     pool: &SqlitePool,
     database_url: &str,
-    memory_plugin_id: &str,
+    memory_plugin_id: Option<&str>,
 ) -> anyhow::Result<()> {
     info!("Running database migrations & seeds...");
 
@@ -304,11 +304,18 @@ pub async fn init_db(
 
     info!("Applying runtime configurations...");
 
-    // Configs that depend on runtime environment
-    sqlx::query("INSERT OR REPLACE INTO plugin_configs (plugin_id, config_key, config_value) VALUES (?, 'database_url', ?)")
-        .bind(memory_plugin_id)
-        .bind(database_url)
-        .execute(pool).await?;
+    // Legacy embedded-plugin seeding: when CLOTO_MEMORY_PLUGIN_ID is set,
+    // mirror the database_url into plugin_configs so a process that boots
+    // without dashboard-driven setup can still resolve the memory plugin's
+    // backing store. With the kernel decoupled in 0.6.6, the modern path
+    // (Setup Wizard / marketplace install) writes agent.metadata.preferred_memory
+    // instead and skips this seed entirely.
+    if let Some(plugin_id) = memory_plugin_id {
+        sqlx::query("INSERT OR REPLACE INTO plugin_configs (plugin_id, config_key, config_value) VALUES (?, 'database_url', ?)")
+            .bind(plugin_id)
+            .bind(database_url)
+            .execute(pool).await?;
+    }
 
     // API keys are NOT persisted to the database for security.
     // Plugins receive API keys at runtime via environment variables
@@ -325,9 +332,7 @@ mod tests {
     #[tokio::test]
     async fn test_audit_log_roundtrip() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-        init_db(&pool, "sqlite::memory:", "memory.cpersona")
-            .await
-            .unwrap();
+        init_db(&pool, "sqlite::memory:", None).await.unwrap();
 
         let entry = AuditLogEntry {
             timestamp: Utc::now(),
@@ -354,9 +359,7 @@ mod tests {
     #[tokio::test]
     async fn test_audit_log_ordering() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-        init_db(&pool, "sqlite::memory:", "memory.cpersona")
-            .await
-            .unwrap();
+        init_db(&pool, "sqlite::memory:", None).await.unwrap();
 
         // Insert multiple entries
         for i in 1..=5 {
@@ -386,9 +389,7 @@ mod tests {
     #[tokio::test]
     async fn test_permission_request_lifecycle() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-        init_db(&pool, "sqlite::memory:", "memory.cpersona")
-            .await
-            .unwrap();
+        init_db(&pool, "sqlite::memory:", None).await.unwrap();
 
         // Create a permission request
         let request = PermissionRequest {
@@ -426,9 +427,7 @@ mod tests {
     #[tokio::test]
     async fn test_multiple_permission_requests() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-        init_db(&pool, "sqlite::memory:", "memory.cpersona")
-            .await
-            .unwrap();
+        init_db(&pool, "sqlite::memory:", None).await.unwrap();
 
         // Create multiple requests
         for i in 1..=3 {

--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -1158,6 +1158,19 @@ async fn register_server(
         warn!("Failed to set marketplace fields: {e}");
     }
 
+    // Modern decouple path (0.6.6+): when a memory-kind plugin is installed
+    // and the default agent has not yet picked one, mirror this install id
+    // into `agent.cloto_default.metadata.preferred_memory`. This replaces
+    // the pre-0.6.6 path where the kernel hardcoded a memory plugin id via
+    // CLOTO_MEMORY_PLUGIN_ID env default and seeded plugin_configs at boot.
+    // Idempotent — touches nothing if the user already chose a memory
+    // plugin manually via the dashboard.
+    if entry.category == "memory" {
+        if let Err(e) = bind_default_memory_if_unset(&state.pool, &entry.id).await {
+            warn!("Failed to bind default agent's preferred_memory: {e}");
+        }
+    }
+
     // If user requested no auto-start, stop the server after registration
     if !auto_start {
         let _ = state.mcp_manager.stop_server(&entry.id).await;
@@ -1171,6 +1184,33 @@ async fn register_server(
     );
 
     info!("Marketplace install complete: {}", entry.id);
+    Ok(())
+}
+
+/// Set `agent.cloto_default.metadata.preferred_memory` to the given plugin
+/// id iff currently absent or empty. Idempotent — touches nothing if the
+/// user has already chosen a memory plugin manually.
+///
+/// Used by `register_server` to auto-bind a memory plugin install when no
+/// kernel-side hardcode is doing it (post-0.6.6 decouple). Mirrors the
+/// shape of the Phase C migration that back-fills the same key for
+/// pre-0.6.6 users (`migrations/<…>_backfill_default_memory.sql`).
+async fn bind_default_memory_if_unset(
+    pool: &sqlx::SqlitePool,
+    plugin_id: &str,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "UPDATE agents \
+         SET metadata = json_set(COALESCE(metadata, '{}'), '$.preferred_memory', ?) \
+         WHERE id = 'agent.cloto_default' \
+           AND ( \
+             json_extract(metadata, '$.preferred_memory') IS NULL \
+             OR json_extract(metadata, '$.preferred_memory') = '' \
+           )",
+    )
+    .bind(plugin_id)
+    .execute(pool)
+    .await?;
     Ok(())
 }
 

--- a/crates/core/src/handlers/setup.rs
+++ b/crates/core/src/handlers/setup.rs
@@ -538,7 +538,7 @@ mod tests {
         // Sanity: empty pool reports no agents.
         assert!(!db_has_agents(&pool).await);
         // After init_db, the cloto_default seed row exists.
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
         assert!(db_has_agents(&pool).await);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -438,7 +438,12 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
         .pragma("foreign_keys", "ON")
         .pragma("synchronous", "NORMAL");
     let pool = sqlx::SqlitePool::connect_with(opts).await?;
-    db::init_db(&pool, &config.database_url, &config.memory_plugin_id).await?;
+    db::init_db(
+        &pool,
+        &config.database_url,
+        config.memory_plugin_id.as_deref(),
+    )
+    .await?;
 
     // 1b. Sync API keys from environment variables into llm_providers table
     db::sync_env_api_keys(&pool, &config.llm_provider_env_mappings).await;

--- a/crates/core/src/managers/mcp.rs
+++ b/crates/core/src/managers/mcp.rs
@@ -3081,7 +3081,7 @@ mod tests {
     #[tokio::test]
     async fn yolo_mode_initializes_correctly() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
 
@@ -3095,7 +3095,7 @@ mod tests {
     #[tokio::test]
     async fn yolo_mode_toggle_at_runtime() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
 
@@ -3112,7 +3112,7 @@ mod tests {
     #[tokio::test]
     async fn yolo_mode_affects_kernel_tool_schemas() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
 
@@ -3136,7 +3136,7 @@ mod tests {
     #[tokio::test]
     async fn kernel_tools_include_access_control() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
 
@@ -3163,7 +3163,7 @@ mod tests {
     #[tokio::test]
     async fn kernel_tools_include_audit_replay() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
 
@@ -3182,7 +3182,7 @@ mod tests {
     #[tokio::test]
     async fn kernel_tools_include_tier3_lifecycle() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
 
@@ -3209,7 +3209,7 @@ mod tests {
     #[tokio::test]
     async fn kernel_tools_include_tier3_streaming() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
 
@@ -3228,7 +3228,7 @@ mod tests {
     #[tokio::test]
     async fn kernel_tools_include_tier3_events() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
 
@@ -3259,7 +3259,7 @@ mod tests {
     #[tokio::test]
     async fn kernel_tools_total_count() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
 
@@ -3304,7 +3304,7 @@ mod tests {
     #[tokio::test]
     async fn yolo_mode_persisted_to_db() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
 

--- a/crates/core/src/managers/mcp_discovery.rs
+++ b/crates/core/src/managers/mcp_discovery.rs
@@ -409,7 +409,7 @@ mod tests {
     #[tokio::test]
     async fn execute_discovery_register_rejects_when_yolo_off() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
         let mgr = McpClientManager::new(pool, false, 120, 30);

--- a/crates/core/src/managers/mcp_kernel_tool.rs
+++ b/crates/core/src/managers/mcp_kernel_tool.rs
@@ -1972,7 +1972,7 @@ mod phase_b_rejection_tests {
 
     async fn yolo_off_manager() -> McpClientManager {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
         McpClientManager::new(pool, false, 120, 30)
@@ -2065,7 +2065,7 @@ mod phase_b_rejection_tests {
     async fn execute_mgp_agent_ask_rejects_self_delegation() {
         // YOLO on so we bypass the first gate; still rejected for self-target.
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
         let mgr = McpClientManager::new(pool, true, 120, 30);
@@ -2087,7 +2087,7 @@ mod phase_b_rejection_tests {
     #[tokio::test]
     async fn execute_mgp_agent_ask_rejects_depth_exceeded() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
         let mgr = McpClientManager::new(pool, true, 120, 30);
@@ -2115,7 +2115,7 @@ mod phase_b_rejection_tests {
     #[tokio::test]
     async fn execute_mgp_agent_ask_rejects_cycle() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+        crate::db::init_db(&pool, "sqlite::memory:", None)
             .await
             .unwrap();
         let mgr = McpClientManager::new(pool, true, 120, 30);

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -8,7 +8,7 @@ use tokio::sync::{broadcast, mpsc, Notify, RwLock};
 
 pub async fn create_test_app_state(admin_api_key: Option<String>) -> Arc<crate::AppState> {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    crate::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    crate::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 

--- a/crates/core/tests/event_cascading_test.rs
+++ b/crates/core/tests/event_cascading_test.rs
@@ -70,7 +70,7 @@ impl Plugin for PingPlugin {
 #[tokio::test]
 async fn test_event_cascading_protection() {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 

--- a/crates/core/tests/event_memory_management_test.rs
+++ b/crates/core/tests/event_memory_management_test.rs
@@ -12,7 +12,7 @@ async fn create_test_processor(
     max_history_size: usize,
 ) -> (Arc<EventProcessor>, Arc<RwLock<VecDeque<SequencedEvent>>>) {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 

--- a/crates/core/tests/migration_test.rs
+++ b/crates/core/tests/migration_test.rs
@@ -12,10 +12,10 @@ async fn test_db_init_is_idempotent() {
     let pool = fresh_pool().await;
 
     // Running init_db twice should not fail (idempotent migrations)
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 }
@@ -23,7 +23,7 @@ async fn test_db_init_is_idempotent() {
 #[tokio::test]
 async fn test_migration_creates_required_tables() {
     let pool = fresh_pool().await;
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 
@@ -58,7 +58,7 @@ async fn test_plugin_data_store_basic_roundtrip() {
     use std::sync::Arc;
 
     let pool = fresh_pool().await;
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 
@@ -79,7 +79,7 @@ async fn test_plugin_data_store_missing_key_returns_none() {
     use std::sync::Arc;
 
     let pool = fresh_pool().await;
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 
@@ -110,7 +110,7 @@ fn make_record(name: &str, trust_level: Option<&str>) -> cloto_core::db::McpServ
 #[tokio::test]
 async fn test_trust_level_column_is_nullable_and_defaults_null() {
     let pool = fresh_pool().await;
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 
@@ -133,7 +133,7 @@ async fn test_trust_level_column_is_nullable_and_defaults_null() {
 #[tokio::test]
 async fn test_trust_level_roundtrips_through_save_and_load() {
     let pool = fresh_pool().await;
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 
@@ -156,7 +156,7 @@ async fn test_trust_level_roundtrips_through_save_and_load() {
 #[tokio::test]
 async fn test_trust_level_upsert_preserves_prior_value_on_partial_write() {
     let pool = fresh_pool().await;
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 
@@ -186,7 +186,7 @@ async fn test_trust_level_upsert_preserves_prior_value_on_partial_write() {
 #[tokio::test]
 async fn test_set_marketplace_fields_persists_trust_level() {
     let pool = fresh_pool().await;
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 
@@ -226,7 +226,7 @@ async fn test_set_marketplace_fields_persists_trust_level() {
 #[tokio::test]
 async fn test_manual_register_leaves_marketplace_id_null() {
     let pool = fresh_pool().await;
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 

--- a/crates/core/tests/permission_elevation_test.rs
+++ b/crates/core/tests/permission_elevation_test.rs
@@ -75,7 +75,7 @@ impl Plugin for MockPlugin {
 async fn test_dynamic_permission_elevation_flow() {
     // 1. Setup Kernel Components
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
     let registry_raw = PluginRegistry::new(5, 10, 50);

--- a/crates/core/tests/permission_workflow_test.rs
+++ b/crates/core/tests/permission_workflow_test.rs
@@ -112,7 +112,7 @@ async fn test_db_permission_grant_roundtrip() {
     use sqlx::SqlitePool;
 
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 

--- a/crates/core/tests/security_forging_test.rs
+++ b/crates/core/tests/security_forging_test.rs
@@ -109,7 +109,7 @@ impl Plugin for MaliciousPlugin {
 async fn test_vulnerability_event_forging() {
     // 1. Setup DB & Managers
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 

--- a/crates/core/tests/system_loop_test.rs
+++ b/crates/core/tests/system_loop_test.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 #[tokio::test]
 async fn test_system_handler_loop_prevention() {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 
@@ -75,7 +75,7 @@ async fn build_cron_test_handler(
     mpsc::Receiver<cloto_core::EnvelopedEvent>,
 ) {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 

--- a/crates/core/tests/tool_rejection_smoke.rs
+++ b/crates/core/tests/tool_rejection_smoke.rs
@@ -26,7 +26,7 @@ fn simulate_agentic_loop_outcome(tool_result: Result<Value, ToolFailure>) -> (bo
 
 async fn setup_manager(yolo: bool) -> McpClientManager {
     let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-    cloto_core::db::init_db(&pool, "sqlite::memory:", "memory.cpersona")
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
     McpClientManager::new(pool, yolo, 120, 30)


### PR DESCRIPTION
## Summary

Architectural refactor — kernel no longer hardcodes a specific memory plugin id. Aligns with MGP §10 invariant 3 (open standard, no privileged plugin) and lets ClotoCore treat any memory-kind plugin from the ClotoHub catalog as a first-class peer.

**This is PR B of 3** for the 0.6.6 release bundle:
- PR A (rename, [#136](https://github.com/Cloto-dev/ClotoCore/pull/136)): ✅ already landed
- **PR B** (this one): production decouple Phase A + test fixture refactor Phase B
- PR C (migration, coming next): data migration Phase C + D — back-fills `agent.metadata.preferred_memory='cpersona'` for existing users and renames legacy `memory.cpersona` → `cpersona` across mcp_servers / mcp_access_control / plugin_configs

## Phase A: production decouple (~80 LOC)

- `config.rs`: `memory_plugin_id: String` → `Option<String>`. Env handling treats empty/unset as `None`. Updated doc to clarify this is the legacy seed for `plugin_configs.database_url`; `agent.metadata.preferred_memory` is the modern single source of truth.
- `db/mod.rs::init_db`: signature `&str` → `Option<&str>`. The `INSERT OR REPLACE INTO plugin_configs` row is gated on `Some(_)` — modern installs skip this legacy seed entirely.
- `lib.rs`: caller uses `as_deref()` to thread `Option`.
- `handlers/marketplace.rs::register_server`: when an installed plugin's `registry.category == "memory"`, mirror its id into `agent.cloto_default.metadata.preferred_memory` via a new `bind_default_memory_if_unset` helper. Idempotent — only writes when the field is null/empty, so user-chosen memory plugins are never overwritten.

## Backward compatibility

- Existing users with `CLOTO_MEMORY_PLUGIN_ID=memory.cpersona` set keep their pre-0.6.6 behavior (env value flows through as `Some(...)`, plugin_configs row written exactly as before).
- Existing dev DBs work unchanged — `handlers/system.rs:400` already did `preferred_memory` lookup with `find_memory()` capability fallback since well before this PR, so memory binding survives the decouple without any data migration.
- `init_db(..., None)` is also a new valid state — the kernel boots successfully with no memory plugin pre-seeded, then the modern Setup Wizard / marketplace install path populates `preferred_memory` on the first memory-kind install.

## Phase B: test fixture refactor (~40 LOC mechanical)

All 41 `init_db(..., \"memory.cpersona\")` call sites in tests / benches / unit tests / manager test contexts switched to `init_db(..., None)`. None of these tests assert on the memory plugin path specifically; they init the schema for unrelated test concerns (audit log, permission workflow, migrations, event cascading, etc).

`handlers_http_test.rs` literals (`seed_mcp_server(\"memory.cpersona\")` + `granted_server_ids: [..., \"memory.cpersona\"]`) are intentionally left for PR C — those touch the same id name from a different angle (test fixture vs runtime data migration) and changing them in lock-step keeps the bisect-by-PR story clean.

## Test plan

- [x] `cargo check --workspace --exclude app` clean
- [x] `cargo test --workspace --exclude app` — 322 tests pass / 0 failed / 0 ignored (test count unchanged from master)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude app -- -D warnings -A clippy::too-many-lines -A clippy::struct-excessive-bools -A clippy::match-same-arms -A clippy::cast-possible-wrap -A clippy::trivially-copy-pass-by-ref -A clippy::manual-let-else -A clippy::option-if-let-else -A clippy::case-sensitive-file-extension-comparisons -A clippy::unwrap-used -A clippy::type-complexity` clean (CI equivalent, no \`--all-targets\` per .github/workflows/ci.yml lint job)
- [ ] PR C will rebase on this branch after merge

## Fixed-points carried (irreversible from this PR)

- `config.memory_plugin_id: Option<String>` (String revert breaks all downstream test fixtures)
- `agent.metadata.preferred_memory` is the authoritative single source of truth for per-agent memory plugin selection
- `init_db` signature `Option<&str>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)