### PR TITLE
refactor(marketplace): prepare for clotohub-servers monorepo rename (Phase 4)

### DIFF
--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -1,5 +1,6 @@
 //! Marketplace endpoints for discovering and installing MCP servers
-//! from the cloto-mcp-servers registry.
+//! from the ClotoHub catalog (legacy: the clotohub-servers registry,
+//! formerly named cloto-mcp-servers).
 
 use axum::{
     extract::{ConnectInfo, Path, Query, State},
@@ -61,10 +62,14 @@ const DEFAULT_CATALOG_URL: &str = "https://hub.cloto.dev/api/catalog";
 /// entries served by ClotoHub.dev dispatch through `run_install`
 /// (`install.source: Git/RawUrl/Pypi/Docker`) and never hit this
 /// template — it is preserved only so a `CLOTO_CATALOG_URL` override
-/// pointing back at the legacy `cloto-mcp-servers` registry still
-/// resolves correctly. Overridable via `CLOTO_TARBALL_URL_TEMPLATE`.
+/// pointing back at the legacy registry still resolves correctly.
+/// Overridable via `CLOTO_TARBALL_URL_TEMPLATE`. Phase 4 renamed the
+/// monorepo `cloto-mcp-servers` → `clotohub-servers` and made it
+/// private, so the default below only works with authenticated access;
+/// unauthenticated dev overrides must point `CLOTO_TARBALL_URL_TEMPLATE`
+/// at a reachable mirror.
 const DEFAULT_TARBALL_URL_TEMPLATE: &str =
-    "https://api.github.com/repos/Cloto-dev/cloto-mcp-servers/tarball/{ref}";
+    "https://api.github.com/repos/Cloto-dev/clotohub-servers/tarball/{ref}";
 
 /// Resolve the marketplace catalog URL, honoring `CLOTO_CATALOG_URL` if set.
 fn catalog_url() -> String {
@@ -749,7 +754,7 @@ fn rust_binary_path(server_path: &std::path::Path, entry: &RegistryEntry) -> Pat
 
 /// Dispatch a marketplace install based on the catalog entry's
 /// `install.source`. `None` falls back to the legacy
-/// `cloto-mcp-servers` monorepo tarball path so pre-v0.2 registries keep
+/// `clotohub-servers` monorepo tarball path so pre-v0.2 registries keep
 /// working unchanged. Per-source installers handle materialization, then
 /// share [`build_and_register`] / [`register_server`] for the toolchain
 /// + add_server + auto_start steps.
@@ -1214,7 +1219,7 @@ async fn bind_default_memory_if_unset(
     Ok(())
 }
 
-/// Legacy install path: download the entire `cloto-mcp-servers` monorepo
+/// Legacy install path: download the entire `clotohub-servers` monorepo
 /// tarball, selectively extract `{entry.directory}/` (plus `common/` if
 /// depended on), then build_and_register. Used when the catalog entry
 /// carries no per-entry `install.source` block — preserves backward
@@ -2033,7 +2038,8 @@ fn validate_dest_path(target_dir: &std::path::Path, dest: &std::path::Path) -> a
 }
 
 /// Extract specific directories from a GitHub tarball.
-/// GitHub tarballs have a prefix like `Cloto-dev-cloto-mcp-servers-{sha}/`.
+/// GitHub tarballs have a prefix like `Cloto-dev-clotohub-servers-{sha}/`
+/// (matching is suffix-based, so the repo name does not matter).
 fn extract_selective(
     archive_path: &std::path::Path,
     target_dir: &std::path::Path,

--- a/crates/core/src/handlers/system.rs
+++ b/crates/core/src/handlers/system.rs
@@ -2097,7 +2097,7 @@ impl SystemHandler {
     /// Record the `usage` block returned by a mind MCP server into the
     /// per-agent [`UsageStore`] so the dashboard can display "used / max".
     /// Silently no-ops when the MCP server didn't include usage (older
-    /// cloto-mcp-servers versions, or non-final responses) — we don't want a
+    /// clotohub-servers builds, or non-final responses) — we don't want a
     /// missing counter to produce log noise on every turn.
     async fn maybe_record_usage(
         &self,

--- a/crates/core/src/installer.rs
+++ b/crates/core/src/installer.rs
@@ -77,9 +77,9 @@ DATABASE_URL=sqlite:{db_path}
 # CORS_ORIGINS=http://localhost:5173
 
 # --- MCP Servers ---
-# Path to cloto-mcp-servers/servers directory.
+# Path to clotohub-servers/servers directory.
 # Required for MCP server auto-discovery from mcp.toml.
-# CLOTO_MCP_SERVERS=C:\path\to\cloto-mcp-servers\servers
+# CLOTO_MCP_SERVERS=C:\path\to\clotohub-servers\servers
 
 # --- Plugin Network Access (Principle #5) ---
 # Additional hosts that plugins with NetworkAccess permission may reach.

--- a/crates/core/src/managers/mcp.rs
+++ b/crates/core/src/managers/mcp.rs
@@ -469,7 +469,7 @@ impl McpClientManager {
 
         // Build path variables from [paths] section.
         // Values may themselves reference env vars: ${ENV_VAR_NAME}
-        // Special case: CLOTO_MCP_SERVERS defaults to ../cloto-mcp-servers/servers
+        // Special case: CLOTO_MCP_SERVERS defaults to ../clotohub-servers/servers
         // (resolved against project root) when the env var is not set.
         let path_vars: HashMap<String, String> = config
             .paths
@@ -2998,7 +2998,10 @@ impl McpClientManager {
                 exe_parent.to_path_buf()
             }
         };
-        if exe_dir.join("cloto-mcp-servers").exists() || exe_dir.join("mcp-servers").exists() {
+        if exe_dir.join("clotohub-servers").exists()
+            || exe_dir.join("cloto-mcp-servers").exists()
+            || exe_dir.join("mcp-servers").exists()
+        {
             return Some(exe_dir);
         }
         None
@@ -3031,9 +3034,10 @@ impl McpClientManager {
 ///
 /// Search order (first existing wins):
 /// 1. `base_dir/mcp-servers` — setup wizard install layout (production)
-/// 2. `base_dir/cloto-mcp-servers/servers` — bundled alongside `mcp.toml`
-/// 3. `base_dir/../cloto-mcp-servers/servers` — sibling repo (development)
-/// 4. `exe_dir/mcp-servers/servers` — legacy bundled layout
+/// 2. `base_dir/clotohub-servers/servers` — bundled alongside `mcp.toml`
+/// 3. `base_dir/../clotohub-servers/servers` — sibling repo (development)
+/// 4. legacy `cloto-mcp-servers` variants of 2/3 — pre-rename checkouts
+/// 5. `exe_dir/mcp-servers/servers` — legacy bundled layout
 ///
 /// Fallback (none exist): `base_dir/mcp-servers` — the setup wizard will
 /// create this directory later, so CONFIG server paths resolve correctly
@@ -3042,6 +3046,8 @@ fn resolve_mcp_servers_dir(base_dir: &std::path::Path) -> String {
     let production = base_dir.join("mcp-servers");
     let candidates = [
         &production,
+        &base_dir.join("clotohub-servers/servers"),
+        &base_dir.join("../clotohub-servers/servers"),
         &base_dir.join("cloto-mcp-servers/servers"),
         &base_dir.join("../cloto-mcp-servers/servers"),
         &crate::config::exe_dir().join("mcp-servers/servers"),

--- a/crates/core/src/managers/mcp_protocol.rs
+++ b/crates/core/src/managers/mcp_protocol.rs
@@ -333,7 +333,7 @@ impl McpServerConfig {
 #[derive(Debug, Deserialize)]
 pub struct McpConfigFile {
     /// Path variables for resolving `${var}` in server args/command.
-    /// Example: `[paths] servers = "C:/path/to/cloto-mcp-servers/servers"`
+    /// Example: `[paths] servers = "C:/path/to/clotohub-servers/servers"`
     #[serde(default)]
     pub paths: std::collections::HashMap<String, String>,
     #[serde(default)]

--- a/crates/core/src/managers/mcp_venv.rs
+++ b/crates/core/src/managers/mcp_venv.rs
@@ -27,7 +27,8 @@ fn resolve_project_root() -> Option<PathBuf> {
 
 /// Resolve the MCP servers directory.
 /// Primary: `{data_dir}/mcp-servers` (production).
-/// Fallback: `CLOTO_MCP_SERVERS` env var, then `../cloto-mcp-servers/servers` relative to project root (dev).
+/// Fallback: `CLOTO_MCP_SERVERS` env var, then `../clotohub-servers/servers`
+/// (legacy: `../cloto-mcp-servers/servers`) relative to project root (dev).
 #[must_use]
 pub fn resolve_servers_dir_from_config() -> Option<PathBuf> {
     // 1. Production: {data_dir}/mcp-servers
@@ -42,11 +43,14 @@ pub fn resolve_servers_dir_from_config() -> Option<PathBuf> {
             return Some(p);
         }
     }
-    // 3. Dev: ../cloto-mcp-servers/servers relative to project root
+    // 3. Dev: ../clotohub-servers/servers relative to project root
+    //    (legacy name cloto-mcp-servers still probed for pre-rename checkouts)
     if let Some(root) = resolve_project_root() {
-        let dev_path = root.join("..").join("cloto-mcp-servers").join("servers");
-        if dev_path.is_dir() {
-            return Some(dev_path);
+        for repo_name in ["clotohub-servers", "cloto-mcp-servers"] {
+            let dev_path = root.join("..").join(repo_name).join("servers");
+            if dev_path.is_dir() {
+                return Some(dev_path);
+            }
         }
     }
     None


### PR DESCRIPTION
## Summary

ClotoHub Phase 4 Sub 4-4 sweep. The MCP servers monorepo was renamed `cloto-mcp-servers` → `clotohub-servers` on 2026-06-10 (old URLs redirect; the repo will later go private behind a hub-mediated distribution prerequisite).

- `DEFAULT_TARBALL_URL_TEMPLATE` points at `Cloto-dev/clotohub-servers`; the doc comment notes the post-privatization auth caveat for the legacy monorepo install path (production installs go through the ClotoHub catalog and never hit this template)
- `resolve_mcp_servers_dir` / `resolve_servers_dir_from_config` / exe-dir probe check the new `clotohub-servers` directory name first and keep `cloto-mcp-servers` as a transition fallback for pre-rename checkouts
- Comment/template mentions updated (installer `.env` template, `mcp.toml` examples, usage-recording note)

Intentionally kept: the Phase 5d-2 historical note, the `cloto-mcp-servers-latest.tar.gz` temp file name (internal identifier), and `qa/issue-registry.json` prose (point-in-time records).

## Test plan

- `cargo check` clean, `cargo test --workspace --exclude app` green, `cargo fmt` clean
- Local clippy reports 5 pre-existing errors on unmodified master (newer local clippy lints; unrelated to this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)