### PR TITLE
fix(0.6.8-alpha.3): verify script — cmd.exe nested quote stripping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.6.8-alpha.2"
+version = "0.6.8-alpha.3"
 dependencies = [
  "base64 0.21.7",
  "cloto_core",
@@ -1139,7 +1139,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cloto_core"
-version = "0.6.8-alpha.2"
+version = "0.6.8-alpha.3"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "cloto_shared"
-version = "0.6.8-alpha.2"
+version = "0.6.8-alpha.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.8-alpha.2"
+version = "0.6.8-alpha.3"
 edition = "2021"
 authors = ["ClotoCore <ClotoCore@proton.me>"]
 license = "BSL-1.1"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloto_dashboard",
-  "version": "0.6.8-alpha.2",
+  "version": "0.6.8-alpha.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard/src-tauri/tauri.conf.json
+++ b/dashboard/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ClotoCore",
-  "version": "0.6.8-alpha.2",
+  "version": "0.6.8-alpha.3",
   "identifier": "com.cloto.app",
   "build": {
     "frontendDist": "../dist",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,24 @@ Versioning follows the project's phase scheme: Alpha (A), Beta (βX.Y = 0.X.Y), 
 
 ---
 
+## [0.6.8-alpha.3] — 2026-05-28
+
+Verify-automation hardening. Third prerelease in the 0.6.8 line, published on the alpha channel. Pure infrastructure / tooling fix discovered during the first end-to-end run of `scripts/proxmox-windows-verify.sh` after `v0.6.8-alpha.2` published. No kernel / dashboard / installer behaviour changes.
+
+### Fixed
+
+- **`scripts/proxmox-windows-verify.sh`** — `capture_fingerprint()` was passing the PowerShell `FINGERPRINT_PS` heredoc through a doubly-nested `"…\"…\""` quote chain. Windows OpenSSH delivers remote commands through cmd.exe, which strips inner quotes the heredoc relied on for path strings like `"C:\Program Files\cloto-system"`. PowerShell then parsed `Test-Path C:\Program Files\cloto-system` as `Test-Path C:\Program` plus an unrecognized positional `Files\cloto-system`, aborting the fingerprint with a `PositionalParameterNotFound` error. Fix: switch literal paths to PowerShell single quotes, use `Join-Path` for `$env:APPDATA` derivations, and ship the entire payload via `powershell -EncodedCommand` (Base64 UTF-16LE) so cmd.exe sees no special characters at all.
+
+### Verified
+
+- End-to-end Sandbox verify for `v0.6.7 → v0.6.8-alpha.2` upgrade path on Proxmox VM 104:
+  - **8/8 assertions PASS** (NO-OP hook path — Tauri default upgrade flow, no legacy migration needed).
+  - **Data preservation confirmed**: dummy `cloto_memories.db` SHA-256 unchanged across upgrade.
+  - **Wall clock: ~6 min 20 s** (rollback → guest SSH → download FROM → seed DB → silent install FROM → PRE fingerprint → download TO → silent install TO → POST fingerprint → assertion), well under the Scope #12 α→β promotion criterion of 20 min.
+- Together with Goal #72 (Pattern-C, landed in `0.6.8-alpha.2`) and Goal #68 verify automation (`0.6.8-alpha.1`), this satisfies all three α→β promotion criteria. The 0.6.8 line is eligible for beta.1 promotion.
+
+---
+
 ## [0.6.8-alpha.2] — 2026-05-28
 
 Pattern-C capability tool name registry. Second prerelease in the 0.6.8 line; like alpha.1, deliberately published on the alpha channel so existing stable installs do not receive an in-app upgrade prompt. This release lands the structural refactor planned as PR #1 in Goal #49 — the kernel no longer hard-codes MCP tool names as string literals in `handlers/system.rs`. It is the α→β promotion-criterion piece for the 0.6.8 line (per Scope #12).

--- a/scripts/proxmox-windows-verify.sh
+++ b/scripts/proxmox-windows-verify.sh
@@ -91,22 +91,29 @@ resolve_asset() {
 }
 
 # PowerShell heredoc → JSON fingerprint of the install state.
+# Uses PowerShell single quotes + Join-Path to avoid nested double-quote stripping
+# by the Windows OpenSSH default shell (cmd.exe) en route to powershell.exe.
 FINGERPRINT_PS=$(cat <<'PS'
+$dbPath = Join-Path $env:APPDATA 'cloto-system\cloto_memories.db'
 @{
-  dbHash = if (Test-Path "$env:APPDATA\cloto-system\cloto_memories.db") { (Get-FileHash "$env:APPDATA\cloto-system\cloto_memories.db" -Algorithm SHA256).Hash } else { $null }
-  legacyDir_cloto_system = Test-Path "C:\Program Files\cloto-system"
-  legacyDir_ClotoCore    = Test-Path "C:\Program Files\ClotoCore"
-  uninstallKey_HKLM_cloto_system = [bool](Get-ItemProperty "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\cloto-system" -ErrorAction SilentlyContinue)
-  uninstallKey_HKLM_ClotoCore    = [bool](Get-ItemProperty "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\ClotoCore" -ErrorAction SilentlyContinue)
-  uninstallKey_HKCU_cloto_system = [bool](Get-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\cloto-system" -ErrorAction SilentlyContinue)
-  uninstallKey_HKCU_ClotoCore    = [bool](Get-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\ClotoCore" -ErrorAction SilentlyContinue)
-  installedVersion = (Get-ItemProperty "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\ClotoCore" DisplayVersion -ErrorAction SilentlyContinue).DisplayVersion
+  dbHash = if (Test-Path $dbPath) { (Get-FileHash $dbPath -Algorithm SHA256).Hash } else { $null }
+  legacyDir_cloto_system = Test-Path 'C:\Program Files\cloto-system'
+  legacyDir_ClotoCore    = Test-Path 'C:\Program Files\ClotoCore'
+  uninstallKey_HKLM_cloto_system = [bool](Get-ItemProperty 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\cloto-system' -ErrorAction SilentlyContinue)
+  uninstallKey_HKLM_ClotoCore    = [bool](Get-ItemProperty 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\ClotoCore' -ErrorAction SilentlyContinue)
+  uninstallKey_HKCU_cloto_system = [bool](Get-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\cloto-system' -ErrorAction SilentlyContinue)
+  uninstallKey_HKCU_ClotoCore    = [bool](Get-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\ClotoCore' -ErrorAction SilentlyContinue)
+  installedVersion = (Get-ItemProperty 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\ClotoCore' DisplayVersion -ErrorAction SilentlyContinue).DisplayVersion
 } | ConvertTo-Json -Compress
 PS
 )
 
+# Send the PowerShell payload to the guest via -EncodedCommand to immunize it
+# against cmd.exe nested-quote handling on the Windows OpenSSH side.
+FINGERPRINT_PS_B64=$(printf '%s' "$FINGERPRINT_PS" | iconv -f UTF-8 -t UTF-16LE | base64 | tr -d '\n')
+
 capture_fingerprint() {
-  $VM "powershell -NoProfile -Command \"$FINGERPRINT_PS\""
+  $VM "powershell -NoProfile -EncodedCommand $FINGERPRINT_PS_B64"
 }
 
 # ─── 1. rollback + cold boot ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `scripts/proxmox-windows-verify.sh` (Goal #68 Piece 2) had a Windows OpenSSH + cmd.exe nested quote stripping bug that made `capture_fingerprint()` fail with `PositionalParameterNotFound` on the `Test-Path C:\Program Files\cloto-system` line.
- Discovered on the **first end-to-end run** of the script during Sandbox manual verify of v0.6.7 → v0.6.8-alpha.2 (after Goal #72 landed). Pieces 1 + 3 are CI-gated; Piece 2 had no E2E test until now.
- Pure infra / tooling fix — no kernel / dashboard / installer behaviour changes.

## Fix
- Literal paths switched to PowerShell **single quotes** (`'C:\Program Files\cloto-system'`) — cmd.exe doesn't process single quotes.
- `$env:APPDATA` derivations use `Join-Path` so no inner double quotes are needed for variable expansion.
- Entire payload now shipped via `powershell -EncodedCommand` (Base64 UTF-16LE) — cmd.exe sees no special characters at all, making the delivery immune to future heredoc edits.

## Verified (post-fix)
End-to-end Sandbox verify, Proxmox VM 104, v0.6.7 → v0.6.8-alpha.2:
- **8/8 assertions PASS** (NO-OP hook path, Tauri default upgrade flow).
- **Data preservation**: dummy `cloto_memories.db` SHA-256 identical pre/post (`22794FD175FF33EAFC4B2BF1977B4C41A939BCCCB6AC6A12C0FF9CEF84C84E8A`).
- **Wall clock**: 6 min 20 s (well under Scope #12 α→β promotion criterion of 20 min).

## α→β promotion impact
Together with Goal #72 (Pattern-C in 0.6.8-alpha.2) and Goal #68 verify automation (0.6.8-alpha.1), this satisfies **all three** α→β promotion criteria for Scope #12. The 0.6.8 line is eligible for beta.1 promotion after the soak period.

## Test plan
- [ ] CI: clippy / fmt / test all green (no code change in cloto_core, scripts/-only)
- [ ] CI: `bash scripts/verify-issues.sh` — no regression in registry (this PR doesn't touch the registry)
- [ ] CI: Goal #68 NSIS Hook Gate passes (this PR is non-NSIS-touching)
- [ ] CI: nsis-touching-detect labels this PR as non-NSIS-touching (no label, no Sandbox verify required pre-merge — this PR IS the Sandbox verify fix)
- [ ] post-merge: `gh workflow run release.yml --ref master -f version=0.6.8-alpha.3 -f draft_only=false` for α channel publish
- [ ] post-release: `gh api /releases/latest` confirms stable tag (0.6.7) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)