### PR TITLE
0.6.6: version bump + CHANGELOG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "base64 0.21.7",
  "cloto_core",
@@ -1139,7 +1139,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cloto_core"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "cloto_shared"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 authors = ["ClotoCore <ClotoCore@proton.me>"]
 license = "BSL-1.1"

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloto_dashboard",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloto_dashboard",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "@pixiv/three-vrm": "^3.5.0",
         "@pixiv/three-vrm-animation": "^3.5.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloto_dashboard",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard/src-tauri/tauri.conf.json
+++ b/dashboard/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ClotoCore",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "identifier": "com.cloto.app",
   "build": {
     "frontendDist": "../dist",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,44 @@ Versioning follows the project's phase scheme: Alpha (A), Beta (βX.Y = 0.X.Y), 
 
 ---
 
+## [0.6.6] — 2026-05-24
+
+Kernel structural cleanup release. Two long-pending architectural threads ship together in a single release with bisect-friendly per-PR isolation: (1) the surface product is renamed `cloto-system` → `ClotoCore` to align with the three-layer doctrine (`ClotoCore + ClotoCloud + Cloto アプリ + ClotoHub`), and (2) the kernel is decoupled from hardcoded knowledge of any specific memory plugin id. Cumulative since v0.6.5.
+
+### Changed
+
+- **Product rename `cloto-system` → `ClotoCore`** (PR #136). `productName` in `tauri.conf.json`, the Cargo `[[bin]]` name (`cloto_system` → `clotocore`, separate from the existing `cloto` Magic Seal CLI), all user-facing display strings (`"Cloto System"` / `"CLOTO SYSTEM"` → `"ClotoCore"` / `"CLOTOCORE"`), `cli.rs` invocation help / version banner / self-update asset lookup pattern (`cloto_system-{target}` → `clotocore-{target}`), platform service `DisplayName` / systemd `Description`, dashboard tray tooltip, i18n titles, NSIS release artifact branding, install scripts (`install.ps1` / `install.sh`), and `docs/INSTALLER_DISTRIBUTION.md` artifact examples. Preserved invariants (rename-safe — would break in-place upgrade): `identifier = com.cloto.app`, `cli.rs default_prefix` (`/opt/cloto`, `C:\ProgramData\Cloto`), macOS launchd `SERVICE_LABEL = com.cloto.system`, Linux systemd `SERVICE_NAME = cloto`, Windows `sc.exe SERVICE_NAME = Cloto`, `config.rs:37 data_dir = ".../cloto-system"` (existing users' chat history / agent state / embedding namespaces live under this path).
+
+- **Memory plugin decouple Phase A + B** (PR #137). `config.memory_plugin_id: String` → `Option<String>` (env empty/unset → `None`); `db::init_db(..., memory_plugin_id: Option<&str>)` signature change; `plugin_configs.database_url` INSERT gated on `Some(_)` so kernel boots successfully without an embedded-plugin seed. `handlers/marketplace.rs::register_server` gained a `bind_default_memory_if_unset` helper — when a `category == "memory"` plugin installs, the helper mirrors its id into `agent.cloto_default.metadata.preferred_memory` (only if absent / empty, never clobbers a user's manual choice). 41 test fixtures across `tests/` / `benches/` / `src/test_utils.rs` / `db/mod.rs` unit tests switched `init_db(..., "memory.cpersona")` → `init_db(..., None)`. Aligns with MGP §10 invariant 3 (open standard, no privileged plugin).
+
+- **Memory plugin id rename `memory.cpersona` → `cpersona`** (PR #138). Catalog-canonical id propagated across dashboard preset lists (`presets.ts` MINIMAL / STANDARD / ADVANCED / EXPERT_SERVERS), `SetupWizard.tsx` `ALL_SELECTABLE_SERVER_IDS`, i18n keys (`server_memory_cpersona` → `server_cpersona`), `handlers_http_test.rs` test fixtures, and `README.md` MCP server table. Intentionally preserved: historical migration SQL literals (sqlx checksum constraint), `marketplace.rs::effective_install_dir` legacy backward-compat tests, `handlers/mcp.rs` dotted-id acceptance test, `capability_dispatcher` test fixtures, `format.test.ts` namespace-stripping assertion, and 5 design docs that discuss both old/new ids (deferred to follow-up editorial pass).
+
+### Migrations
+
+- `20260524000000_backfill_default_memory.sql` — back-fills `agent.cloto_default.metadata.preferred_memory = 'cpersona'` for existing users whose pre-0.6.6 memory binding came from the env default (`CLOTO_MEMORY_PLUGIN_ID`) rather than dashboard selection. Idempotent: no-op when `preferred_memory` already has a value or when no memory plugin is installed yet.
+- `20260524010000_rename_memory_cpersona_to_cpersona.sql` — renames `mcp_servers.name` `memory.cpersona` → `cpersona`, re-issues the `mcp_access_control` `server_grant` row under the new id (DELETE + INSERT around the parent rename — mirrors the KS22 rename precedent at `20260309000000`, FK requires this shape), renames `plugin_configs.plugin_id`, and cosmetically normalises any `agent.metadata.preferred_memory = 'memory.cpersona'` row to `'cpersona'`. Idempotent: WHERE clauses target only legacy rows.
+
+### Backward compatibility
+
+- Users with `CLOTO_MEMORY_PLUGIN_ID=memory.cpersona` in env keep their pre-0.6.6 behavior (env value flows through as `Some(...)`, plugin_configs row written as before). Phase D migration then renames the row so `cpersona` becomes the canonical id.
+- `init_db(..., None)` is a new valid state — the kernel boots with no memory plugin pre-seeded, then the modern Setup Wizard / marketplace install path populates `preferred_memory` on the first memory-kind install (via `bind_default_memory_if_unset`).
+- Existing chat history, agent state, embedding namespaces, mcp_access_control grants — all preserved (`config.rs:37 data_dir` and `tauri.conf.json identifier` are explicitly held constant).
+
+### CI / QA
+
+- Test count: 324 tests pass (322 pre-0.6.6 + 2 new migration tests in `migration_test.rs` for Phase C+D smoke and Phase C idempotency).
+- `cargo fmt --all -- --check` + `cargo clippy --workspace --exclude app -- -D warnings -A …` (CI lint suppressions) + `npx biome lint src/` all clean.
+
+### Fixed-points (irreversible from this release)
+
+- `config.memory_plugin_id: Option<String>` (downstream test fixtures depend on Option semantics)
+- `agent.metadata.preferred_memory` is the single source of truth for per-agent memory plugin selection
+- `init_db` signature `Option<&str>`
+- Cargo `[[bin]] name = "clotocore"` (cascades to CI artifact names + install scripts + platform path constants)
+- `mcp_servers.name = 'cpersona'` for the CPersona plugin (no `memory.` prefix); legacy rows migrated and gone after first boot on 0.6.6+
+
+---
+
 ## [0.6.5] — 2026-05-24
 
 CRITICAL hotfix release. Restores the auto-update path for all installer-based ClotoCore installs by switching the dashboard from a broken sidecar shell-out to the configured Tauri Updater plugin. Cumulative since v0.6.4 (2026-05-23).


### PR DESCRIPTION
## Summary

Final release ceremony commit for the **0.6.6 kernel structural cleanup bundle**. Aggregates the three substantive PRs into a publishable artifact:

- PR A ([#136](https://github.com/Cloto-dev/ClotoCore/pull/136)) — rename `cloto-system` → `ClotoCore`
- PR B ([#137](https://github.com/Cloto-dev/ClotoCore/pull/137)) — production decouple Phase A + B (`memory_plugin_id: Option<String>`, marketplace auto-binds `preferred_memory`, 41 test fixtures)
- PR C ([#138](https://github.com/Cloto-dev/ClotoCore/pull/138)) — data migrations Phase C + D (back-fill `preferred_memory`, rename `memory.cpersona` → `cpersona`)

## 4-file version sync (0.6.5 → 0.6.6)

- `Cargo.toml` `workspace.package.version`
- `dashboard/package.json` `version`
- `dashboard/src-tauri/tauri.conf.json` `version`
- `Cargo.lock` + `dashboard/package-lock.json` auto-updated to match

## CHANGELOG

`docs/CHANGELOG.md` v0.6.6 section prepended above v0.6.5 entry. Three subsections (Changed / Migrations / Backward compatibility) + CI/QA summary + Fixed-points list — covers rename + decouple + migration as one coherent kernel cleanup narrative.

## Test plan

- [x] `cargo check --workspace --exclude app` clean
- [x] `cargo test --workspace --exclude app` — 324 tests pass / 0 failed
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude app -- -D warnings -A …` (CI equivalent suppressions) clean
- [x] `bash scripts/verify-issues.sh` — 90 verified / 135 fixed / 0 stale / 0 errors
- [ ] **After this lands**: `gh workflow run release.yml --ref master -f version=0.6.6 -f draft_only=true` → Windows Sandbox in-place upgrade smoke from v0.6.5 → v0.6.6 (verify chat history / agent state / setup-completed flag survive the rename + decouple + migrations)
- [ ] **If sandbox smoke green**: `gh release create v0.6.6 --target master --notes-file …` to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)