### PR TITLE
fix(dashboard): surface kernel error messages instead of bare statusText (bug-393)

### DIFF
--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -68,7 +68,8 @@ async function fetchJson<T>(path: string, ctx: string, apiKey?: string, signal?:
   const headers: Record<string, string> = {};
   if (apiKey) headers['X-API-Key'] = apiKey;
   const res = await fetch(`${API_BASE}${path}`, { headers, signal: signal ?? AbortSignal.timeout(API_TIMEOUT_MS) });
-  if (!res.ok) throw new Error(`Failed to ${ctx}: ${res.statusText}`);
+  // bug-393: surface the kernel's error.message instead of the bare statusText
+  await throwIfNotOk(res, ctx);
   const body = await res.json();
   return body.data as T;
 }
@@ -87,7 +88,10 @@ async function mutate(
     signal: signal ?? AbortSignal.timeout(API_TIMEOUT_MS),
     ...(body !== undefined && { body: JSON.stringify(body) }),
   });
-  if (!res.ok) throw new Error(`Failed to ${ctx}: ${res.statusText}`);
+  // bug-393: surface the kernel's error.message instead of the bare statusText
+  // (a 400 "Server 'X' is already installed" used to reach the user as just
+  // "Bad Request", masking the actual rejection reason)
+  await throwIfNotOk(res, ctx);
   return res;
 }
 

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -2944,6 +2944,19 @@
       "status": "fixed",
       "github_issue": 166,
       "fix_note": "Fixed: uninstall now probes candidates in order — catalog effective_install_dir, the directory derived from the registered entry-point args (install_dir_from_args reads mcp_servers.args BEFORE remove_server deletes the row), then server_id — removes the first that exists, and warns instead of silently no-oping when none is found."
+    },
+    {
+      "id": "bug-393",
+      "summary": "MEDIUM: dashboard fetchJson/mutate discard the kernel's JSON error body and surface only res.statusText, so a 400 ValidationError like \"Server 'cpersona' is already installed\" reaches the user as just 'Bad Request'. This masked the real rejection reason behind the long-standing «CPersona raw_url install 'Bad Request'» mystery (Scope #3 narrative) — the synchronous install_handler validations are the only Bad Request sources; the raw_url path itself reports errors via SSE StepError and was never reached. A throwIfNotOk helper with body-message extraction already existed in api.ts but neither generic path used it.",
+      "severity": "MEDIUM",
+      "discovered": "2026-06-10T05:00:00Z",
+      "version": "0.6.8-alpha.3",
+      "commit": "cc71954",
+      "file": "dashboard/src/services/api.ts",
+      "pattern": "throw new Error\\(`Failed to \\$\\{ctx\\}: \\$\\{res\\.statusText\\}`\\)",
+      "expected": "absent",
+      "status": "fixed",
+      "fix_note": "Fixed: fetchJson and mutate now route !res.ok through the existing throwIfNotOk helper, which extracts body.error.message (kernel AppError shape {error:{type,message}}) and falls back to statusText only for non-JSON bodies."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Diagnosis outcome of the "CPersona raw_url install 'Bad Request'" mystery (CSC Goal #110 step 1, Scope #3 narrative).

`fetchJson` / `mutate` threw `Failed to {ctx}: {res.statusText}`, discarding the kernel's JSON error body (`{error: {type, message}}`) — so a 400 ValidationError like **"Server 'cpersona' is already installed"** reached the user as just **"Bad Request"**. The synchronous `install_handler` validations (not-in-registry / already-installed / install-in-progress / rate-limit) are the only Bad Request sources on the install path; `install_from_raw_url` reports its errors via SSE `StepError` and was never reached. The raw_url path itself was never at fault.

A `throwIfNotOk` helper that extracts `body.error.message` already existed in `api.ts`; both generic paths now route through it.

## Test plan

- `npx biome check` clean, `npm run build` green
- `verify-issues.sh` all green; bug-393 filed → [FIXED]
- After this lands, retrying the cpersona install will show the kernel's actual message, confirming the already-installed diagnosis

🤖 Generated with [Claude Code](https://claude.com/claude-code)