### PR TITLE
chore: remove tool.research references after server deprecation

### DIFF
--- a/crates/core/src/handlers/engine_routing.rs
+++ b/crates/core/src/handlers/engine_routing.rs
@@ -43,7 +43,6 @@ impl RoutingRule {
                 "run",
                 "execute",
                 "find",
-                "research",
             ];
             return tool_keywords
                 .iter()

--- a/crates/core/src/managers/mcp_tool_discovery.rs
+++ b/crates/core/src/managers/mcp_tool_discovery.rs
@@ -58,10 +58,9 @@ fn classify_latency_tier(server_id: &str, tool_name: &str) -> LatencyTier {
 
     match (suffix, tool_name) {
         // Tier S — very expensive
-        ("imagegen", "generate_image")
-        | ("research", "deep_research")
-        | ("stt", "transcribe")
-        | ("capture", "analyze_image") => LatencyTier::S,
+        ("imagegen", "generate_image") | ("stt", "transcribe") | ("capture", "analyze_image") => {
+            LatencyTier::S
+        }
 
         // Tier A — network or moderate LLM
         ("websearch", "fetch_page")
@@ -1594,17 +1593,6 @@ mod tests {
                 ],
             ),
             (
-                "tool.research",
-                vec![
-                    ("deep_research", "Conduct deep research on a topic", 5),
-                    (
-                        "summarize_sources",
-                        "Summarize multiple research sources",
-                        4,
-                    ),
-                ],
-            ),
-            (
                 "tool.capture",
                 vec![
                     ("screenshot", "Capture a screenshot of the screen", 4),
@@ -1708,8 +1696,8 @@ mod tests {
 
         // Assertions: meaningful reduction must be achieved
         assert!(
-            total_tools >= 40,
-            "Realistic deployment should have 40+ tools, got {total_tools}"
+            total_tools >= 35,
+            "Realistic deployment should have 35+ tools, got {total_tools}"
         );
         assert!(
             reduction_pct >= 50.0,
@@ -1809,22 +1797,19 @@ mod tests {
     fn latency_tier_affects_scoring() {
         let index = ToolIndex::new();
 
-        // Two tools with the keyword "search" — one Tier C (websearch), one Tier S (research)
-        let fast_tool = make_tool("web_search", "Search the web for information");
-        let slow_tool = make_tool(
-            "deep_research",
-            "Deep research search across multiple sources",
-        );
+        // Two tools with the keyword "image" — one Tier C (websearch), one Tier S (imagegen)
+        let fast_tool = make_tool("search_image_results", "Search the web for image pages");
+        let slow_tool = make_tool("generate_image", "Generate an image via Stable Diffusion");
 
         index.add_server_tools("tool.websearch", &[fast_tool], |_| None);
-        index.add_server_tools("tool.research", &[slow_tool], |_| None);
+        index.add_server_tools("tool.imagegen", &[slow_tool], |_| None);
 
-        let results = index.search_keyword("search", 10, &ToolSearchFilter::default());
-        assert!(results.len() >= 2, "Both tools should match 'search'");
+        let results = index.search_keyword("image", 10, &ToolSearchFilter::default());
+        assert!(results.len() >= 2, "Both tools should match 'image'");
 
-        // web_search (Tier C, multiplier 1.0) should rank above deep_research (Tier S, multiplier 0.5)
+        // search_image_results (Tier C, multiplier 1.0) should rank above generate_image (Tier S, multiplier 0.5)
         assert_eq!(
-            results[0].0.name, "web_search",
+            results[0].0.name, "search_image_results",
             "Tier C tool should rank above Tier S tool for equal keyword relevance"
         );
         assert!(
@@ -1840,10 +1825,6 @@ mod tests {
         // Tier S
         assert_eq!(
             classify_latency_tier("tool.imagegen", "generate_image"),
-            LatencyTier::S
-        );
-        assert_eq!(
-            classify_latency_tier("tool.research", "deep_research"),
             LatencyTier::S
         );
         assert_eq!(

--- a/dashboard/src/components/SetupWizard.tsx
+++ b/dashboard/src/components/SetupWizard.tsx
@@ -44,7 +44,6 @@ const ALL_SELECTABLE_SERVER_IDS = [
   'tool.terminal',
   'tool.cron',
   'tool.websearch',
-  'tool.research',
   'tool.agent_utils',
   'tool.embedding',
   'tool.imagegen',

--- a/dashboard/src/lib/presets.ts
+++ b/dashboard/src/lib/presets.ts
@@ -4,14 +4,7 @@ import { Box, Layers, type LucideIcon, Shield, Zap } from 'lucide-react';
 
 export const MINIMAL_SERVERS = ['cpersona', 'tool.agent_utils'];
 
-export const STANDARD_SERVERS = [
-  'cpersona',
-  'tool.cron',
-  'tool.terminal',
-  'tool.websearch',
-  'tool.research',
-  'tool.agent_utils',
-];
+export const STANDARD_SERVERS = ['cpersona', 'tool.cron', 'tool.terminal', 'tool.websearch', 'tool.agent_utils'];
 
 export const ADVANCED_SERVERS = [...STANDARD_SERVERS, 'tool.imagegen', 'tool.embedding'];
 


### PR DESCRIPTION
## Summary

Companion to [cloto-mcp-servers#21](https://github.com/Cloto-dev/cloto-mcp-servers/pull/21) which drops the `tool.research` MCP server (zero invocations recorded in the past two weeks). This PR removes the now-dead kernel/dashboard references so the deprecation lands cleanly.

**Merge order**: cloto-mcp-servers#21 first, then this PR. The reverse also works (kernel handles a missing server gracefully), but the canonical sequence keeps the registry consistent during rollout.

## Changes

| File | Change |
|---|---|
| `crates/core/src/managers/mcp_tool_discovery.rs` | Drop `tool.research` from the Tier S latency match arm (L62) and from the registry seed (L1597-1602); rewrite `latency_tier_affects_scoring` to use `tool.imagegen` for the Tier S example; drop the `tool.research` arm from `classify_latency_tier_mapping` |
| `crates/core/src/handlers/engine_routing.rs` | Drop `"research"` from `tool_keywords` (L46) — the rest (search/run/execute/find) still routes generic research-style intents through `tool.websearch` |
| `dashboard/src/components/SetupWizard.tsx` | Drop `tool.research` from `ALL_SELECTABLE_SERVER_IDS` |
| `dashboard/src/lib/presets.ts` | Drop `tool.research` from `STANDARD_SERVERS` (advanced/expert presets transitively drop it as well) |

## Migrations intentionally NOT modified

The following migrations retain their `tool.research` rows by design:

- `crates/core/migrations/20260304200000_default_agent_mcp_grants.sql:16` — server_grant for `agent.cloto_default`
- `crates/core/migrations/20260309100000_heal_default_agent.sql:22` — heal install
- `crates/core/migrations/20260309100000_heal_default_agent.sql:46` — heal UNION SELECT

Per the SQLx Migration Rules in CLAUDE.md, applied migrations are immutable — editing them post-apply triggers a checksum mismatch that prevents kernel boot. The kernel handles missing servers gracefully: marketplace sync flips `is_active=0`, and connection attempts skip cleanly. A small amount of dead grant/config rows in existing user DBs is the documented trade-off (also captured in Goal #62 description).

## Test plan

- [x] `cargo fmt --all -- --check` — pass
- [x] `cargo clippy --workspace --exclude app -- -D warnings <CI -A flags>` — pass
- [x] `cargo test --workspace --exclude app --lib` — 260/260 pass
- [x] `cd dashboard && npx biome check src/components/SetupWizard.tsx src/lib/presets.ts` — pass (auto-format applied)
- [x] `cd dashboard && npx tsc --noEmit` — pass
- [x] Pre-commit hook (author + issue-registry) — pass

## Notes

- Adjusted unrelated assertion in `measure_context_reduction_realistic` from `total_tools >= 40` to `>= 35` to absorb the dropped registry seed entry — the test's intent (≥ 50% context reduction on a realistic deployment) is unchanged.
- The biome check error on `src/i18n.ts` reproduces on `master` and is unrelated to this PR.

## Rationale (from cloto-mcp-servers#21)

`TOOL_EXECUTED` audit 2026-05-09 — 2026-05-24 recorded 106 invocations across the catalog, **0 for `tool.research`**. No active agent (`agent.karin` 12 msg, `agent.sapphy`/`agent.ks22` 0 msg) references the server. If a deep-research capability is needed in the future, a generic `common/agentic_loop.py` abstraction is a simpler path than reviving the 374 LOC server + 4 LLM provider deps.