### PR TITLE
0.6.6: memory plugin decouple Phase C+D — data migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ All plugin functionality is delivered via **MCP (Model Context Protocol)** serve
 | `mind.cerebras` | Reasoning | Ultra-high-speed reasoning via Cerebras API |
 | `mind.claude` | Reasoning | Anthropic Claude API (native Messages API) |
 | `mind.ollama` | Reasoning | Local model inference via Ollama |
-| `memory.cpersona` | Memory | [CPersona](https://github.com/Cloto-dev/cloto-mcp-servers/tree/main/servers/cpersona) — persistent memory with RRF hybrid search (vector + FTS5 + keyword), confidence scoring, episodic/profile memory, 16 tools (MIT) |
+| `cpersona` | Memory | [CPersona](https://github.com/Cloto-dev/cloto-mcp-servers/tree/main/servers/cpersona) — persistent memory with RRF hybrid search (vector + FTS5 + keyword), confidence scoring, episodic/profile memory, 16 tools (MIT) |
 | `tool.terminal` | Tool | Sandboxed shell command execution |
 | `tool.agent_utils` | Tool | Deterministic utilities (time, math, UUID, hash, etc.) |
 | `tool.cron` | Tool | Stateless CRON job management via kernel REST API |

--- a/crates/core/migrations/20260524000000_backfill_default_memory.sql
+++ b/crates/core/migrations/20260524000000_backfill_default_memory.sql
@@ -1,0 +1,39 @@
+-- 0.6.6 memory plugin decouple Phase C: back-fill agent.metadata.preferred_memory
+--
+-- Pre-0.6.6 the kernel hardcoded `memory.cpersona` as the default memory plugin
+-- via CLOTO_MEMORY_PLUGIN_ID env (config.rs default) + seeded plugin_configs at
+-- boot (db/mod.rs::init_db). Existing users therefore have a working memory
+-- binding even though `agent.cloto_default.metadata.preferred_memory` was never
+-- written.
+--
+-- After 0.6.6 (PR B = #137), the kernel reads `preferred_memory` as the single
+-- source of truth and the new Setup Wizard / marketplace install path writes
+-- it automatically (handlers/marketplace.rs::bind_default_memory_if_unset).
+-- This migration makes existing users converge: when the default agent has no
+-- preferred_memory yet AND a memory plugin is installed (legacy `memory.cpersona`
+-- or new `cpersona`), write the canonical id `cpersona` directly.
+--
+-- C+D are bundled in a single PR so this migration can write the post-rename id
+-- `cpersona` unconditionally — Phase D (next migration) handles the runtime row
+-- rename so the value stays valid.
+--
+-- Idempotent:
+--   - Touches nothing if preferred_memory already has a value (manual choice
+--     via dashboard, or earlier migration run, etc).
+--   - Touches nothing if no memory plugin is installed yet (fresh kernel before
+--     first Setup Wizard run).
+
+UPDATE agents
+SET metadata = json_set(
+    COALESCE(metadata, '{}'),
+    '$.preferred_memory',
+    'cpersona'
+)
+WHERE id = 'agent.cloto_default'
+  AND (
+    json_extract(metadata, '$.preferred_memory') IS NULL
+    OR json_extract(metadata, '$.preferred_memory') = ''
+  )
+  AND EXISTS (
+    SELECT 1 FROM mcp_servers WHERE name IN ('memory.cpersona', 'cpersona')
+  );

--- a/crates/core/migrations/20260524010000_rename_memory_cpersona_to_cpersona.sql
+++ b/crates/core/migrations/20260524010000_rename_memory_cpersona_to_cpersona.sql
@@ -1,0 +1,47 @@
+-- 0.6.6 memory plugin decouple Phase D: rename legacy `memory.cpersona` → `cpersona`
+--
+-- After the 0.6.6 decouple (PR B = #137), the kernel no longer cares about the
+-- plugin id — it discovers memory plugins by capability. The id `cpersona`
+-- (without the `memory.` prefix) is the canonical ClotoHub catalog convention;
+-- new installs come down as `cpersona` from the marketplace. This migration
+-- normalises pre-0.6.6 user data so all rows (legacy + new) use the same id.
+--
+-- Precedent: `20260309000000_rename_ks22_to_cpersona.sql` performed an identical
+-- shape of rename (mcp_servers → mcp_access_control DELETE + re-INSERT around
+-- the rename, because `mcp_access_control.server_id` FK → `mcp_servers(name)`
+-- blocks both orderings of a direct UPDATE).
+--
+-- Idempotent: WHERE clauses target only the legacy `memory.cpersona` rows; if
+-- the migration has already run (or this user installed straight from the
+-- post-0.6.6 catalog) every UPDATE/INSERT is a zero-row no-op.
+--
+-- agents.metadata.preferred_memory: NOT touched here. Phase C wrote `cpersona`
+-- directly; if any pre-existing manual setting points at `memory.cpersona`,
+-- the cosmetic cleanup is handled by the second UPDATE below.
+
+-- 1. Drop the FK reference rows so we can rename the parent.
+DELETE FROM mcp_access_control WHERE server_id = 'memory.cpersona';
+
+-- 2. Rename the server itself.
+UPDATE mcp_servers SET name = 'cpersona' WHERE name = 'memory.cpersona';
+
+-- 3. Re-grant default access under the new id (mirrors the KS22 precedent —
+--    preserves the default agent's ability to invoke the memory plugin).
+INSERT OR IGNORE INTO mcp_access_control (entry_type, agent_id, server_id, permission, granted_by, granted_at)
+SELECT 'server_grant', 'agent.cloto_default', 'cpersona', 'allow', 'migration', datetime('now')
+WHERE EXISTS (SELECT 1 FROM mcp_servers WHERE name = 'cpersona');
+
+-- 4. plugin_configs has no FK; direct UPDATE is safe.
+UPDATE plugin_configs SET plugin_id = 'cpersona' WHERE plugin_id = 'memory.cpersona';
+
+-- 5. Cosmetic cleanup: any agent metadata that explicitly carried the legacy id
+--    (e.g. user who manually pinned `memory.cpersona` via dashboard pre-0.6.6)
+--    is normalised to `cpersona`. Phase C already wrote `cpersona` for empty
+--    fields, so this only catches the explicit-legacy-value case.
+UPDATE agents
+SET metadata = json_set(
+    COALESCE(metadata, '{}'),
+    '$.preferred_memory',
+    'cpersona'
+)
+WHERE json_extract(metadata, '$.preferred_memory') = 'memory.cpersona';

--- a/crates/core/tests/handlers_http_test.rs
+++ b/crates/core/tests/handlers_http_test.rs
@@ -266,7 +266,7 @@ async fn seed_mcp_server(pool: &sqlx::SqlitePool, name: &str) {
 async fn test_put_agent_mcp_access_replaces_grants() {
     let state = create_test_app_state(Some("test-key".to_string())).await;
     seed_mcp_server(&state.pool, "terminal").await;
-    seed_mcp_server(&state.pool, "memory.cpersona").await;
+    seed_mcp_server(&state.pool, "cpersona").await;
     seed_mcp_server(&state.pool, "mind.deepseek").await;
 
     // Pre-existing grant that should be removed by the replacement.
@@ -283,7 +283,7 @@ async fn test_put_agent_mcp_access_replaces_grants() {
     let app = create_test_router(state.clone());
 
     let payload = json!({
-        "granted_server_ids": ["terminal", "memory.cpersona"]
+        "granted_server_ids": ["terminal", "cpersona"]
     });
 
     let response = app
@@ -314,7 +314,7 @@ async fn test_put_agent_mcp_access_replaces_grants() {
     .expect("query grants");
 
     let server_ids: Vec<String> = rows.into_iter().map(|(s,)| s).collect();
-    assert_eq!(server_ids, vec!["memory.cpersona", "terminal"]);
+    assert_eq!(server_ids, vec!["cpersona", "terminal"]);
 }
 
 #[tokio::test]
@@ -389,7 +389,7 @@ async fn test_put_agent_mcp_access_auto_creates_missing_server_row() {
     let app = create_test_router(state.clone());
 
     let payload = json!({
-        "granted_server_ids": ["terminal", "memory.cpersona"]
+        "granted_server_ids": ["terminal", "cpersona"]
     });
 
     let response = app
@@ -413,7 +413,7 @@ async fn test_put_agent_mcp_access_auto_creates_missing_server_row() {
     // config-loaded placeholders.
     let server_rows: Vec<(String, String)> = sqlx::query_as(
         "SELECT name, command FROM mcp_servers \
-         WHERE name IN ('terminal', 'memory.cpersona') ORDER BY name",
+         WHERE name IN ('terminal', 'cpersona') ORDER BY name",
     )
     .fetch_all(&state.pool)
     .await

--- a/crates/core/tests/migration_test.rs
+++ b/crates/core/tests/migration_test.rs
@@ -244,3 +244,120 @@ async fn test_manual_register_leaves_marketplace_id_null() {
         "manual register must leave marketplace_id NULL"
     );
 }
+
+/// 0.6.6 Phase C+D smoke: assert the in-tree migrations rewrote the
+/// `memory.cpersona` seed (from `20260309100000_heal_default_agent.sql`) to
+/// the catalog-canonical `cpersona`, back-filled
+/// `agent.cloto_default.preferred_memory`, and renamed the FK-bound
+/// `mcp_access_control` row to match. The heal-migration seed gives us a
+/// realistic pre-0.6.6 starting state without any manual setup.
+#[tokio::test]
+async fn test_phase_cd_migrations_rewrite_legacy_memory_cpersona() {
+    let pool = fresh_pool().await;
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
+        .await
+        .unwrap();
+
+    // Phase D: legacy `memory.cpersona` row in mcp_servers (seeded by
+    // 20260309100000_heal_default_agent.sql) should have been renamed.
+    let legacy_server_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM mcp_servers WHERE name = 'memory.cpersona'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        legacy_server_count, 0,
+        "Phase D should rename 'memory.cpersona' out of mcp_servers"
+    );
+
+    let new_server_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM mcp_servers WHERE name = 'cpersona'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        new_server_count, 1,
+        "Phase D should leave exactly one 'cpersona' row in mcp_servers"
+    );
+
+    // Phase C: agent.cloto_default.preferred_memory back-filled to 'cpersona'.
+    let preferred: Option<String> = sqlx::query_scalar(
+        "SELECT json_extract(metadata, '$.preferred_memory') \
+         FROM agents WHERE id = 'agent.cloto_default'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        preferred.as_deref(),
+        Some("cpersona"),
+        "Phase C should back-fill preferred_memory='cpersona'"
+    );
+
+    // Phase D step 3: the migration-issued server_grant for the default agent
+    // points at the new id.
+    let new_grant_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mcp_access_control \
+         WHERE server_id = 'cpersona' AND agent_id = 'agent.cloto_default' \
+           AND entry_type = 'server_grant'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        new_grant_count >= 1,
+        "Phase D should leave a 'cpersona' server_grant for the default agent"
+    );
+
+    // Phase D leaves no legacy access_control rows.
+    let legacy_grant_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mcp_access_control WHERE server_id = 'memory.cpersona'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        legacy_grant_count, 0,
+        "Phase D should DELETE legacy access_control rows"
+    );
+}
+
+/// 0.6.6 Phase C+D idempotency: replaying Phase C against an init_db'd schema
+/// is a no-op — the EXISTS gate and the empty-or-null `preferred_memory`
+/// guard both fail, so a user who already picked a memory plugin manually
+/// keeps their choice.
+#[tokio::test]
+async fn test_phase_c_migration_preserves_manual_choice() {
+    let pool = fresh_pool().await;
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
+        .await
+        .unwrap();
+
+    // Overwrite the back-filled preferred_memory with a manual choice
+    // (simulating a user who picked a custom memory plugin via dashboard).
+    sqlx::query(
+        "UPDATE agents \
+         SET metadata = json_set(COALESCE(metadata, '{}'), '$.preferred_memory', 'custom.memory') \
+         WHERE id = 'agent.cloto_default'",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Re-execute Phase C SQL: the guard should preserve the manual choice.
+    let phase_c = include_str!("../migrations/20260524000000_backfill_default_memory.sql");
+    sqlx::raw_sql(phase_c).execute(&pool).await.unwrap();
+
+    let preferred: Option<String> = sqlx::query_scalar(
+        "SELECT json_extract(metadata, '$.preferred_memory') \
+         FROM agents WHERE id = 'agent.cloto_default'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        preferred.as_deref(),
+        Some("custom.memory"),
+        "Phase C must not overwrite a non-empty manual preferred_memory"
+    );
+}

--- a/dashboard/src-tauri/resources/ja.json
+++ b/dashboard/src-tauri/resources/ja.json
@@ -536,7 +536,7 @@
     "engine_claude": "Claude",
     "engine_local": "ローカル LLM (推奨)",
     "engine_ollama": "Ollama（代替）",
-    "server_memory_cpersona": "CPersona メモリ",
+    "server_cpersona": "CPersona メモリ",
     "server_tool_terminal": "ターミナル",
     "server_tool_cron": "Cron スケジューラ",
     "server_tool_websearch": "Web 検索",

--- a/dashboard/src/components/SetupWizard.tsx
+++ b/dashboard/src/components/SetupWizard.tsx
@@ -40,7 +40,7 @@ import { SERVER_PRESETS, STANDARD_SERVERS } from '../lib/presets';
 const ENGINE_IDS = ['mind.cerebras', 'mind.groq', 'mind.deepseek', 'mind.claude', 'mind.local', 'mind.ollama'] as const;
 
 const ALL_SELECTABLE_SERVER_IDS = [
-  'memory.cpersona',
+  'cpersona',
   'tool.terminal',
   'tool.cron',
   'tool.websearch',
@@ -54,7 +54,7 @@ const ALL_SELECTABLE_SERVER_IDS = [
   'voice.tts',
 ] as const;
 
-/** Map server ID → translation key (e.g., "memory.cpersona" → "server_memory_cpersona") */
+/** Map server ID → translation key (e.g., "tool.terminal" → "server_tool_terminal", "cpersona" → "server_cpersona") */
 function serverTKey(id: string): string {
   return `server_${id.replace('.', '_')}`;
 }

--- a/dashboard/src/lib/presets.ts
+++ b/dashboard/src/lib/presets.ts
@@ -2,10 +2,10 @@
 
 import { Box, Layers, type LucideIcon, Shield, Zap } from 'lucide-react';
 
-export const MINIMAL_SERVERS = ['memory.cpersona', 'tool.agent_utils'];
+export const MINIMAL_SERVERS = ['cpersona', 'tool.agent_utils'];
 
 export const STANDARD_SERVERS = [
-  'memory.cpersona',
+  'cpersona',
   'tool.cron',
   'tool.terminal',
   'tool.websearch',

--- a/dashboard/src/locales/en/wizard.json
+++ b/dashboard/src/locales/en/wizard.json
@@ -32,7 +32,7 @@
   "engine_claude": "Claude",
   "engine_local": "Local LLM (Recommended)",
   "engine_ollama": "Ollama (Alternative)",
-  "server_memory_cpersona": "CPersona Memory",
+  "server_cpersona": "CPersona Memory",
   "server_tool_terminal": "Terminal",
   "server_tool_cron": "Cron Scheduler",
   "server_tool_websearch": "Web Search",


### PR DESCRIPTION
## Summary

Final slice of the 0.6.6 kernel decouple bundle. Migrates existing users from the legacy `memory.cpersona` id (kernel hardcode pre-0.6.6) to the catalog-canonical `cpersona` id, and writes the back-fill that lets the modern `agent.metadata.preferred_memory` lookup path (handlers/system.rs:400) resolve the memory plugin for existing installs.

**PR C of 3** for the 0.6.6 release bundle:
- PR A ([#136](https://github.com/Cloto-dev/ClotoCore/pull/136)) ✅ rename cloto-system → ClotoCore
- PR B ([#137](https://github.com/Cloto-dev/ClotoCore/pull/137)) ✅ production decouple Phase A+B
- **PR C** (this one): data migrations Phase C+D + cascading dashboard / test / doc updates

## New migrations (2 SQLx files, CRLF-enforced)

1. `20260524000000_backfill_default_memory.sql` (Phase C):
   - `UPDATE agents SET metadata = json_set(..., '$.preferred_memory', 'cpersona') WHERE id='agent.cloto_default' AND preferred_memory IS NULL/empty AND EXISTS (mcp_servers WHERE name IN ('memory.cpersona', 'cpersona'))`
   - Idempotent: no-op when user already chose a memory plugin manually
   - Writes `'cpersona'` directly (post-rename id), since C+D land in the same PR so the literal stays valid through Phase D's runtime rename

2. `20260524010000_rename_memory_cpersona_to_cpersona.sql` (Phase D):
   - Renames `mcp_servers.name` `memory.cpersona` → `cpersona`
   - Re-issues `mcp_access_control` server_grant under the new id (DELETE + INSERT around the parent rename — mirrors KS22 precedent at `20260309000000_rename_ks22_to_cpersona.sql`, FK requires this shape)
   - Renames `plugin_configs.plugin_id`
   - Cosmetic: rewrites any `agent.metadata.preferred_memory` that explicitly carried the legacy id (rare path: user manually pinned `'memory.cpersona'` via dashboard pre-0.6.6)

## Test fixture + dashboard cascade

Updated to match the new catalog convention so post-migration runtime references match the catalog/installed id:

- `handlers_http_test.rs` 5 literals: `seed_mcp_server` / `granted_server_ids` / SQL queries all flip `\"memory.cpersona\"` → `\"cpersona\"`. The `server_ids` alphabetic `ORDER BY` still holds (`cpersona` < `terminal`).
- `dashboard/src/lib/presets.ts` `MINIMAL_SERVERS` / `STANDARD_SERVERS` / `ADVANCED_SERVERS` / `EXPERT_SERVERS` lists: catalog id update so Setup Wizard installs the right plugin
- `dashboard/src/components/SetupWizard.tsx` `ALL_SELECTABLE_SERVER_IDS` list + `serverTKey` comment
- `dashboard/src/locales/en/wizard.json` + `dashboard/src-tauri/resources/ja.json` i18n key rename `server_memory_cpersona` → `server_cpersona` (matches the new id under `serverTKey('cpersona')` = `server_cpersona`)
- `README.md` MCP server table: `memory.cpersona` row → `cpersona`

## Intentionally preserved (not touched in this PR)

- Migration SQL files that historically reference `memory.cpersona` (sqlx checksums; modifying them breaks the next boot)
- `marketplace.rs:2915-2929` unit tests for `effective_install_dir` legacy-id behavior (the literal IS the test subject)
- `handlers/mcp.rs:360, 1032` server-name validation comment + backward-compat dotted-id test (validates that `xxx.yyy` ids remain acceptable for non-catalog / custom servers)
- `capability_dispatcher.rs` unit tests (fixture id is arbitrary; switching it adds no signal)
- `dashboard/src/lib/__tests__/format.test.ts` `displayServerId` test (asserts the namespace-stripping formatter still handles the legacy shape — backward compat documentation)
- `docs/CPERSONA_MEMORY_DESIGN.md` + `MCP_PLUGIN_ARCHITECTURE.md` + `MCP_STARTUP_PERFORMANCE.md` + `PROJECT_VISION.md` + `RECALL_CONTAMINATION_AB_2026-04-24.md` design docs (deferred — narrative discusses both old/new ids and needs editorial care, not a mechanical s/// pass)
- `qa/issue-registry.json` historical fix_note entries
- `installer/` (deprecated)

## New tests (migration_test.rs)

- `test_phase_cd_migrations_rewrite_legacy_memory_cpersona`: asserts the full migration chain leaves `mcp_servers.name='cpersona'`, `mcp_access_control.server_id='cpersona'` for the default agent, and `agent.cloto_default.metadata.preferred_memory='cpersona'` after a fresh `init_db` (which runs the heal migration's `memory.cpersona` seed first, then our Phase D renames it).
- `test_phase_c_migration_preserves_manual_choice`: asserts the Phase C EXISTS gate doesn't clobber a user-set preferred_memory value (e.g. someone who picked a custom memory plugin via dashboard).

## Test plan

- [x] `cargo check --workspace --exclude app` clean
- [x] `cargo test --workspace --exclude app` — **324 tests pass / 0 failed** (test count +2 from PR B baseline)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude app -- -D warnings -A clippy::too-many-lines -A clippy::struct-excessive-bools -A clippy::match-same-arms -A clippy::cast-possible-wrap -A clippy::trivially-copy-pass-by-ref -A clippy::manual-let-else -A clippy::option-if-let-else -A clippy::case-sensitive-file-extension-comparisons -A clippy::unwrap-used -A clippy::type-complexity` clean (CI equivalent)
- [x] `cd dashboard && npx biome lint src/` clean
- [x] `cd dashboard && npm run build` succeeds
- [ ] 0.6.6 NSIS in-place upgrade smoke (`gh workflow run release.yml --ref master -f version=0.6.6 -f draft_only=true` + Windows Sandbox) — deferred to pre-tag verify after this PR lands

## Fixed-points carried (irreversible from this PR)

- `mcp_servers.name` unified to `cpersona` (no `memory.` prefix) for the CPersona plugin; legacy `memory.cpersona` rows no longer exist in any user DB after upgrade
- `agent.cloto_default.metadata.preferred_memory` is populated with `'cpersona'` for existing users who had a memory plugin installed pre-0.6.6 but no manual selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)