### PR TITLE
fix(release): close Tauri Updater 404 race by two-phase upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -626,7 +626,30 @@ jobs:
           ---
           HEADER
 
-      - name: Create GitHub Release
+      # Two-phase upload to prevent the Tauri Updater 404 race window:
+      # softprops/action-gh-release uploads `files` glob entries serially, and the
+      # ~hundreds-of-bytes latest.json finishes long before the ~25 MB
+      # *.nsis.zip. While the binary is still uploading, a client that polled
+      # latest.json sees the new version and triggers downloadAndInstall(),
+      # which 404s on the binary URL → "Failed to apply update". Splitting the
+      # upload so latest.json is published only AFTER every binary asset
+      # closes that window.
+      - name: Stage latest.json for second-phase upload
+        if: github.event.inputs.draft_only != 'true'
+        run: |
+          if [[ -f release-files/latest.json ]]; then
+            mkdir -p release-indicator
+            mv release-files/latest.json release-indicator/
+            echo "Moved latest.json out of release-files/ — will be uploaded after binaries"
+            echo "release-files/ remaining:"
+            ls -1 release-files/
+            echo "release-indicator/:"
+            ls -1 release-indicator/
+          else
+            echo "No latest.json generated (no platform signatures) — skipping stage step"
+          fi
+
+      - name: Create GitHub Release (binaries first, no latest.json)
         if: github.event.inputs.draft_only != 'true'
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
@@ -638,5 +661,14 @@ jobs:
           append_body: true
           generate_release_notes: true
           files: release-files/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Append latest.json (auto-update indicator, after all binaries)
+        if: github.event.inputs.draft_only != 'true' && hashFiles('release-indicator/latest.json') != ''
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          files: release-indicator/latest.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Splits the GitHub Release asset upload into two phases so that `latest.json` (the Tauri Updater indicator) publishes **only after every binary asset is reachable**, eliminating the 404 race window that contributes to "Failed to apply update" failures.

This is the **contributing-factor axis** of [bug-386](https://github.com/Cloto-dev/ClotoCore/issues/141); the dominant axis (the 0.6.5→0.6.6 `productName` change moving the NSIS install path) is tracked separately and pending hands-on Windows verification.

## The race

`softprops/action-gh-release@v2` uploads `files` glob entries serially.

- `latest.json` is ~hundreds of bytes — finishes seconds after Create Release fires
- `*.nsis.zip` is ~25 MB — still uploading minutes later
- Anything in `release-files/*` becomes publicly fetchable as soon as its individual upload completes

During the window where `latest.json` is live but `*.nsis.zip` is not, a Tauri Updater `check()` succeeds, then `downloadAndInstall()` 404s on the binary URL → the desktop UI prints **"Failed to apply update"** and the upgrade does not complete.

## The fix

Two new steps wrap the existing Create Release step:

1. **Stage `latest.json` for second-phase upload** — moves `release-files/latest.json` into `release-indicator/`. Gated on `draft_only != 'true'`. No-op if `latest.json` was never generated (signature-less build).
2. **Create GitHub Release (binaries first, no `latest.json`)** — unchanged from the previous step, but `release-files/*` now contains everything **except** `latest.json`. Binaries, signatures, checksums, and the cosign bundle all upload here.
3. **Append `latest.json` (auto-update indicator, after all binaries)** — second `softprops/action-gh-release` invocation against the same tag, uploading only `release-indicator/latest.json`. Gated on `hashFiles('release-indicator/latest.json') != ''` so signature-less builds skip cleanly.

The same release object accumulates assets across the two invocations — no tag duplication, no body churn (`body_path` and friends are only passed on the first call).

## Test plan

- [x] `yaml.safe_load(...)` on the updated workflow — parses cleanly
- [x] `git diff` is minimal (34 lines, single file)
- [ ] Smoke-tested on the next real release (will surface in the v0.6.7 cut)
- [ ] (Optional) `gh workflow run release.yml --ref fix-release-yml-race-condition -f draft_only=true` produces installers without publishing a tag, confirming `draft_only` paths are still well-formed

## Scope

This PR is **independent of the `productName` axis** of bug-386 and does not modify `tauri.conf.json` or any Updater client code. It can land on its own or be bundled into the 0.6.7 hotfix alongside the eventual productName fix.

## Why two `softprops` invocations instead of one with explicit globs

`softprops/action-gh-release` supports `files: |\n  pattern1\n  pattern2`, but its glob library does not include `!` negation, so excluding `latest.json` would require enumerating every binary kind (`*.nsis.zip`, `*.nsis.zip.sig`, `*.exe`, `*.dmg`, `*.deb`, `*.AppImage`, `*.tar.gz`, `checksums.txt`, `*.bundle`, …). That list is fragile across future installer additions. Splitting the directory keeps the original `release-files/*` pattern intact and isolates the change to where `latest.json` lives, not which binaries are matched.

## Related

- `qa/issue-registry.json` bug-386 — entry remains `open` until the productName axis also lands
- CScheduler Goal #63 (Scope #11 — 0.6.x quality remediation line)
- Tauri Updater integration history: bug-385 / PR #134 (proper consumer integration in 0.6.5)