### PR TITLE
refactor(0.6.8-alpha.2): Pattern-C capability tool name registry (Goal #72)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.6.8-alpha.1"
+version = "0.6.8-alpha.2"
 dependencies = [
  "base64 0.21.7",
  "cloto_core",
@@ -1139,7 +1139,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cloto_core"
-version = "0.6.8-alpha.1"
+version = "0.6.8-alpha.2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "cloto_shared"
-version = "0.6.8-alpha.1"
+version = "0.6.8-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.8-alpha.1"
+version = "0.6.8-alpha.2"
 edition = "2021"
 authors = ["ClotoCore <ClotoCore@proton.me>"]
 license = "BSL-1.1"

--- a/crates/core/src/handlers/system.rs
+++ b/crates/core/src/handlers/system.rs
@@ -505,7 +505,11 @@ impl SystemHandler {
             });
             match tokio::time::timeout(
                 Duration::from_secs(self.memory_timeout_secs),
-                mcp.call_server_tool(server_id, "recall", mcp_recall_payload),
+                mcp.call_kind_at(
+                    server_id,
+                    &crate::managers::ToolKind::Recall,
+                    mcp_recall_payload,
+                ),
             )
             .await
             {
@@ -627,7 +631,8 @@ impl SystemHandler {
                 .entry("agent_id".to_string())
                 .or_insert(serde_json::json!(agent.id));
             // For backward compat: speak requires "text" from message content
-            if tool_name == "speak" {
+            if crate::managers::ToolKind::from_name(&tool_name) == crate::managers::ToolKind::Speak
+            {
                 args_map
                     .entry("text".to_string())
                     .or_insert(serde_json::json!(msg.content));
@@ -911,7 +916,11 @@ impl SystemHandler {
                             });
                             let _ = tokio::time::timeout(
                                 mem_timeout2,
-                                mcp_clone.call_server_tool(&server_id_clone, "store", store_args),
+                                mcp_clone.call_kind_at(
+                                    &server_id_clone,
+                                    &crate::managers::ToolKind::Store,
+                                    store_args,
+                                ),
                             )
                             .await;
                         });
@@ -1087,12 +1096,8 @@ impl SystemHandler {
                             tokio::spawn(async move {
                                 match tokio::time::timeout(
                                     Duration::from_secs(timeout_secs),
-                                    mcp_clone.call_capability_tool(
-                                        crate::managers::capability_dispatcher::CapabilityType::Speech,
-                                        "speak",
-                                        speak_args,
-                                        None,
-                                    ),
+                                    mcp_clone
+                                        .call_kind(&crate::managers::ToolKind::Speak, speak_args),
                                 )
                                 .await
                                 {
@@ -1296,7 +1301,7 @@ impl SystemHandler {
                 });
                 match tokio::time::timeout(
                     memory_timeout,
-                    mcp.call_server_tool(&server_id, "store", store_args),
+                    mcp.call_kind_at(&server_id, &crate::managers::ToolKind::Store, store_args),
                 )
                 .await
                 {
@@ -1375,7 +1380,8 @@ impl SystemHandler {
                 .is_some_and(cloto_shared::ReasoningEngine::supports_tools)
         } else if let Some(ref mcp) = mcp_engine {
             // MCP engine supports tools if it has a 'think_with_tools' tool
-            mcp.has_server_tool(engine_id, "think_with_tools").await
+            mcp.has_kind_at(engine_id, &crate::managers::ToolKind::ThinkWithTools)
+                .await
         } else {
             false
         };
@@ -1909,7 +1915,9 @@ impl SystemHandler {
                 "message": message_val,
                 "context": context_val,
             });
-            let result = mcp.call_server_tool(engine_id, "think", args).await?;
+            let result = mcp
+                .call_kind_at(engine_id, &crate::managers::ToolKind::Think, args)
+                .await?;
             self.maybe_record_usage(&agent.id, engine_id, &result).await;
             return Self::extract_mcp_think_content(&result);
         }
@@ -1984,7 +1992,7 @@ impl SystemHandler {
                 "tool_history": tool_history,
             });
             let result = mcp
-                .call_server_tool(engine_id, "think_with_tools", args)
+                .call_kind_at(engine_id, &crate::managers::ToolKind::ThinkWithTools, args)
                 .await?;
             self.maybe_record_usage(&agent.id, engine_id, &result).await;
             return Self::parse_mcp_think_result(&result);
@@ -2036,7 +2044,7 @@ impl SystemHandler {
         });
 
         let (mut chunk_rx, result_rx) = mcp
-            .call_server_tool_streaming(engine_id, "think_with_tools", args)
+            .call_kind_streaming_at(engine_id, &crate::managers::ToolKind::ThinkWithTools, args)
             .await?;
 
         // Fan chunk deltas onto the event bus as `AgentTokenStream`. The
@@ -2240,12 +2248,7 @@ impl SystemHandler {
             });
 
             match mcp
-                .call_capability_tool(
-                    crate::managers::CapabilityType::Vision,
-                    "analyze_image",
-                    args,
-                    None,
-                )
+                .call_kind(&crate::managers::ToolKind::AnalyzeImage, args)
                 .await
             {
                 Ok(result) => {
@@ -2355,12 +2358,7 @@ impl SystemHandler {
             });
 
             match mcp
-                .call_capability_tool(
-                    crate::managers::CapabilityType::Stt,
-                    "transcribe",
-                    args,
-                    None,
-                )
+                .call_kind(&crate::managers::ToolKind::Transcribe, args)
                 .await
             {
                 Ok(result) => {
@@ -2708,9 +2706,9 @@ impl SystemHandler {
         // 1. Fetch recent memories
         let Ok(Ok(mem_result)) = tokio::time::timeout(
             memory_timeout,
-            mcp.call_server_tool(
+            mcp.call_kind_at(
                 server_id,
-                "list_memories",
+                &crate::managers::ToolKind::ListMemories,
                 serde_json::json!({"agent_id": agent_id, "limit": TOOL_USAGE_THRESHOLD + 5}),
             ),
         )
@@ -2730,9 +2728,9 @@ impl SystemHandler {
         // 2. Get last episode timestamp
         let Ok(Ok(ep_result)) = tokio::time::timeout(
             memory_timeout,
-            mcp.call_server_tool(
+            mcp.call_kind_at(
                 server_id,
-                "list_episodes",
+                &crate::managers::ToolKind::ListEpisodes,
                 serde_json::json!({"agent_id": agent_id, "limit": 1}),
             ),
         )
@@ -2856,7 +2854,11 @@ impl SystemHandler {
         }
 
         match mcp
-            .call_server_tool(server_id, "archive_episode", archive_args)
+            .call_kind_at(
+                server_id,
+                &crate::managers::ToolKind::ArchiveEpisode,
+                archive_args,
+            )
             .await
         {
             Ok(_) => {
@@ -2868,9 +2870,9 @@ impl SystemHandler {
 
                 // Pre-compute profile update via CFR engine
                 let existing_profile = mcp
-                    .call_server_tool(
+                    .call_kind_at(
                         server_id,
-                        "get_profile",
+                        &crate::managers::ToolKind::Custom("get_profile".to_string()),
                         serde_json::json!({"agent_id": agent_id}),
                     )
                     .await
@@ -2907,9 +2909,9 @@ impl SystemHandler {
 
                 if let Some(profile) = new_profile {
                     match mcp
-                        .call_server_tool(
+                        .call_kind_at(
                             server_id,
-                            "update_profile",
+                            &crate::managers::ToolKind::UpdateProfile,
                             serde_json::json!({"agent_id": agent_id, "profile": profile}),
                         )
                         .await
@@ -2965,7 +2967,10 @@ impl SystemHandler {
             },
             "context": [],
         });
-        match mcp.call_server_tool(engine_id, "think", args).await {
+        match mcp
+            .call_kind_at(engine_id, &crate::managers::ToolKind::Think, args)
+            .await
+        {
             Ok(result) => Self::extract_mcp_think_content(&result).ok(),
             Err(e) => {
                 warn!(engine_id = %engine_id, error = %e, "Engine think_simple failed");

--- a/crates/core/src/managers/capability_dispatcher.rs
+++ b/crates/core/src/managers/capability_dispatcher.rs
@@ -5,6 +5,8 @@
 //! (P1 Core Minimalism compliance).
 
 use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
 use tokio::sync::RwLock;
 use tracing::debug;
 
@@ -21,6 +23,122 @@ pub enum CapabilityType {
     Stt,
     /// Speech output / text-to-speech (speak)
     Speech,
+}
+
+impl fmt::Display for CapabilityType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            CapabilityType::Memory => "Memory",
+            CapabilityType::Reasoning => "Reasoning",
+            CapabilityType::Vision => "Vision",
+            CapabilityType::Stt => "Stt",
+            CapabilityType::Speech => "Speech",
+        };
+        f.write_str(s)
+    }
+}
+
+impl FromStr for CapabilityType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, ()> {
+        match s {
+            "Memory" => Ok(CapabilityType::Memory),
+            "Reasoning" => Ok(CapabilityType::Reasoning),
+            "Vision" => Ok(CapabilityType::Vision),
+            "Stt" => Ok(CapabilityType::Stt),
+            "Speech" => Ok(CapabilityType::Speech),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Well-known tool names the kernel dispatches by enum (no string literals in handlers).
+///
+/// The 11 named variants cover every tool the kernel currently calls or checks for via
+/// `handlers/system.rs`. `Custom(String)` is an escape hatch for explicit-target calls
+/// that don't fit a well-known capability (e.g. `get_profile` at single use sites).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ToolKind {
+    // Memory (6)
+    Store,
+    Recall,
+    ListMemories,
+    ListEpisodes,
+    ArchiveEpisode,
+    UpdateProfile,
+    // Reasoning (2)
+    Think,
+    ThinkWithTools,
+    // Vision (1)
+    AnalyzeImage,
+    // Stt (1)
+    Transcribe,
+    // Speech (1)
+    Speak,
+    /// Escape hatch — wire-level tool name without a well-known variant.
+    /// `capability()` returns `None`, so this variant must be paired with an
+    /// explicit `server_id` (use `call_kind_at` / `has_kind_at` family).
+    Custom(String),
+}
+
+impl ToolKind {
+    /// Wire-level MCP tool name as transmitted over MGP.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            ToolKind::Store => "store",
+            ToolKind::Recall => "recall",
+            ToolKind::ListMemories => "list_memories",
+            ToolKind::ListEpisodes => "list_episodes",
+            ToolKind::ArchiveEpisode => "archive_episode",
+            ToolKind::UpdateProfile => "update_profile",
+            ToolKind::Think => "think",
+            ToolKind::ThinkWithTools => "think_with_tools",
+            ToolKind::AnalyzeImage => "analyze_image",
+            ToolKind::Transcribe => "transcribe",
+            ToolKind::Speak => "speak",
+            ToolKind::Custom(s) => s,
+        }
+    }
+
+    /// Which capability provides this kind. `Custom` returns `None` — callers
+    /// must route via explicit `server_id`.
+    #[must_use]
+    pub fn capability(&self) -> Option<CapabilityType> {
+        match self {
+            ToolKind::Store
+            | ToolKind::Recall
+            | ToolKind::ListMemories
+            | ToolKind::ListEpisodes
+            | ToolKind::ArchiveEpisode
+            | ToolKind::UpdateProfile => Some(CapabilityType::Memory),
+            ToolKind::Think | ToolKind::ThinkWithTools => Some(CapabilityType::Reasoning),
+            ToolKind::AnalyzeImage => Some(CapabilityType::Vision),
+            ToolKind::Transcribe => Some(CapabilityType::Stt),
+            ToolKind::Speak => Some(CapabilityType::Speech),
+            ToolKind::Custom(_) => None,
+        }
+    }
+
+    /// Reverse map: build a `ToolKind` from an MCP tool name. Unknown names
+    /// fall through to `Custom(name)`.
+    #[must_use]
+    pub fn from_name(name: &str) -> Self {
+        match name {
+            "store" => ToolKind::Store,
+            "recall" => ToolKind::Recall,
+            "list_memories" => ToolKind::ListMemories,
+            "list_episodes" => ToolKind::ListEpisodes,
+            "archive_episode" => ToolKind::ArchiveEpisode,
+            "update_profile" => ToolKind::UpdateProfile,
+            "think" => ToolKind::Think,
+            "think_with_tools" => ToolKind::ThinkWithTools,
+            "analyze_image" => ToolKind::AnalyzeImage,
+            "transcribe" => ToolKind::Transcribe,
+            "speak" => ToolKind::Speak,
+            _ => ToolKind::Custom(name.to_string()),
+        }
+    }
 }
 
 /// A mapping from capability to a specific server/tool pair.
@@ -54,7 +172,11 @@ impl CapabilityDispatcher {
         }
     }
 
-    /// Register capabilities from a newly connected server's tool list.
+    /// Register capabilities from a newly connected server's tool list using
+    /// the legacy `classify_tool` heuristic (server prefix + tool name match).
+    ///
+    /// Use [`build_from_capabilities`] instead when the server declares its
+    /// own `tools_for_capability` mapping in its MGP `initialize` response.
     pub async fn build_from_tools(&self, server_id: &str, tools: &[super::mcp_protocol::McpTool]) {
         let mut mappings = self.mappings.write().await;
         for tool in tools {
@@ -73,6 +195,49 @@ impl CapabilityDispatcher {
             }
         }
         debug!(server = %server_id, "Capability mappings updated");
+    }
+
+    /// Register capabilities from a server-declared manifest
+    /// (`MgpServerCapabilities.tools_for_capability`, Pattern-C, 0.6.8-alpha.2).
+    ///
+    /// Keys must parse as [`CapabilityType`] via `FromStr` (`"Memory"`,
+    /// `"Reasoning"`, `"Vision"`, `"Stt"`, `"Speech"`). Unknown keys are
+    /// logged and skipped — the kernel never invents capabilities from
+    /// arbitrary server strings.
+    ///
+    /// This is the manifest-driven path that replaces the `classify_tool`
+    /// heuristic for servers that opt in. Both paths can coexist in the
+    /// same dispatcher (different servers).
+    pub async fn build_from_capabilities(
+        &self,
+        server_id: &str,
+        tools_for_capability: &HashMap<String, Vec<String>>,
+    ) {
+        let mut mappings = self.mappings.write().await;
+        for (cap_name, tool_names) in tools_for_capability {
+            let Ok(cap) = CapabilityType::from_str(cap_name) else {
+                tracing::warn!(
+                    server = %server_id,
+                    capability = %cap_name,
+                    "tools_for_capability declared unknown CapabilityType; ignoring",
+                );
+                continue;
+            };
+            let entries = mappings.entry(cap).or_default();
+            for tool_name in tool_names {
+                if !entries
+                    .iter()
+                    .any(|m| m.server_id == server_id && &m.tool_name == tool_name)
+                {
+                    entries.push(CapabilityMapping {
+                        server_id: server_id.to_string(),
+                        tool_name: tool_name.clone(),
+                        priority: 0,
+                    });
+                }
+            }
+        }
+        debug!(server = %server_id, "Capability mappings updated from manifest");
     }
 
     /// Remove all mappings for a disconnected server.
@@ -122,6 +287,21 @@ impl CapabilityDispatcher {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    /// Resolve a `ToolKind` to the server that provides it.
+    ///
+    /// For well-known variants this is equivalent to `resolve(kind.capability()?, kind.name())`.
+    /// `Custom(_)` returns `None` because there is no capability to filter on — use
+    /// explicit-target shims (`call_kind_at`) for those.
+    pub async fn resolve_kind(&self, kind: &ToolKind) -> Option<(String, String)> {
+        let cap = kind.capability()?;
+        self.resolve(cap, kind.name()).await
+    }
+
+    /// True if any registered server provides this `ToolKind` under its capability.
+    pub async fn has_kind(&self, kind: &ToolKind) -> bool {
+        self.resolve_kind(kind).await.is_some()
     }
 }
 
@@ -231,5 +411,128 @@ mod tests {
 
         let all = dispatcher.resolve_all(CapabilityType::Memory).await;
         assert_eq!(all.len(), 1);
+    }
+
+    // ============================================================
+    // ToolKind enum tests (Pattern-C, 0.6.8-alpha.2)
+    // ============================================================
+
+    fn well_known_kinds() -> Vec<ToolKind> {
+        vec![
+            ToolKind::Store,
+            ToolKind::Recall,
+            ToolKind::ListMemories,
+            ToolKind::ListEpisodes,
+            ToolKind::ArchiveEpisode,
+            ToolKind::UpdateProfile,
+            ToolKind::Think,
+            ToolKind::ThinkWithTools,
+            ToolKind::AnalyzeImage,
+            ToolKind::Transcribe,
+            ToolKind::Speak,
+        ]
+    }
+
+    #[test]
+    fn test_kind_round_trip() {
+        for kind in well_known_kinds() {
+            let name = kind.name();
+            let recovered = ToolKind::from_name(name);
+            assert_eq!(recovered, kind, "round-trip failed for {kind:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_kind_memory() {
+        let dispatcher = CapabilityDispatcher::new();
+        let tools = vec![make_tool("store"), make_tool("recall")];
+        dispatcher.build_from_tools("memory.cpersona", &tools).await;
+
+        let result = dispatcher.resolve_kind(&ToolKind::Recall).await;
+        assert!(result.is_some());
+        let (server, tool) = result.unwrap();
+        assert_eq!(server, "memory.cpersona");
+        assert_eq!(tool, "recall");
+        assert!(dispatcher.has_kind(&ToolKind::Recall).await);
+        assert!(dispatcher.has_kind(&ToolKind::Store).await);
+        assert!(!dispatcher.has_kind(&ToolKind::Think).await);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_kind_speech() {
+        let dispatcher = CapabilityDispatcher::new();
+        let tools = vec![make_tool("speak")];
+        dispatcher.build_from_tools("output.coqui", &tools).await;
+
+        let result = dispatcher.resolve_kind(&ToolKind::Speak).await;
+        assert_eq!(
+            result,
+            Some(("output.coqui".to_string(), "speak".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_from_name_custom_falls_through() {
+        let kind = ToolKind::from_name("get_profile");
+        assert_eq!(kind, ToolKind::Custom("get_profile".to_string()));
+        assert_eq!(kind.capability(), None);
+        assert_eq!(kind.name(), "get_profile");
+
+        // Custom is not dispatchable via resolve_kind (no capability filter).
+        let dispatcher = CapabilityDispatcher::new();
+        let tools = vec![make_tool("get_profile")];
+        dispatcher.build_from_tools("memory.cpersona", &tools).await;
+        assert!(dispatcher.resolve_kind(&kind).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_kind_capability_mapping_consistent_with_classify_tool() {
+        // Every well-known ToolKind's tool name must be classified into the
+        // same CapabilityType by the legacy classify_tool fallback. This is the
+        // regression guard for manifest-vs-fallback divergence.
+        for kind in well_known_kinds() {
+            let cap = kind.capability().expect("well-known kind has capability");
+            // Use a neutral server_id ("custom.x") so classify_tool falls back
+            // to its tool-name match table rather than the server-prefix rule.
+            let classified = classify_tool("custom.x", kind.name());
+            assert_eq!(
+                classified,
+                Some(cap),
+                "classify_tool divergence for kind={kind:?}: \
+                 ToolKind.capability()={cap:?}, classify_tool({:?})={classified:?}",
+                kind.name(),
+            );
+        }
+    }
+
+    #[test]
+    fn test_capability_type_display_round_trip() {
+        use std::str::FromStr;
+        for cap in [
+            CapabilityType::Memory,
+            CapabilityType::Reasoning,
+            CapabilityType::Vision,
+            CapabilityType::Stt,
+            CapabilityType::Speech,
+        ] {
+            let s = cap.to_string();
+            let recovered = CapabilityType::from_str(&s).expect("FromStr should succeed");
+            assert_eq!(recovered, cap);
+        }
+        assert!(CapabilityType::from_str("Unknown").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_kind_rejects_cross_capability() {
+        // A server prefixed memory.* with the wrong tool name should not be
+        // reachable via a different-capability ToolKind. (Defense in depth:
+        // resolve() already filters by CapabilityType.)
+        let dispatcher = CapabilityDispatcher::new();
+        let tools = vec![make_tool("store")];
+        dispatcher.build_from_tools("memory.cpersona", &tools).await;
+
+        // Recall under Memory: found. Think under Reasoning: nothing registered.
+        assert!(dispatcher.resolve_kind(&ToolKind::Store).await.is_some());
+        assert!(dispatcher.resolve_kind(&ToolKind::Think).await.is_none());
     }
 }

--- a/crates/core/src/managers/mcp.rs
+++ b/crates/core/src/managers/mcp.rs
@@ -1413,8 +1413,18 @@ impl McpClientManager {
             }
         }
 
-        // Build capability mappings for dynamic dispatch (P1 Core Minimalism)
-        self.dispatcher.build_from_tools(&id, &tools).await;
+        // Build capability mappings for dynamic dispatch (P1 Core Minimalism).
+        // Manifest-driven (Pattern-C, 0.6.8-alpha.2) takes precedence over the
+        // legacy classify_tool heuristic when the server declares
+        // `tools_for_capability` in its MGP `initialize` response.
+        if let Some(map) = mgp_server_caps
+            .as_ref()
+            .and_then(|c| c.tools_for_capability.as_ref())
+        {
+            self.dispatcher.build_from_capabilities(&id, map).await;
+        } else {
+            self.dispatcher.build_from_tools(&id, &tools).await;
+        }
 
         info!(
             "MCP server '{}' connected with {} tools",
@@ -2493,6 +2503,85 @@ impl McpClientManager {
                 })?
         };
         self.call_server_tool(&server_id, tool_name, args).await
+    }
+
+    // ============================================================
+    // ToolKind-typed entry points (Pattern-C, 0.6.8-alpha.2)
+    //
+    // Keep handlers/ free of tool-name string literals (§1.2). Two flavors:
+    //   * `*_kind`        — dispatcher-resolved server_id (capability-aware)
+    //   * `*_kind_at`     — explicit server_id (engine_id override, Custom variants)
+    // ============================================================
+
+    /// Call a [`ToolKind`] via dispatcher resolution.
+    /// `Custom(_)` variants have no capability and will fail here — use
+    /// [`call_kind_at`] with an explicit `server_id` instead.
+    pub async fn call_kind(
+        &self,
+        kind: &super::capability_dispatcher::ToolKind,
+        args: Value,
+    ) -> Result<super::mcp_protocol::CallToolResult> {
+        let (server_id, _) = self.dispatcher.resolve_kind(kind).await.ok_or_else(|| {
+            anyhow::anyhow!("No server provides ToolKind for tool '{}'", kind.name())
+        })?;
+        self.call_server_tool(&server_id, kind.name(), args).await
+    }
+
+    /// Call a [`ToolKind`] against an explicit `server_id`. Use when the
+    /// caller has a routing override (engine_id, consensus target, …) or is
+    /// dispatching a `Custom` variant.
+    pub async fn call_kind_at(
+        &self,
+        server_id: &str,
+        kind: &super::capability_dispatcher::ToolKind,
+        args: Value,
+    ) -> Result<super::mcp_protocol::CallToolResult> {
+        self.call_server_tool(server_id, kind.name(), args).await
+    }
+
+    /// Streaming counterpart of [`call_kind`].
+    pub async fn call_kind_streaming(
+        &self,
+        kind: &super::capability_dispatcher::ToolKind,
+        args: Value,
+    ) -> Result<(
+        tokio::sync::mpsc::Receiver<Value>,
+        tokio::sync::oneshot::Receiver<Result<super::mcp_protocol::CallToolResult>>,
+    )> {
+        let (server_id, _) = self.dispatcher.resolve_kind(kind).await.ok_or_else(|| {
+            anyhow::anyhow!("No server provides ToolKind for tool '{}'", kind.name())
+        })?;
+        self.call_server_tool_streaming(&server_id, kind.name(), args)
+            .await
+    }
+
+    /// Streaming counterpart of [`call_kind_at`].
+    pub async fn call_kind_streaming_at(
+        &self,
+        server_id: &str,
+        kind: &super::capability_dispatcher::ToolKind,
+        args: Value,
+    ) -> Result<(
+        tokio::sync::mpsc::Receiver<Value>,
+        tokio::sync::oneshot::Receiver<Result<super::mcp_protocol::CallToolResult>>,
+    )> {
+        self.call_server_tool_streaming(server_id, kind.name(), args)
+            .await
+    }
+
+    /// Whether any registered server provides this [`ToolKind`].
+    pub async fn has_kind(&self, kind: &super::capability_dispatcher::ToolKind) -> bool {
+        self.dispatcher.has_kind(kind).await
+    }
+
+    /// Whether `server_id` specifically lists this [`ToolKind`] in its tool index.
+    /// Equivalent to `has_server_tool(server_id, kind.name())`.
+    pub async fn has_kind_at(
+        &self,
+        server_id: &str,
+        kind: &super::capability_dispatcher::ToolKind,
+    ) -> bool {
+        self.has_server_tool(server_id, kind.name()).await
     }
 
     /// Check whether any connected memory server provides the named tool.

--- a/crates/core/src/managers/mcp_mgp.rs
+++ b/crates/core/src/managers/mcp_mgp.rs
@@ -394,6 +394,18 @@ pub struct MgpServerCapabilities {
     /// Permissions the server declares it requires (§3).
     #[serde(default)]
     pub permissions_required: Vec<String>,
+    /// ClotoCore vendor extension (Pattern-C, 0.6.8-alpha.2): explicit
+    /// capability→tool mapping. Keys are `CapabilityType` Display strings
+    /// (`"Memory" | "Reasoning" | "Vision" | "Stt" | "Speech"`).
+    ///
+    /// When present, the kernel uses this to build `CapabilityDispatcher`
+    /// entries directly (manifest-driven). When absent, the kernel falls
+    /// back to the legacy `classify_tool` heuristic for backward compatibility.
+    ///
+    /// Targeted for spec formalization in MGP 0.7.0 Layered Manifest §
+    /// (Layer 1/2 schema).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools_for_capability: Option<std::collections::HashMap<String, Vec<String>>>,
 }
 
 /// Result of MGP capability negotiation, stored in `McpServerHandle`.
@@ -738,6 +750,7 @@ mod tests {
             server_id: Some("test".to_string()),
             trust_level: Some("standard".to_string()),
             permissions_required: Vec::new(),
+            tools_for_capability: None,
         };
         let result = negotiate(Some(&server), None).unwrap();
         // Tier 2: both tool_security and permissions are now in CLIENT_EXTENSIONS
@@ -759,6 +772,7 @@ mod tests {
             server_id: None,
             trust_level: Some("core".to_string()),
             permissions_required: Vec::new(),
+            tools_for_capability: None,
         };
         // Config says experimental, server says core → config wins
         let result = negotiate(Some(&server), Some("experimental")).unwrap();
@@ -889,5 +903,65 @@ mod tests {
         let json = err.to_json_rpc_error();
         assert_eq!(json["data"]["_mgp"]["retryable"], false);
         assert_eq!(json["data"]["_mgp"]["category"], "permission");
+    }
+
+    // ============================================================
+    // Pattern-C tools_for_capability tests (0.6.8-alpha.2)
+    // ============================================================
+
+    #[test]
+    fn tools_for_capability_round_trip() {
+        use std::collections::HashMap;
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        map.insert(
+            "Memory".to_string(),
+            vec!["store".to_string(), "recall".to_string()],
+        );
+        map.insert("Reasoning".to_string(), vec!["think".to_string()]);
+
+        let caps = MgpServerCapabilities {
+            version: "0.6.3".to_string(),
+            extensions: vec![],
+            server_id: None,
+            trust_level: None,
+            permissions_required: vec![],
+            tools_for_capability: Some(map.clone()),
+        };
+
+        let json = serde_json::to_string(&caps).unwrap();
+        let decoded: MgpServerCapabilities = serde_json::from_str(&json).unwrap();
+        let decoded_map = decoded
+            .tools_for_capability
+            .expect("field round-trips as Some");
+        assert_eq!(decoded_map.get("Memory"), map.get("Memory"));
+        assert_eq!(decoded_map.get("Reasoning"), map.get("Reasoning"));
+    }
+
+    #[test]
+    fn tools_for_capability_absent_serialize() {
+        let caps = MgpServerCapabilities {
+            version: "0.6.3".to_string(),
+            extensions: vec![],
+            server_id: None,
+            trust_level: None,
+            permissions_required: vec![],
+            tools_for_capability: None,
+        };
+        let json = serde_json::to_string(&caps).unwrap();
+        // skip_serializing_if = "Option::is_none" suppresses the field entirely
+        // so legacy servers that never see this extension keep their wire format.
+        assert!(
+            !json.contains("tools_for_capability"),
+            "absent field should not appear in JSON, got: {json}"
+        );
+    }
+
+    #[test]
+    fn tools_for_capability_default_when_absent_in_input() {
+        // serde(default) lets us decode legacy server responses (no field)
+        // and get None — backward compatibility for existing servers.
+        let json = r#"{"version":"0.6.3"}"#;
+        let caps: MgpServerCapabilities = serde_json::from_str(json).unwrap();
+        assert!(caps.tools_for_capability.is_none());
     }
 }

--- a/crates/core/src/managers/mod.rs
+++ b/crates/core/src/managers/mod.rs
@@ -31,7 +31,7 @@ pub mod token_budget;
 pub mod usage_tracker;
 
 pub use agents::AgentManager;
-pub use capability_dispatcher::{CapabilityDispatcher, CapabilityType};
+pub use capability_dispatcher::{CapabilityDispatcher, CapabilityType, ToolKind};
 pub use mcp::McpClientManager;
 pub use plugin::PluginManager;
 pub use registry::{PluginRegistry, PluginSetting, SystemMetrics};

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloto_dashboard",
-  "version": "0.6.8-alpha.1",
+  "version": "0.6.8-alpha.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard/src-tauri/tauri.conf.json
+++ b/dashboard/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ClotoCore",
-  "version": "0.6.8-alpha.1",
+  "version": "0.6.8-alpha.2",
   "identifier": "com.cloto.app",
   "build": {
     "frontendDist": "../dist",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,35 @@ Versioning follows the project's phase scheme: Alpha (A), Beta (βX.Y = 0.X.Y), 
 
 ---
 
+## [0.6.8-alpha.2] — 2026-05-28
+
+Pattern-C capability tool name registry. Second prerelease in the 0.6.8 line; like alpha.1, deliberately published on the alpha channel so existing stable installs do not receive an in-app upgrade prompt. This release lands the structural refactor planned as PR #1 in Goal #49 — the kernel no longer hard-codes MCP tool names as string literals in `handlers/system.rs`. It is the α→β promotion-criterion piece for the 0.6.8 line (per Scope #12).
+
+### Added
+
+- **`ToolKind` enum** (`crates/core/src/managers/capability_dispatcher.rs`) — 11 well-known tool variants (`Store`, `Recall`, `ListMemories`, `ListEpisodes`, `ArchiveEpisode`, `UpdateProfile`, `Think`, `ThinkWithTools`, `AnalyzeImage`, `Transcribe`, `Speak`) plus `Custom(String)` escape hatch for non-well-known tools.
+- **`CapabilityType::Display` / `FromStr`** — single source of truth for the JSON keys (`"Memory" | "Reasoning" | "Vision" | "Stt" | "Speech"`) used both by the new `build_from_capabilities` ingest path and by server-side `tools_for_capability` declarations.
+- **`MgpServerCapabilities.tools_for_capability`** vendor extension (`Option<HashMap<String, Vec<String>>>`) — MCP servers can now explicitly declare which tools they expose under each capability, overriding the kernel's heuristic `classify_tool` fallback. Targeted for spec formalization in MGP 0.7.0 (Layered Manifest Layer 1/2, see mgp-spec Goal #70).
+- **`McpClientManager` ToolKind shims** (`call_kind`, `call_kind_at`, `call_kind_streaming`, `call_kind_streaming_at`, `has_kind`, `has_kind_at`) — typed entry points that keep handlers/ free of tool name string literals.
+- **Tests** — 7 new unit tests in `capability_dispatcher.rs` (round-trip, capability mapping consistency, cross-capability rejection, Custom fallback, Display round-trip) and 3 serde tests in `mcp_mgp.rs` for the new field.
+
+### Changed
+
+- **`handlers/system.rs`** — 17 call sites swapped from string-literal tool names to `ToolKind` (categories: 11 direct `call_server_tool`, 1 `has_server_tool`, 3 `call_capability_tool` arg literal, 1 streaming, 1 event-dispatch string comparison). The `get_profile` tool, which is not in any well-known capability whitelist, uses `ToolKind::Custom("get_profile".to_string())` with an explicit `server_id` (escape-hatch convention).
+- **MCP handshake flow** (`crates/core/src/managers/mcp.rs:1417`) — capability mappings are now built from the server's `tools_for_capability` manifest when present, falling back to the legacy `classify_tool` heuristic only for backward compatibility with servers that have not adopted the extension. **No behavior change for current servers** — none emit the field yet.
+
+### Fixed
+
+- **bug-289** (HIGH P2): `"think_with_tools"` literal no longer present in `crates/core/src/handlers/system.rs`. Tool name dispatched via `ToolKind::ThinkWithTools` through `call_kind_at` / `has_kind_at` / `call_kind_streaming_at` shims.
+- **bug-290** (HIGH P2): `"archive_episode"` (and the rest of the Memory-capability literals — `store`, `recall`, `list_memories`, `list_episodes`, `update_profile`) no longer present. ARCHITECTURE.md §1.2 Capability-over-Concrete-Type compliance restored for these dispatch paths.
+
+### Known limitations
+
+- `classify_tool` private fallback list remains in `capability_dispatcher.rs` for servers that have not declared `tools_for_capability`. Removal is scheduled for 0.6.9+ once every shipped server has adopted the manifest path. Server-prefix heuristics (`memory.*`, `mind.*`, `vision.*`, `stt.*`, `output.*`) are also still present and tracked separately under §1.2 audit.
+- bug-282 / bug-285 / bug-293 / bug-296 (other §1.2 violations from the Goal #49 5-PR plan) are unaffected by this release and remain open.
+
+---
+
 ## [0.6.8-alpha.1] — 2026-05-27
 
 Verify automation MVP release. First prerelease in the 0.6.8 line, deliberately published on the alpha channel so that the Tauri Updater (which resolves `latest.json` via `/releases/latest/download/` and therefore skips entries flagged `prerelease`) does NOT push it to existing stable installs. Production `v0.6.7` users will not see an in-app upgrade prompt; the alpha is reachable only via manual download from the Releases page. This structural isolation is exploited intentionally so verify automation regressions cannot realize on production user machines while the automation itself is being iterated.

--- a/docs/MCP_PLUGIN_ARCHITECTURE.md
+++ b/docs/MCP_PLUGIN_ARCHITECTURE.md
@@ -188,6 +188,49 @@ access control policies (§5). They are excluded from LLM tool context by
 default per MGP §1.6.3 visibility rules for administrative tools, and
 are surfaced to operators via the dashboard or programmatic API.
 
+#### `tools_for_capability` (capability declaration, vendor extension)
+
+ClotoCore vendor extension on `MgpServerCapabilities`, added in ClotoCore
+`0.6.8-alpha.2` (Pattern-C, Goal #72). Lets MCP servers explicitly declare
+which tools they expose under each ClotoCore `CapabilityType`, overriding
+the kernel's heuristic `classify_tool` fallback.
+
+**Field**: `tools_for_capability?: Map<CapabilityName, Array<ToolName>>`
+attached to the `MgpServerCapabilities` payload returned in the MGP
+`initialize` response.
+
+**JSON example** (excerpt from a memory server's `initialize` reply):
+
+```json
+{
+  "capabilities": {
+    "mgp": {
+      "version": "0.6.3",
+      "extensions": ["tool_security", "permissions"],
+      "tools_for_capability": {
+        "Memory": ["store", "recall", "list_memories", "archive_episode"]
+      }
+    }
+  }
+}
+```
+
+**CapabilityName** ∈ `"Memory" | "Reasoning" | "Vision" | "Stt" | "Speech"`.
+Unknown keys are logged and skipped (kernel never invents capabilities from
+arbitrary server strings).
+
+**Precedence**: When present, `tools_for_capability` is authoritative —
+the kernel uses it to build `CapabilityDispatcher` entries directly and
+does **not** consult its built-in `classify_tool` server-prefix /
+tool-name heuristic for that server. Absent field falls back to the
+heuristic, which keeps existing servers working without modification.
+
+This extension is targeted for spec formalization in **MGP 0.7.0** as part
+of the Layered Manifest provisioning section (Layer 1/2 schema). Until
+then it remains a ClotoCore-specific vendor extension. See
+[mgp-spec](https://github.com/Cloto-dev/mgp-spec) for the canonical
+specification roadmap.
+
 ### 3.3 Legacy Trait to MCP Tool Mapping
 
 #### ReasoningEngine → MCP Tools

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -1671,8 +1671,10 @@
       "commit": "8c09a10",
       "file": "crates/core/src/handlers/system.rs",
       "pattern": "\"think_with_tools\"",
-      "expected": "present",
-      "status": "open"
+      "expected": "absent",
+      "status": "fixed",
+      "fixed_in": "0.6.8-alpha.2",
+      "fix_note": "Pattern-C (Goal #72): replaced literals with ToolKind::ThinkWithTools via call_kind_at / has_kind_at / call_kind_streaming_at shims."
     },
     {
       "id": "bug-290",
@@ -1683,8 +1685,10 @@
       "commit": "8c09a10",
       "file": "crates/core/src/handlers/system.rs",
       "pattern": "\"archive_episode\"",
-      "expected": "present",
-      "status": "open"
+      "expected": "absent",
+      "status": "fixed",
+      "fixed_in": "0.6.8-alpha.2",
+      "fix_note": "Pattern-C (Goal #72): tool names typed via ToolKind enum (Store, Recall, ListMemories, ListEpisodes, ArchiveEpisode, UpdateProfile). get_profile uses ToolKind::Custom escape hatch."
     },
     {
       "id": "bug-291",


### PR DESCRIPTION
## Summary
- Land PR #1 from Goal #49's plan-file (`linear-snacking-blum.md`) as a single 0.6.8-alpha.2 prerelease.
- Kernel `handlers/system.rs` no longer carries MCP tool name string literals — every call site dispatches through a typed `ToolKind` enum, restoring ARCHITECTURE.md §1.2 (Capability over Concrete Type) for these dispatch paths.
- α→β promotion piece for the 0.6.8 line (Scope #12). bug-289 and bug-290 close to `[FIXED]`.

## What changed
**Added (`capability_dispatcher.rs`)** — `ToolKind` enum (11 well-known variants + `Custom(String)`), `CapabilityType::Display`/`FromStr`, `resolve_kind` / `has_kind` / `build_from_capabilities`.

**Added (`mcp_mgp.rs`)** — `MgpServerCapabilities.tools_for_capability: Option<HashMap<String, Vec<String>>>` vendor extension. Servers can now declare capability→tool mappings explicitly. Targeted for MGP 0.7.0 Layered Manifest formalization (mgp-spec Goal #70).

**Added (`mcp.rs`)** — 6 typed shims: `call_kind` / `call_kind_at` / `call_kind_streaming` / `call_kind_streaming_at` / `has_kind` / `has_kind_at`. `*_kind` for dispatcher-resolved calls, `*_kind_at` for explicit `server_id` (engine_id override, `Custom` variants).

**Changed (`handlers/system.rs`)** — 17 call sites swapped from string literals to `ToolKind` (11 direct `call_server_tool`, 1 `has_server_tool`, 3 `call_capability_tool` arg literal, 1 streaming, 1 event-dispatch string comparison). `get_profile` uses `ToolKind::Custom("get_profile")` with explicit `server_id`.

**Changed (`mcp.rs:1417`)** — handshake flow: `tools_for_capability` manifest takes precedence over `classify_tool` heuristic. Absent field falls back. **No behavior change for any current server** (none emit the field yet).

## Bugs fixed
- **bug-289** (HIGH P2): `"think_with_tools"` literal removed. `verify-issues.sh` → `[FIXED]`.
- **bug-290** (HIGH P2): `"archive_episode"` (and the rest of the Memory-capability literals) removed. `verify-issues.sh` → `[FIXED]`.

## Tests
- 7 new unit tests in `capability_dispatcher.rs` (round-trip, capability mapping consistency, cross-capability rejection, Custom fallback, Display round-trip).
- 3 new serde tests in `mcp_mgp.rs` (round-trip, absent-suppress, default-when-absent).
- 262 lib tests + integration tests passing, no regressions.

## Test plan
- [ ] CI: `cargo clippy --workspace --exclude app -- -D warnings ...` (full CI invocation) green
- [ ] CI: `cargo fmt --all -- --check` green
- [ ] CI: `cargo test --workspace --exclude app` green
- [ ] CI: `bash scripts/verify-issues.sh` — bug-289 / bug-290 both `[FIXED]`
- [ ] CI: Goal #68 NSIS hook gate runs (and passes; this PR is non-NSIS-touching)
- [ ] CI: nsis-touching-detect labels this PR as non-NSIS-touching (no label, no Sandbox verify required)
- [ ] post-merge: `gh workflow run release.yml --ref master -f version=0.6.8-alpha.2 -f draft_only=false`
- [ ] post-release: `gh api /releases/latest` confirms stable tag (0.6.7) unchanged (channel isolation)

## Known limitations
- `classify_tool` private fallback list remains in `capability_dispatcher.rs` for backward compatibility with servers that have not adopted the manifest path. Removal scheduled for 0.6.9+.
- bug-282 / bug-285 / bug-293 / bug-296 (other §1.2 violations from the Goal #49 5-PR plan) are unaffected by this release.

Release channel: alpha (Tauri Updater stable-only resolve keeps production 0.6.7 users from seeing an upgrade prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)