### PR TITLE
docs: update references for clotohub-servers rename + ClotoHub distribution (Phase 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Read these before making changes. Do not summarize — read the actual files.
 
 - **`docs/PROJECT_VISION.md`** — Core identity, competitive positioning, target users
 - **`docs/ARCHITECTURE.md`** — System architecture, security framework, design principles
-- **`docs/MGP_SPEC.md`** — MGP protocol (strict MCP superset). Servers: [cloto-mcp-servers](https://github.com/Cloto-dev/cloto-mcp-servers)
+- **`docs/MGP_SPEC.md`** — MGP protocol (strict MCP superset). Servers: [clotohub-servers](https://github.com/Cloto-dev/clotohub-servers) (private; formerly cloto-mcp-servers)
 - **`docs/DEVELOPMENT.md`** — 8 critical guardrails (security, cascading, state, storage, UI/UX, physical safety, external processes, privacy)
 
 If a proposed change conflicts with any of these, flag it before proceeding.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,12 +27,12 @@ cargo test
 npm --prefix dashboard ci
 npm --prefix dashboard run build
 
-# Python MCP servers (separate repository)
-git clone https://github.com/Cloto-dev/cloto-mcp-servers.git ../cloto-mcp-servers
-cd ../cloto-mcp-servers/servers
+# Python MCP servers (separate private repository — maintainers only)
+git clone https://github.com/Cloto-dev/clotohub-servers.git ../clotohub-servers
+cd ../clotohub-servers/servers
 python -m venv .venv
-.venv/Scripts/pip install -e cpersona -e embedding   # Windows
-# .venv/bin/pip install -e cpersona -e embedding      # Linux/macOS
+.venv/Scripts/pip install -e embedding   # Windows
+# .venv/bin/pip install -e embedding      # Linux/macOS
 cd -
 ```
 
@@ -52,8 +52,8 @@ All tests must pass before submitting a pull request:
 cargo test --workspace --exclude app
 cargo clippy --workspace --exclude app --all-targets -- -D warnings
 
-# Python MCP (117 tests) — in cloto-mcp-servers repository
-cd ../cloto-mcp-servers/servers && python -m pytest tests/ -v
+# Python MCP — in the private clotohub-servers repository (maintainers only)
+cd ../clotohub-servers/servers && python -m pytest tests/ -v
 
 # Dashboard
 cd dashboard && npm run build
@@ -70,7 +70,7 @@ cd dashboard && npm run build
 - Function length limit: 100 lines (enforced by clippy `too_many_lines`)
 
 ### Python
-- Follow existing patterns in [cloto-mcp-servers](https://github.com/Cloto-dev/cloto-mcp-servers)
+- Follow existing patterns in the clotohub-servers repository (private)
 - Use `ToolRegistry` and `auto_tool()` from `common/mcp_utils.py` for new MCP servers
 - Use validators from `common/validation.py` for argument extraction
 
@@ -85,12 +85,12 @@ cd dashboard && npm run build
 
 ## Adding an MCP Server
 
-MCP servers are maintained in [cloto-mcp-servers](https://github.com/Cloto-dev/cloto-mcp-servers). See that repository's `CLAUDE.md` for setup instructions.
+First-party MCP servers are maintained in the private clotohub-servers repository. Community servers are distributed through the [ClotoHub marketplace](https://hub.cloto.dev) — see the [Quickstart Guide](docs/QUICKSTART_MCP_SERVER.md) to build your own.
 
-1. Create `servers/<name>/server.py` (in cloto-mcp-servers)
+1. Create `servers/<name>/server.py` (in clotohub-servers)
 2. Use `ToolRegistry` from `common/mcp_utils.py` for tool registration
 3. Add the server entry to ClotoCore's `mcp.toml`
-4. Add tests to `servers/tests/` (in cloto-mcp-servers)
+4. Add tests to `servers/tests/` (in clotohub-servers)
 5. Register in `registry.json` and document in `README.md`
 
 See existing servers (e.g., `terminal/server.py`) for reference.

--- a/README.md
+++ b/README.md
@@ -125,13 +125,12 @@ All plugin functionality is delivered via **MCP (Model Context Protocol)** serve
 | `mind.cerebras` | Reasoning | Ultra-high-speed reasoning via Cerebras API |
 | `mind.claude` | Reasoning | Anthropic Claude API (native Messages API) |
 | `mind.ollama` | Reasoning | Local model inference via Ollama |
-| `cpersona` | Memory | [CPersona](https://github.com/Cloto-dev/cloto-mcp-servers/tree/main/servers/cpersona) — persistent memory with RRF hybrid search (vector + FTS5 + keyword), confidence scoring, episodic/profile memory, 16 tools (MIT) |
+| `cpersona` | Memory | [CPersona](https://github.com/Cloto-dev/CPersona) — persistent memory with RRF hybrid search (vector + FTS5 + keyword), confidence scoring, episodic/profile memory, 24 tools (MIT) |
 | `tool.terminal` | Tool | Sandboxed shell command execution |
 | `tool.agent_utils` | Tool | Deterministic utilities (time, math, UUID, hash, etc.) |
 | `tool.cron` | Tool | Stateless CRON job management via kernel REST API |
 | `tool.embedding` | Tool | Vector embedding generation (ONNX: Jina-v5-nano / MiniLM) |
 | `tool.websearch` | Tool | Web search via Tavily or SearXNG |
-| `tool.research` | Tool | Multi-engine research synthesis pipeline |
 | `tool.imagegen` | Tool | Image generation via Stable Diffusion API |
 | `vision.gaze_webcam` | Vision | Eye gaze tracking via MediaPipe |
 | `vision.capture` | Vision | Screen/image analysis via Ollama (hybrid OCR) |
@@ -139,8 +138,8 @@ All plugin functionality is delivered via **MCP (Model Context Protocol)** serve
 | `output.avatar` | Output | VRM expression, idle behavior, and VOICEVOX TTS (Rust) |
 | `io.discord` | I/O | Bidirectional Discord communication via MGP events (Rust) |
 
-MCP servers live in the [cloto-mcp-servers](https://github.com/Cloto-dev/cloto-mcp-servers) repository
-and are configured via `mcp.toml`. See [MCP Plugin Architecture](docs/MCP_PLUGIN_ARCHITECTURE.md) for details.
+First-party MCP servers are maintained in the private clotohub-servers repository and
+distributed via the [ClotoHub marketplace](https://hub.cloto.dev); they are configured via `mcp.toml`. See [MCP Plugin Architecture](docs/MCP_PLUGIN_ARCHITECTURE.md) for details.
 
 **Build your own server:** [Quickstart Guide](docs/QUICKSTART_MCP_SERVER.md) — create a working MCP/MGP server in 5 minutes.
 
@@ -298,7 +297,7 @@ Copy `.env.example` to `.env` to customize. All settings have sensible defaults.
 
 ## Testing
 
-234 Rust tests. MCP server tests (117 Python) are in [cloto-mcp-servers](https://github.com/Cloto-dev/cloto-mcp-servers).
+234 Rust tests. MCP server tests (Python) are in the private clotohub-servers repository.
 
 ```bash
 cargo test                              # all Rust tests
@@ -326,11 +325,11 @@ See [Architecture](docs/ARCHITECTURE.md) for the full security model.
 - [Project Vision](docs/PROJECT_VISION.md) — Strategic direction and roadmap
 - [Development](docs/DEVELOPMENT.md) — Coding standards, guardrails, PR process
 - [MGP Spec](docs/MGP_SPEC.md) — Multi-Agent Gateway Protocol specification
-- [MGP Guide](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_GUIDE.md) — MGP usage guide
-- [MGP Security](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_SECURITY.md) — MGP security model
-- [MGP Isolation](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_ISOLATION_DESIGN.md) — MGP isolation design
-- [MGP Communication](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_COMMUNICATION.md) — MGP communication protocol
-- [MGP Discovery](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_DISCOVERY.md) — MGP service discovery
+- [MGP Guide](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_GUIDE.md) — MGP usage guide
+- [MGP Security](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_SECURITY.md) — MGP security model
+- [MGP Isolation](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_ISOLATION_DESIGN.md) — MGP isolation design
+- [MGP Communication](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_COMMUNICATION.md) — MGP communication protocol
+- [MGP Discovery](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_DISCOVERY.md) — MGP service discovery
 - [MCP Architecture](docs/MCP_PLUGIN_ARCHITECTURE.md) — MCP server communication protocol
 - [CPersona Memory](docs/CPERSONA_MEMORY_DESIGN.md) — Memory system design
 - [Database Schema](docs/SCHEMA.md) — SQLite schema reference

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -353,7 +353,7 @@ MCP servers are independent processes that communicate with the Kernel via JSON-
 For full architecture details, see [MCP Plugin Architecture](MCP_PLUGIN_ARCHITECTURE.md).
 
 **Key characteristics:**
-- Servers maintained in [cloto-mcp-servers](https://github.com/Cloto-dev/cloto-mcp-servers) repository
+- Servers maintained in the private clotohub-servers repository (formerly cloto-mcp-servers)
 - Configured via `mcp.toml` with `[paths]` section for external server resolution
 - Language-agnostic: any language implementing MCP protocol
 - Process isolation: each server runs as a separate OS process
@@ -367,7 +367,7 @@ For full architecture details, see [MCP Plugin Architecture](MCP_PLUGIN_ARCHITEC
 
 ```toml
 [paths]
-servers = "C:/path/to/cloto-mcp-servers/servers"
+servers = "C:/path/to/clotohub-servers/servers"
 
 [[servers]]
 command = "python"
@@ -380,7 +380,7 @@ If `[paths]` is absent, relative paths are resolved against the project root (ba
 **Migration plan (D → C):** The current approach (D) uses file-path-based server
 resolution. The future approach (C) will use Python package-based invocation
 (`python -m cloto_mcp_servers.terminal`), eliminating path configuration entirely.
-The root `pyproject.toml` in cloto-mcp-servers is prepared for this migration.
+The root `pyproject.toml` in clotohub-servers is prepared for this migration.
 
 ### 3.2 Architecture History
 
@@ -426,4 +426,4 @@ These principles define the "correct approach" within ClotoCore. The following c
 ### Related Design Documents
 
 - [MGP_SPEC.md](MGP_SPEC.md) — Multi-Agent Gateway Protocol specification (index)
-- [MGP Isolation Design](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_ISOLATION_DESIGN.md) — OS-Level isolation design (in cloto-mcp-servers repo)
+- [MGP Isolation Design](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_ISOLATION_DESIGN.md) — OS-Level isolation design (in the mgp-spec repo)

--- a/docs/CLAUDE_CODE_INTEGRATION.md
+++ b/docs/CLAUDE_CODE_INTEGRATION.md
@@ -16,14 +16,21 @@ Both servers run as stdio MCP processes. CPersona calls the Embedding server's
 HTTP endpoint for vector operations — Claude Code launches both, so the
 dependency resolves automatically.
 
+> **Note:** CPersona now lives in its own repository —
+> [Cloto-dev/CPersona](https://github.com/Cloto-dev/CPersona) (MIT). The
+> canonical Claude Code setup instructions are in that repository's README;
+> this document is kept as the ClotoCore-side integration reference.
+
 ## Prerequisites
 
 - Python 3.11+ with `pip`
-- `cloto-mcp-servers` repository cloned locally
+- [CPersona](https://github.com/Cloto-dev/CPersona) repository cloned locally
+- `clotohub-servers` repository (formerly `cloto-mcp-servers`; private,
+  maintainers only) cloned locally for the embedding server
 - Virtual environment with dependencies installed:
 
 ```bash
-cd C:/Users/Cycia/source/repos/cloto-mcp-servers/servers
+cd C:/Users/Cycia/source/repos/clotohub-servers/servers
 python -m venv .venv
 .venv/Scripts/activate   # Windows
 pip install -r requirements.txt
@@ -37,8 +44,8 @@ Register both MCP servers using `claude mcp add-json` (user scope):
 # Embedding server (must start before CPersona for vector operations)
 claude mcp add-json embedding '{
   "type": "stdio",
-  "command": "C:/Users/Cycia/source/repos/cloto-mcp-servers/servers/.venv/Scripts/python.exe",
-  "args": ["C:/Users/Cycia/source/repos/cloto-mcp-servers/servers/embedding/server.py"],
+  "command": "C:/Users/Cycia/source/repos/clotohub-servers/servers/.venv/Scripts/python.exe",
+  "args": ["C:/Users/Cycia/source/repos/clotohub-servers/servers/embedding/server.py"],
   "env": {
     "EMBEDDING_PROVIDER": "onnx_miniml",
     "EMBEDDING_HTTP_PORT": "8401"
@@ -48,8 +55,8 @@ claude mcp add-json embedding '{
 # CPersona memory server
 claude mcp add-json cpersona '{
   "type": "stdio",
-  "command": "C:/Users/Cycia/source/repos/cloto-mcp-servers/servers/.venv/Scripts/python.exe",
-  "args": ["C:/Users/Cycia/source/repos/cloto-mcp-servers/servers/cpersona/server.py"],
+  "command": "C:/Users/Cycia/source/repos/CPersona/.venv/Scripts/python.exe",
+  "args": ["C:/Users/Cycia/source/repos/CPersona/server.py"],
   "env": {
     "CPERSONA_DB_PATH": "C:/Users/Cycia/.claude/cpersona.db",
     "CPERSONA_EMBEDDING_MODE": "http",

--- a/docs/MCP_PLUGIN_ARCHITECTURE.md
+++ b/docs/MCP_PLUGIN_ARCHITECTURE.md
@@ -8,7 +8,7 @@
 > All MCP servers are MGP-compliant. MGP adds trust levels, isolation policies, handshake
 > extensions, and event forwarding on top of the standard MCP protocol.
 > See [MGP_SPEC.md](MGP_SPEC.md) for the full specification and
-> [cloto-mcp-servers](https://github.com/Cloto-dev/cloto-mcp-servers) for detailed MGP documentation.
+> [mgp-spec](https://github.com/Cloto-dev/mgp-spec) for detailed MGP documentation.
 
 ---
 
@@ -92,7 +92,7 @@ Results of evaluating alternatives:
 ┌───────────────────────▼──────────────────────────────┐
 │  Layer 2: MCP Servers (any language)                   │
 │                                                        │
-│  Repository: cloto-mcp-servers (github.com/Cloto-dev/cloto-mcp-servers) │
+│  Repository: clotohub-servers (private, formerly cloto-mcp-servers)   │
 │                                                        │
 │  ┌─────────────┐ ┌─────────────┐ ┌─────────────────┐ │
 │  │ mind.*      │ │ memory.*    │ │ tool.*          │ │
@@ -181,7 +181,7 @@ Layer 4 `mgp.*` kernel tools defined in MGP_SPEC §1.6.
 
 (`mgp.agent.ask` was listed here in an earlier revision. It is part of
 MGP spec Layer 4 (`mgp.agent.*`) and is therefore documented in
-[MGP_SPEC](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_SPEC.md) §1.6.)
+[MGP_SPEC](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_SPEC.md) §1.6.)
 
 These tools are invoked via standard `tools/call` and follow ClotoCore's
 access control policies (§5). They are excluded from LLM tool context by
@@ -602,7 +602,7 @@ Components removed or archived as part of the MCP migration:
 
 As of v0.5.4, all MCP/MGP server implementations are maintained in a separate repository:
 
-- **Repository:** [cloto-mcp-servers](https://github.com/Cloto-dev/cloto-mcp-servers)
+- **Repository:** clotohub-servers (private, formerly cloto-mcp-servers); community servers via [ClotoHub](https://hub.cloto.dev)
 - **Contents:** 15 Python + 2 Rust MCP servers (17 total) + common library + tests + MGP documentation
 - **Integration:** `mcp.toml` `[paths].servers` points to the local clone
 - **License:** BSL 1.1 (CPersona and MGP Protocol individually MIT-licensed)

--- a/docs/PROJECT_VISION.md
+++ b/docs/PROJECT_VISION.md
@@ -120,7 +120,7 @@ No major Kernel modifications are required.
 ┌─────────────────────────────────────────────────────┐
 │  Layer 5: Frontend Experience                        │
 │  Live2D/VRM avatar, TTS/STT, streaming integration   │
-│  → MCP: output.avatar, voice.stt (cloto-mcp-servers repo) │
+│  → MCP: output.avatar, voice.stt (clotohub-servers repo) │
 ├─────────────────────────────────────────────────────┤
 │  Layer 4: Emotion & Personality Engine               │
 │  Internal emotional state, personality consistency,   │

--- a/docs/QUICKSTART_MCP_SERVER.md
+++ b/docs/QUICKSTART_MCP_SERVER.md
@@ -178,7 +178,7 @@ Trust level determines the default isolation profile:
 
 ### 5. Using MgpCapabilities helper (optional)
 
-The `cloto-mcp-servers` repository provides a lightweight `MgpCapabilities` builder
+The [`mcp-common`](https://github.com/Cloto-dev/mgp-py) package provides a lightweight `MgpCapabilities` builder
 for declaring MGP capabilities without manually constructing JSON:
 
 ```python
@@ -194,12 +194,12 @@ capabilities = {"tools": {}, **mgp.as_dict()}
 
 > **Note:** A full MGP SDK is not yet available. For advanced MGP features
 > (events, streaming, callbacks), implement the JSON-RPC methods directly.
-> See [MGP Guide](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_GUIDE.md)
+> See [MGP Guide](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_GUIDE.md)
 > for the staged adoption path.
 
 ### 6. Using ClotoCore's ToolRegistry (optional)
 
-The `cloto-mcp-servers` repository provides a `ToolRegistry` helper that
+The [`mcp-common`](https://github.com/Cloto-dev/mgp-py) package provides a `ToolRegistry` helper that
 eliminates boilerplate:
 
 ```python
@@ -228,24 +228,26 @@ if __name__ == "__main__":
 
 ---
 
-## Adding to cloto-mcp-servers
+## Publishing your server
 
-If you want to contribute your server to the official repository:
+First-party servers are maintained in the private `clotohub-servers` repository
+(formerly `cloto-mcp-servers`). Community servers are distributed through the
+[ClotoHub marketplace](https://hub.cloto.dev) instead:
 
-1. Create `servers/<name>/server.py` (use `ToolRegistry` from `common/mcp_utils.py`)
-2. Add `servers/<name>/pyproject.toml`
-3. Add tests to `servers/tests/`
-4. Register in `registry.json`
-5. Add server entry to ClotoCore's `mcp.toml`
-
-See `servers/example/server.py` for a complete reference implementation.
+1. Host your server in your own repository (git / raw_url / pypi / docker sources
+   are supported)
+2. Describe it with a `cloto-connector.json` manifest or `[tool.cloto.mgp]`
+   pyproject hints — see the
+   [MGP Connector spec](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_CONNECTOR.md)
+3. Contact the maintainers (ClotoCore@proton.me) to get it listed in the
+   ClotoHub catalog (listing is currently curated)
 
 ---
 
 ## Further Reading
 
-- [MGP Specification](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_SPEC.md) — Full protocol spec
-- [MGP Security](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_SECURITY.md) — Permission model, RBAC, audit
-- [MGP Guide](https://github.com/Cloto-dev/cloto-mcp-servers/blob/main/docs/MGP_GUIDE.md) — Implementation guide with staged adoption
+- [MGP Specification](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_SPEC.md) — Full protocol spec
+- [MGP Security](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_SECURITY.md) — Permission model, RBAC, audit
+- [MGP Guide](https://github.com/Cloto-dev/mgp-spec/blob/main/docs/MGP_GUIDE.md) — Implementation guide with staged adoption
 - [MCP Official Docs](https://modelcontextprotocol.io/docs/develop/build-server) — Anthropic's MCP documentation
 - [ClotoCore Architecture](ARCHITECTURE.md) — System design and security framework


### PR DESCRIPTION
## Summary

ClotoHub Phase 4 docs sweep (live docs only — CHANGELOG, dated reports, hn-prep checklists, and historical design-scope notes keep the old name as point-in-time records).

- MGP doc deep links point at the canonical [mgp-spec](https://github.com/Cloto-dev/mgp-spec) repository (public, MIT) instead of the monorepo copies, which would go dark on privatization
- CPersona links point at the standalone [Cloto-dev/CPersona](https://github.com/Cloto-dev/CPersona) repository; CLAUDE_CODE_INTEGRATION defers to its README as the canonical setup
- QUICKSTART/CONTRIBUTING contribution flows point community servers at the [ClotoHub marketplace](https://hub.cloto.dev); helper references point at mcp-common (mgp-py)
- Drop the stale `tool.research` row (deprecated) and the removed `pip install -e cpersona` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)