### PR TITLE
fix(marketplace): stop orphaning install files on uninstall (bug-392)

### DIFF
--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -419,18 +419,34 @@ pub async fn uninstall_handler(
         ));
     }
 
+    // bug-392: capture the registered args before remove_server deletes the
+    // DB row — the entry-point path is the ground truth for where the
+    // install lives on disk (the catalog entry may be gone, and install
+    // directories don't always match the server id, e.g. legacy registry
+    // installs: id `mind.deepseek`, dir `deepseek`).
+    let registered_args: Option<String> =
+        sqlx::query_scalar("SELECT args FROM mcp_servers WHERE name = ?")
+            .bind(&server_id)
+            .fetch_optional(&state.pool)
+            .await
+            .ok()
+            .flatten();
+
     // Disconnect and remove from manager + DB
     if let Err(e) = state.mcp_manager.remove_server(&server_id).await {
         warn!("remove_server warning for {}: {}", server_id, e);
         // Still proceed with file cleanup even if server wasn't in memory
     }
 
-    // Delete server files from disk. Resolve via the catalog cache when
-    // we have an entry (so `effective_install_dir` mirrors the install
-    // path's fallback); otherwise drop back to `server_id` as-is — same
-    // convention the installers (`install_from_git`,
-    // `install_from_raw_url`) use when `entry.directory` is empty.
-    let directory = {
+    // Delete server files from disk. Candidates in order: the catalog
+    // cache's `effective_install_dir` (mirrors the install path's
+    // fallback), the directory derived from the registered entry-point
+    // args, then `server_id` as-is — the installers' convention when
+    // `entry.directory` is empty. The first candidate that exists on disk
+    // is the install; a miss across all of them is logged instead of
+    // silently orphaning the files (bug-392).
+    let servers_root = state.data_dir.join("mcp-servers");
+    let catalog_dir = {
         let cache = state.marketplace_cache.read().await;
         cache.data.as_ref().and_then(|reg| {
             reg.servers
@@ -438,11 +454,24 @@ pub async fn uninstall_handler(
                 .find(|s| s.id == server_id)
                 .map(|s| effective_install_dir(s).to_string())
         })
+    };
+    let args_dir = install_dir_from_args(registered_args.as_deref(), &servers_root);
+    let mut candidates: Vec<String> = Vec::new();
+    for c in [catalog_dir, args_dir, Some(server_id.clone())]
+        .into_iter()
+        .flatten()
+    {
+        if !candidates.contains(&c) {
+            candidates.push(c);
+        }
     }
-    .unwrap_or_else(|| server_id.clone());
 
-    let server_dir = state.data_dir.join("mcp-servers").join(&directory);
-    if server_dir.is_dir() {
+    let mut removed = false;
+    for directory in &candidates {
+        let server_dir = servers_root.join(directory);
+        if !server_dir.is_dir() {
+            continue;
+        }
         if let Err(e) = tokio::fs::remove_dir_all(&server_dir).await {
             warn!(
                 "Failed to remove server directory {}: {}",
@@ -454,7 +483,18 @@ pub async fn uninstall_handler(
                 "Removed marketplace server directory: {}",
                 server_dir.display()
             );
+            removed = true;
         }
+        break;
+    }
+    if !removed {
+        warn!(
+            "Uninstall of '{}' removed no files: no install directory found under {} \
+             (probed {:?})",
+            server_id,
+            servers_root.display(),
+            candidates
+        );
     }
 
     info!("Marketplace server uninstalled: {}", server_id);
@@ -2023,6 +2063,25 @@ fn effective_install_dir(entry: &RegistryEntry) -> &str {
     }
 }
 
+/// Derive the on-disk install directory from a registered server's `args`
+/// JSON (bug-392): the first arg that is an absolute path under
+/// `servers_root` names the install directory as its first path component.
+/// Returns `None` for unparseable args or paths outside the servers root
+/// (e.g. dev-layout scripts).
+fn install_dir_from_args(
+    args_json: Option<&str>,
+    servers_root: &std::path::Path,
+) -> Option<String> {
+    let args: Vec<String> = serde_json::from_str(args_json?).ok()?;
+    args.iter().find_map(|a| {
+        let rel = std::path::Path::new(a).strip_prefix(servers_root).ok()?;
+        rel.components().next().and_then(|c| match c {
+            std::path::Component::Normal(s) => Some(s.to_string_lossy().to_string()),
+            _ => None,
+        })
+    })
+}
+
 /// Locate an installable source tree for the shared `common` package
 /// (bug-389/390). Two layouts exist on disk:
 ///
@@ -2946,6 +3005,39 @@ mod tests {
             seal: None,
             install: None,
         }
+    }
+
+    // ── install_dir_from_args (bug-392) ──
+
+    #[test]
+    fn install_dir_derived_from_first_path_under_root() {
+        let root = std::path::Path::new("/data/mcp-servers");
+        let args = r#"["/data/mcp-servers/deepseek/server.py"]"#;
+        assert_eq!(
+            install_dir_from_args(Some(args), root),
+            Some("deepseek".to_string())
+        );
+    }
+
+    #[test]
+    fn install_dir_skips_flags_and_outside_paths() {
+        let root = std::path::Path::new("/data/mcp-servers");
+        let args = r#"["-u", "/opt/elsewhere/server.py", "/data/mcp-servers/cscheduler/servers/cscheduler/server.py"]"#;
+        assert_eq!(
+            install_dir_from_args(Some(args), root),
+            Some("cscheduler".to_string())
+        );
+    }
+
+    #[test]
+    fn install_dir_none_for_missing_or_invalid_args() {
+        let root = std::path::Path::new("/data/mcp-servers");
+        assert_eq!(install_dir_from_args(None, root), None);
+        assert_eq!(install_dir_from_args(Some("not json"), root), None);
+        assert_eq!(
+            install_dir_from_args(Some(r#"["/opt/elsewhere/server.py"]"#), root),
+            None
+        );
     }
 
     // ── resolve_common_source (bug-389/390) ──

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -2940,9 +2940,10 @@
       "commit": "9f7f498",
       "file": "crates/core/src/handlers/marketplace.rs",
       "pattern": "join\\(\"mcp-servers\"\\)\\.join\\(&directory\\)",
-      "expected": "present",
-      "status": "open",
-      "github_issue": 166
+      "expected": "absent",
+      "status": "fixed",
+      "github_issue": 166,
+      "fix_note": "Fixed: uninstall now probes candidates in order — catalog effective_install_dir, the directory derived from the registered entry-point args (install_dir_from_args reads mcp_servers.args BEFORE remove_server deletes the row), then server_id — removes the first that exists, and warns instead of silently no-oping when none is found."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes **bug-392 (MEDIUM)**, the last entry from the 2026-06-10 marketplace install debug (CSC Goal #108) — closes #166.

Uninstall resolved the on-disk directory via the catalog cache, falling back to `server_id` as the directory name. With no current catalog entry AND an install directory that differs from the id (legacy registry installs: id `mind.deepseek`, dir `deepseek`), the fallback path didn't exist and `remove_dir_all` was silently skipped — DB rows removed, files orphaned (observed uninstalling mind.deepseek/tool.terminal/tool.websearch).

The handler now reads the registered entry-point `args` from `mcp_servers` **before** `remove_server` deletes the row, and probes candidates in order: catalog `effective_install_dir` → directory derived from the args (`install_dir_from_args`: first absolute path under the servers root) → `server_id`. First existing directory wins; a miss across all candidates logs a warning instead of silently no-oping.

## Test plan

- 3 unit tests for `install_dir_from_args` (derivation incl. nested clone layout, flag/outside-path skipping, invalid args)
- `cargo test --workspace --exclude app` green; CI-equivalent clippy clean
- `verify-issues.sh` all green (232 issues, 0 stale, 0 errors); bug-392 → [FIXED]

🤖 Generated with [Claude Code](https://claude.com/claude-code)