### PR TITLE
fix(marketplace): harden Setup Wizard / marketplace install robustness (Group B1)

### DIFF
--- a/crates/core/src/handlers.rs
+++ b/crates/core/src/handlers.rs
@@ -217,6 +217,7 @@ pub async fn shutdown_handler(
     let mcp = state.mcp_manager.clone();
     let shutdown = state.shutdown.clone();
     let setup_flag = state.setup_in_progress.clone();
+    let install_task = state.install_task.clone();
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
@@ -261,6 +262,11 @@ pub async fn shutdown_handler(
             Err(e) => error!("❌ Failed to create .maintenance file: {}", e),
         }
 
+        // bug-366: abort any in-flight install task so its child uv/pip processes
+        // are reaped via kill_on_drop instead of orphaned across shutdown.
+        if let Some(h) = install_task.lock().await.take() {
+            h.abort();
+        }
         // Reset setup_in_progress flag to prevent stale lock on restart (bug-366)
         setup_flag.store(false, std::sync::atomic::Ordering::SeqCst);
 

--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -471,7 +471,7 @@ pub async fn install_handler(
     let env_overrides = request.env.unwrap_or_default();
     let auto_start = request.auto_start.unwrap_or(true);
 
-    tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         let result = run_install(&state_clone, &entry, env_overrides, auto_start).await;
         state_clone
             .setup_in_progress
@@ -482,6 +482,9 @@ pub async fn install_handler(
         // Always emit Complete so the frontend SSE listener can close.
         emit(&state_clone.setup_progress_tx, SetupProgressEvent::Complete);
     });
+    // bug-366: track the install task so shutdown can abort it and reap any
+    // orphaned child uv/pip processes (kill_on_drop) instead of leaking them.
+    *state.install_task.lock().await = Some(handle);
 
     super::ok_data(serde_json::json!({ "started": true, "server_id": request.server_id }))
 }
@@ -678,7 +681,7 @@ pub async fn batch_install_handler(
     let state_clone = state.clone();
     let auto_start = request.auto_start.unwrap_or(true);
 
-    tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         // Notify skipped servers not found in registry (bug-381)
         for id in &skipped_ids {
             emit(
@@ -703,6 +706,9 @@ pub async fn batch_install_handler(
             error!("Batch install failed: {e}");
         }
     });
+    // bug-366: track the install task so shutdown can abort it and reap any
+    // orphaned child uv/pip processes (kill_on_drop) instead of leaking them.
+    *state.install_task.lock().await = Some(handle);
 
     super::ok_data(serde_json::json!({
         "started": true,
@@ -1142,24 +1148,32 @@ async fn build_and_register(
                         status: "installing".into(),
                     },
                 );
+                // bug-369: drive the common install through null-stdio status()
+                // (matching the batch path) instead of a piped output(). Capturing
+                // both pipes without concurrently draining them risks a back-pressure
+                // deadlock when uv emits verbose output.
+                let mut cmd = tokio::process::Command::new(&uv_str);
+                cmd.args([
+                    "pip",
+                    "install",
+                    "--no-progress",
+                    "--python",
+                    &venv_python_str,
+                    &common_path.to_string_lossy(),
+                ])
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .kill_on_drop(true); // bug-366: reap on install-task abort
+                #[cfg(windows)]
+                cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
                 let result = tokio::time::timeout(
                     Duration::from_secs(CHILD_PROCESS_TIMEOUT_SECS),
-                    tokio::process::Command::new(&uv_str)
-                        .args([
-                            "pip",
-                            "install",
-                            "--no-progress",
-                            "--python",
-                            &venv_python_str,
-                            &common_path.to_string_lossy(),
-                        ])
-                        .stdout(std::process::Stdio::piped())
-                        .stderr(std::process::Stdio::piped())
-                        .output(),
+                    cmd.status(),
                 )
                 .await;
                 match result {
-                    Ok(Ok(output)) if output.status.success() => {
+                    Ok(Ok(status)) if status.success() => {
                         emit(
                             tx,
                             SetupProgressEvent::ServerInstall {
@@ -1192,22 +1206,24 @@ async fn build_and_register(
             },
         );
 
-        let result = tokio::process::Command::new(&uv_str)
-            .args([
-                "pip",
-                "install",
-                "--no-progress",
-                "--python",
-                &venv_python_str,
-                &server_path.to_string_lossy(),
-            ])
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .output()
-            .await;
-
-        match result {
-            Ok(output) if output.status.success() => {
+        // bug-369: stream the server install through spawn_uv_streaming, which
+        // drains stdout/stderr on dedicated tasks and enforces a timeout. The
+        // previous piped output() had no timeout and could deadlock on a full pipe.
+        let server_path_str = server_path.to_string_lossy().to_string();
+        let logs_dir = state.data_dir.join("logs");
+        let _ = tokio::fs::create_dir_all(&logs_dir).await;
+        let log_file = logs_dir.join("install.log");
+        match super::setup::spawn_uv_streaming(
+            tx,
+            &uv_str,
+            &venv_python_str,
+            &entry.name,
+            &server_path_str,
+            Some(&log_file),
+        )
+        .await
+        {
+            Ok(()) => {
                 emit(
                     tx,
                     SetupProgressEvent::ServerInstall {
@@ -1216,25 +1232,12 @@ async fn build_and_register(
                     },
                 );
             }
-            Ok(output) => {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                let last_line = stderr.lines().last().unwrap_or("unknown error");
+            Err(detail) => {
                 emit(
                     tx,
                     SetupProgressEvent::StepError {
                         step: "install_deps".into(),
-                        error: format!("uv pip install failed: {last_line}"),
-                        recoverable: true,
-                    },
-                );
-                return Ok(());
-            }
-            Err(e) => {
-                emit(
-                    tx,
-                    SetupProgressEvent::StepError {
-                        step: "install_deps".into(),
-                        error: format!("Failed to run pip: {e}"),
+                        error: format!("uv pip install failed: {detail}"),
                         recoverable: true,
                     },
                 );
@@ -1929,7 +1932,14 @@ async fn install_from_raw_url(
     if let Some(expected) = &spec.sha256 {
         let actual = hex::encode(hasher.finalize());
         if !actual.eq_ignore_ascii_case(expected) {
-            let _ = tokio::fs::remove_file(&archive_path).await;
+            // bug-367: surface cleanup failures instead of swallowing them, so a
+            // corrupted-download retry loop can't silently leak disk space.
+            if let Err(e) = tokio::fs::remove_file(&archive_path).await {
+                warn!(
+                    "Failed to cleanup archive after sha256 mismatch {}: {e}",
+                    archive_path.display()
+                );
+            }
             emit(
                 tx,
                 SetupProgressEvent::StepError {
@@ -3166,7 +3176,8 @@ async fn run_batch_install(
             ])
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null());
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true); // bug-366: reap on install-task abort
             #[cfg(windows)]
             cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
             let result = tokio::time::timeout(
@@ -3891,6 +3902,40 @@ mod tests {
         assert_eq!(
             effective_install_dir(&entry("memory.cpersona", "")),
             "memory.cpersona"
+        );
+    }
+
+    /// bug-366: an in-flight install task registered in `AppState.install_task`
+    /// must be abortable by the shutdown path so its child uv/pip processes are
+    /// reaped (via kill_on_drop) instead of orphaned.
+    #[tokio::test]
+    async fn bug366_shutdown_aborts_inflight_install_task() {
+        let state = crate::test_utils::create_test_app_state(None).await;
+
+        // Mirror install_handler / batch_install_handler: a long-running task
+        // stored in the tracking slot.
+        let handle = tokio::spawn(async {
+            loop {
+                tokio::time::sleep(Duration::from_secs(3600)).await;
+            }
+        });
+        *state.install_task.lock().await = Some(handle);
+
+        // Mirror the shutdown handler's abort path.
+        let taken = state.install_task.lock().await.take();
+        let handle = taken.expect("install_task should hold the in-flight handle");
+        handle.abort();
+
+        let join_err = handle
+            .await
+            .expect_err("an aborted task must not complete normally");
+        assert!(
+            join_err.is_cancelled(),
+            "install task should be cancelled by shutdown"
+        );
+        assert!(
+            state.install_task.lock().await.is_none(),
+            "slot is cleared after take()"
         );
     }
 }

--- a/crates/core/src/handlers/setup.rs
+++ b/crates/core/src/handlers/setup.rs
@@ -405,7 +405,8 @@ pub(crate) async fn spawn_uv_streaming(
     ])
     .stdin(std::process::Stdio::null())
     .stdout(std::process::Stdio::piped())
-    .stderr(std::process::Stdio::piped());
+    .stderr(std::process::Stdio::piped())
+    .kill_on_drop(true); // bug-366: reap the child if the install task is aborted
 
     #[cfg(windows)]
     cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -180,6 +180,9 @@ pub struct AppState {
     pub max_cron_generation: Arc<AtomicU8>,
     /// Whether a bootstrap setup is currently running.
     pub setup_in_progress: Arc<AtomicBool>,
+    /// Handle to the in-flight install task (bootstrap or marketplace), tracked so
+    /// shutdown can abort it and reap orphaned child uv/pip processes (bug-366).
+    pub install_task: Arc<tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>>,
     /// Whether initial setup (venv, servers) has been completed at least once.
     /// Starts `false` on first run; set `true` when batch install finishes.
     /// Used by health monitor to suppress auto-restart before setup.
@@ -650,6 +653,7 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
         active_cron_contexts,
         max_cron_generation,
         setup_in_progress: Arc::new(AtomicBool::new(false)),
+        install_task: Arc::new(tokio::sync::Mutex::new(None)),
         setup_done: Arc::new(AtomicBool::new(setup_json.exists() || is_dev)),
         setup_progress_tx: {
             let (tx, _) = broadcast::channel(64);

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -63,6 +63,7 @@ pub async fn create_test_app_state(admin_api_key: Option<String>) -> Arc<crate::
         active_cron_contexts: Arc::new(dashmap::DashMap::new()),
         max_cron_generation: Arc::new(std::sync::atomic::AtomicU8::new(2)),
         setup_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        install_task: Arc::new(tokio::sync::Mutex::new(None)),
         setup_done: Arc::new(std::sync::atomic::AtomicBool::new(true)),
         setup_progress_tx: {
             let (tx, _) = tokio::sync::broadcast::channel(64);

--- a/dashboard/src/components/SetupWizard.tsx
+++ b/dashboard/src/components/SetupWizard.tsx
@@ -273,13 +273,23 @@ export function SetupWizard({ onComplete }: Props) {
     if (installingRef.current) return;
     installingRef.current = true;
     setInstallStarted(true);
+
+    // bug-365: refuse an empty batch up front. The backend also rejects it, but
+    // guarding here shows an actionable message and avoids opening an SSE session
+    // for an install that can't proceed.
+    const servers = getActiveServers();
+    if (servers.length === 0) {
+      installingRef.current = false;
+      setInstallError(t('install_error_no_servers'));
+      return;
+    }
+
     setInstallStartTime(Date.now());
     setInstallError(null);
     setServerStatuses([]);
     setInstallSteps([]);
 
     try {
-      const servers = getActiveServers();
       await api.batchInstallMarketplaceServers({ server_ids: servers, auto_start: true });
 
       // Connect SSE for progress — close any existing connection first (bug-359)

--- a/dashboard/src/locales/en/wizard.json
+++ b/dashboard/src/locales/en/wizard.json
@@ -51,6 +51,7 @@
   "install_elapsed": "Elapsed: {{time}}",
   "install_estimate": "Estimated: {{min}}–{{max}} min",
   "install_error_stream_disconnected": "Install progress stream disconnected. Please retry.",
+  "install_error_no_servers": "Select at least one server to install before continuing.",
   "quick_guide": "Quick Guide",
   "guide_agents": "Chat with AI agents, create new ones, and manage their settings.",
   "guide_mcp": "Connect and manage MCP server plugins for extended capabilities.",

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -2589,9 +2589,10 @@
       "version": "0.6.3-beta.9",
       "commit": "0d03c1a",
       "file": "dashboard/src/components/SetupWizard.tsx",
-      "pattern": "getActiveServers",
+      "pattern": "install_error_no_servers",
       "expected": "present",
-      "status": "open"
+      "status": "fixed",
+      "fix_note": "Fixed in 0.6.8 (PR #2 Group B1): doInstall() computes getActiveServers() up front and refuses an empty batch with the install_error_no_servers message before opening an install/SSE session (the backend batch_install_handler also rejects empty server_ids). Reverse-polarity: verifies presence of the empty-batch guard."
     },
     {
       "id": "bug-366",
@@ -2601,9 +2602,10 @@
       "version": "0.6.3-beta.9",
       "commit": "0d03c1a",
       "file": "crates/core/src/handlers/marketplace.rs",
-      "pattern": "setup_in_progress",
+      "pattern": "install_task",
       "expected": "present",
-      "status": "open"
+      "status": "fixed",
+      "fix_note": "Fixed in 0.6.8 (PR #2 Group B1): the install/batch-install handlers store their tokio::spawn JoinHandle in AppState.install_task; shutdown aborts it and the child uv/pip processes carry kill_on_drop(true), so closing the app during install reaps them instead of orphaning. Reverse-polarity: verifies presence of the install_task tracking field."
     },
     {
       "id": "bug-367",
@@ -2613,9 +2615,10 @@
       "version": "0.6.3-beta.9",
       "commit": "0d03c1a",
       "file": "crates/core/src/handlers/marketplace.rs",
-      "pattern": "remove_file.*archive",
-      "expected": "present",
-      "status": "open"
+      "pattern": "let _ = tokio::fs::remove_file\\(&archive_path\\)",
+      "expected": "absent",
+      "status": "fixed",
+      "fix_note": "Fixed in 0.6.8 (PR #2 Group B1): the sha256-mismatch cleanup now logs failures via `if let Err(e) … warn!` like the other three archive-removal sites, so the swallowing `let _ = remove_file(&archive_path)` form is gone. Pattern verifies that bad form is absent."
     },
     {
       "id": "bug-368",
@@ -2637,9 +2640,10 @@
       "version": "0.6.3-beta.9",
       "commit": "0d03c1a",
       "file": "crates/core/src/handlers/marketplace.rs",
-      "pattern": "install common dependency",
+      "pattern": "bug-369:",
       "expected": "present",
-      "status": "open"
+      "status": "fixed",
+      "fix_note": "Fixed in 0.6.8 (PR #2 Group B1): build_and_register's common-module and target-server pip installs were converted from piped .output() to the null-stdio .status() / spawn_uv_streaming idioms used by the batch path (concurrent pipe drain + timeout), eliminating the back-pressure deadlock risk. Reverse-polarity: verifies presence of the bug-369 fix markers."
     },
     {
       "id": "bug-370",


### PR DESCRIPTION
Group B1 of the 0.6.8 P1/P2 design-violation remediation (one of the backlog PRs gating the 0.6.8 beta feature-freeze). Aligns the single-server install path with the batch path and reaps install child processes on shutdown.

## Fixes
- **bug-365**: `SetupWizard.doInstall()` refuses an empty batch up front with an actionable message (`install_error_no_servers`) instead of opening an SSE session for an install the backend will reject. Preserves the bug-359 concurrency guard ordering and avoids the step-5 auto-start loop.
- **bug-366**: track the in-flight install `JoinHandle` in `AppState.install_task`; shutdown aborts it and child uv/pip processes carry `kill_on_drop(true)`, so closing the app during install reaps them instead of orphaning.
- **bug-367**: log sha256-mismatch tarball cleanup failures (was `let _ = remove_file(...)`) so a corrupted-download retry loop can't silently leak disk space.
- **bug-369**: route `build_and_register`'s common + target-server pip installs through the null-stdio `status()` / `spawn_uv_streaming` idioms (concurrent pipe drain + timeout) used by the batch path, removing the back-pressure deadlock risk and adding the previously-missing server-install timeout.

## Verification
- `scripts/verify-issues.sh`: bug-367 `[FIXED]` (bad form absent); bug-365/366/369 `[VERIFIED]` (fix-marker present). Overall 0 errors / 0 stale.
- New unit test `bug366_shutdown_aborts_inflight_install_task`.
- `cargo clippy --workspace --exclude app --all-targets -D warnings` clean; `cargo fmt --check` clean; `cargo test --workspace --exclude app` green.

## Notes
- **bug-376** (`to_string_lossy`) intentionally deferred to a separate LOW housekeeping PR (its registry pattern needs redefinition and it would conflict with the `uv_str` edits here).
- Independent of the Group C1 PR (different files); both target master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)