### PR TITLE
fix(mcp): MCP transport timeouts, graceful kill, send-path guards (Group C1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,6 +1160,7 @@ dependencies = [
  "governor",
  "hex",
  "http",
+ "libc",
  "lindera",
  "mgp-sdk",
  "mgp-seal",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -54,6 +54,11 @@ unicode-normalization = "0.1"
 lindera = { version = "2.3", features = ["embed-ipadic"] }
 dirs = "5"
 
+# bug-358: graceful SIGTERM (before SIGKILL) for MCP child shutdown. Unix only —
+# tokio's process API can only send SIGKILL.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 http = "1.0"
 criterion = { workspace = true }

--- a/crates/core/src/managers/mcp_client.rs
+++ b/crates/core/src/managers/mcp_client.rs
@@ -63,6 +63,36 @@ impl Drop for McpClient {
 impl McpClient {
     const MAX_PENDING_REQUESTS: usize = 100;
 
+    /// bug-357: upper bound for enqueueing a request into the transport channel.
+    /// The send should be near-instant; a stall means the writer/HTTP task is
+    /// wedged (bug-355/bug-356), so we fail fast instead of blocking the caller
+    /// — the response-side timeout only protects the receive path.
+    const SEND_TIMEOUT_SECS: u64 = 10;
+
+    /// Send a payload into the transport request channel with a timeout. Without
+    /// this, a wedged transport (full child stdin pipe / stalled HTTP loop)
+    /// could block the caller indefinitely, since the bounded request channel
+    /// applies back-pressure and the response timeout does not cover the send
+    /// path (bug-357).
+    async fn send_with_timeout(&self, payload: String, what: &str) -> Result<()> {
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(Self::SEND_TIMEOUT_SECS),
+            self.sender.send(payload),
+        )
+        .await
+        {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => {
+                Err(anyhow::Error::new(e)
+                    .context(format!("Failed to send {what} to MCP transport")))
+            }
+            Err(_) => Err(anyhow::anyhow!(
+                "Timed out sending {what} to MCP transport ({}s)",
+                Self::SEND_TIMEOUT_SECS
+            )),
+        }
+    }
+
     /// Kill the underlying child process and wait for it to exit.
     /// Must be called before dropping the handle to avoid race conditions
     /// where the old process still holds file locks (Issue #65).
@@ -278,10 +308,10 @@ impl McpClient {
             map.insert(id, tx);
         }
 
-        self.sender
-            .send(req_str)
-            .await
-            .context("Failed to send request to MCP transport")?;
+        if let Err(e) = self.send_with_timeout(req_str, "request").await {
+            self.pending_requests.lock().await.remove(&id);
+            return Err(e);
+        }
 
         if let Ok(res) = tokio::time::timeout(
             std::time::Duration::from_secs(self.request_timeout_secs),
@@ -336,10 +366,8 @@ impl McpClient {
     pub async fn send_initialized_notification(&self) -> Result<()> {
         let notify = JsonRpcRequest::notification("notifications/initialized", None);
         let notify_str = serde_json::to_string(&notify)?;
-        self.sender
-            .send(notify_str)
+        self.send_with_timeout(notify_str, "initialized notification")
             .await
-            .context("Failed to send initialized notification")
     }
 
     pub async fn list_tools(&self) -> Result<ListToolsResult> {
@@ -472,10 +500,12 @@ impl McpClient {
             });
         }
 
-        self.sender
-            .send(req_str)
-            .await
-            .context("Failed to send streaming request to MCP transport")?;
+        if let Err(e) = self.send_with_timeout(req_str, "streaming request").await {
+            // Dropping the pending entry closes the watchdog's inner_rx, which
+            // self-cleans the stream collector registered for this id.
+            self.pending_requests.lock().await.remove(&id);
+            return Err(e);
+        }
 
         Ok((chunk_rx, result_rx))
     }
@@ -484,10 +514,7 @@ impl McpClient {
     pub async fn send_notification(&self, method: &str, params: Option<Value>) -> Result<()> {
         let request = JsonRpcRequest::notification(method, params);
         let req_str = serde_json::to_string(&request)?;
-        self.sender
-            .send(req_str)
-            .await
-            .context("Failed to send notification to MCP transport")
+        self.send_with_timeout(req_str, "notification").await
     }
 
     /// Perform cloto/handshake custom method.

--- a/crates/core/src/managers/mcp_transport.rs
+++ b/crates/core/src/managers/mcp_transport.rs
@@ -57,6 +57,20 @@ const ALLOWED_COMMANDS: &[&str] = &["npx", "node", "python", "python3", "deno", 
 /// Buffer size for MCP stdio channel (request and response).
 const MCP_CHANNEL_BUFFER_SIZE: usize = 100;
 
+/// bug-355: timeout for a single write to the child's stdin pipe. Guards
+/// against a child that stops reading stdin (full pipe buffer) wedging the
+/// writer task — and, transitively, the bounded request channel upstream.
+const STDIO_WRITE_TIMEOUT_SECS: u64 = 10;
+
+/// bug-356: per-request send timeout for the HTTP transport. Bounds how long a
+/// single queued message can hold the request loop before the next one runs,
+/// on top of the reqwest client's global timeout.
+const HTTP_PER_MESSAGE_TIMEOUT_SECS: u64 = 30;
+
+/// bug-358: grace period to wait for a graceful (SIGTERM) exit before
+/// escalating to SIGKILL in `kill_and_wait`.
+const SHUTDOWN_GRACE_SECS: u64 = 3;
+
 /// If command is python/python3, resolve to venv Python if available.
 /// Returns (resolved_command, is_venv) tuple.
 fn resolve_python_command(command: &str) -> (String, bool) {
@@ -139,6 +153,34 @@ impl StdioTransport {
     /// Kill the child process and wait for it to actually exit.
     /// Ensures file locks (DB, ports) are released before returning.
     pub async fn kill_and_wait(&mut self) {
+        // bug-358: try a graceful SIGTERM first so the MCP server can flush
+        // state and release locks, then escalate to SIGKILL if it refuses to
+        // exit. SIGTERM is Unix-only; other platforms go straight to start_kill
+        // (already a forceful kill).
+        #[cfg(unix)]
+        {
+            if let Some(pid) = self.child.id() {
+                // SAFETY: sending SIGTERM to a child PID we own. libc::kill is
+                // the only way to send a non-SIGKILL signal via tokio's process API.
+                unsafe {
+                    libc::kill(pid as libc::pid_t, libc::SIGTERM);
+                }
+                if let Ok(Ok(status)) = tokio::time::timeout(
+                    std::time::Duration::from_secs(SHUTDOWN_GRACE_SECS),
+                    self.child.wait(),
+                )
+                .await
+                {
+                    debug!("Child process exited gracefully after SIGTERM: {status}");
+                    return;
+                }
+                tracing::warn!(
+                    "Child did not exit within {SHUTDOWN_GRACE_SECS}s of SIGTERM — escalating to SIGKILL"
+                );
+            }
+        }
+
+        // SIGKILL fallback (also the primary path on non-Unix targets).
         let _ = self.child.start_kill();
         match tokio::time::timeout(std::time::Duration::from_secs(5), self.child.wait()).await {
             Ok(Ok(status)) => {
@@ -148,7 +190,7 @@ impl StdioTransport {
                 debug!("Child process wait error: {e}");
             }
             Err(_) => {
-                tracing::warn!("Child process did not exit within 5s after kill signal");
+                tracing::warn!("Child process did not exit within 5s after SIGKILL");
             }
         }
     }
@@ -275,15 +317,36 @@ impl StdioTransport {
         // Writer Task
         tokio::spawn(async move {
             let mut writer = stdin;
+            // bug-355: bound each write/flush so a child that stops reading its
+            // stdin (full pipe buffer) cannot wedge this task forever. On stall
+            // we break — closing req_rx, which surfaces as is_alive()==false and
+            // lets the health monitor restart the server.
+            let write_timeout = std::time::Duration::from_secs(STDIO_WRITE_TIMEOUT_SECS);
             while let Some(msg) = req_rx.recv().await {
                 let line = format!("{}\n", msg);
-                if let Err(e) = writer.write_all(line.as_bytes()).await {
-                    error!("Failed to write to MCP server stdin: {}", e);
-                    break;
+                match tokio::time::timeout(write_timeout, writer.write_all(line.as_bytes())).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => {
+                        error!("Failed to write to MCP server stdin: {}", e);
+                        break;
+                    }
+                    Err(_) => {
+                        error!(
+                            "Timed out writing to MCP server stdin ({STDIO_WRITE_TIMEOUT_SECS}s) — child stdin pipe likely full"
+                        );
+                        break;
+                    }
                 }
-                if let Err(e) = writer.flush().await {
-                    error!("Failed to flush MCP server stdin: {}", e);
-                    break;
+                match tokio::time::timeout(write_timeout, writer.flush()).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => {
+                        error!("Failed to flush MCP server stdin: {}", e);
+                        break;
+                    }
+                    Err(_) => {
+                        error!("Timed out flushing MCP server stdin ({STDIO_WRITE_TIMEOUT_SECS}s)");
+                        break;
+                    }
                 }
             }
         });
@@ -424,14 +487,33 @@ impl HttpTransport {
                     request = request.header("Mcp-Session-Id", sid.clone());
                 }
 
-                let response = match request.body(msg).send().await {
-                    Ok(r) => r,
-                    Err(e) => {
+                // bug-356: bound each request so one slow message can't stall the
+                // serial request loop (and the queue behind it). This is in
+                // addition to the reqwest client's global timeout above.
+                let send_fut = request.body(msg).send();
+                let response = match tokio::time::timeout(
+                    std::time::Duration::from_secs(HTTP_PER_MESSAGE_TIMEOUT_SECS),
+                    send_fut,
+                )
+                .await
+                {
+                    Ok(Ok(r)) => r,
+                    Ok(Err(e)) => {
                         error!(url = %url_owned, error = %e, "HTTP request failed");
                         // Send JSON-RPC error so pending requests don't hang
                         let err_msg = serde_json::json!({
                             "jsonrpc": "2.0",
                             "error": {"code": -32000, "message": format!("HTTP transport error: {e}")},
+                            "id": null
+                        });
+                        let _ = res_tx.send(err_msg.to_string()).await;
+                        continue;
+                    }
+                    Err(_) => {
+                        error!(url = %url_owned, "HTTP request timed out ({HTTP_PER_MESSAGE_TIMEOUT_SECS}s)");
+                        let err_msg = serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "error": {"code": -32000, "message": format!("HTTP per-message timeout ({HTTP_PER_MESSAGE_TIMEOUT_SECS}s)")},
                             "id": null
                         });
                         let _ = res_tx.send(err_msg.to_string()).await;

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -1851,15 +1851,16 @@
     },
     {
       "id": "bug-304",
-      "summary": "P9: StdioTransport has no explicit Drop impl",
+      "summary": "P9: StdioTransport child cleanup on drop (explicit Drop impl + kill_on_drop)",
       "severity": "MEDIUM",
       "discovered": "2026-03-10T00:00:00Z",
       "version": "0.6.2",
       "commit": "8c09a10",
       "file": "crates/core/src/managers/mcp_transport.rs",
-      "pattern": "pub struct StdioTransport",
+      "pattern": "impl Drop for StdioTransport",
       "expected": "present",
-      "status": "open"
+      "status": "fixed",
+      "fix_note": "Verified in 0.6.8 (PR #3 Group C1): StdioTransport already carries an explicit `impl Drop` (start_kill) plus kill_on_drop(true) on the spawned Command, so the original 'no Drop impl' concern does not hold on this code. Pattern re-anchored on the Drop impl (was the meaningless struct declaration) so the check actually proves child cleanup exists."
     },
     {
       "id": "bug-305",
@@ -2461,9 +2462,10 @@
       "version": "0.6.3-beta.8",
       "commit": "ccfbc25",
       "file": "crates/core/src/managers/mcp_transport.rs",
-      "pattern": "writer\\.write_all\\(",
+      "pattern": "STDIO_WRITE_TIMEOUT_SECS",
       "expected": "present",
-      "status": "open"
+      "status": "fixed",
+      "fix_note": "Fixed in 0.6.8 (PR #3 Group C1): the stdio writer task wraps write_all/flush in tokio::time::timeout(STDIO_WRITE_TIMEOUT_SECS); a child that stops reading stdin no longer wedges the writer (it breaks, closing the channel -> is_alive()==false). Reverse-polarity: verifies the write timeout is present."
     },
     {
       "id": "bug-356",
@@ -2473,9 +2475,10 @@
       "version": "0.6.3-beta.8",
       "commit": "ccfbc25",
       "file": "crates/core/src/managers/mcp_transport.rs",
-      "pattern": "timeout\\(std::time::Duration::from_mins\\(1\\)\\)",
+      "pattern": "HTTP_PER_MESSAGE_TIMEOUT_SECS",
       "expected": "present",
-      "status": "open"
+      "status": "fixed",
+      "fix_note": "Fixed in 0.6.8 (PR #3 Group C1): the HTTP request loop wraps each request.send() in tokio::time::timeout(HTTP_PER_MESSAGE_TIMEOUT_SECS) on top of the reqwest client's global 60s timeout, so one slow message no longer blocks the serial queue. Reverse-polarity: verifies the per-message timeout is present."
     },
     {
       "id": "bug-357",
@@ -2485,9 +2488,10 @@
       "version": "0.6.3-beta.8",
       "commit": "ccfbc25",
       "file": "crates/core/src/managers/mcp_client.rs",
-      "pattern": "self\\.sender",
+      "pattern": "SEND_TIMEOUT_SECS",
       "expected": "present",
-      "status": "open"
+      "status": "fixed",
+      "fix_note": "Fixed in 0.6.8 (PR #3 Group C1): all transport sends go through send_with_timeout(SEND_TIMEOUT_SECS) (call / call_tool_streaming / send_initialized_notification / send_notification), so a wedged transport can no longer block the caller on the send path (the response timeout only covered rx). Reverse-polarity: verifies the send-path timeout is present."
     },
     {
       "id": "bug-358",
@@ -2497,9 +2501,10 @@
       "version": "0.6.3-beta.8",
       "commit": "ccfbc25",
       "file": "crates/core/src/managers/mcp_transport.rs",
-      "pattern": "start_kill\\(\\)",
+      "pattern": "SHUTDOWN_GRACE_SECS",
       "expected": "present",
-      "status": "open"
+      "status": "fixed",
+      "fix_note": "Fixed in 0.6.8 (PR #3 Group C1): kill_and_wait sends a graceful SIGTERM (Unix), waits SHUTDOWN_GRACE_SECS, then escalates to start_kill (SIGKILL) if the child refuses to exit; non-Unix goes straight to start_kill. Reverse-polarity: verifies the SIGTERM-then-SIGKILL grace path is present."
     },
     {
       "id": "bug-359",


### PR DESCRIPTION
Group C1 of the 0.6.8 P1/P2 design-violation remediation (one of the backlog PRs gating the 0.6.8 beta feature-freeze). Bounds the previously-unbounded MCP transport I/O paths so a wedged child can't hang the kernel, and makes child shutdown graceful-then-forceful.

## Fixes
- **bug-355**: the stdio writer task wraps `write_all`/`flush` in a timeout (`STDIO_WRITE_TIMEOUT_SECS=10`); a child that stops reading stdin no longer wedges the writer — it breaks, closing the channel so the health monitor can restart the server.
- **bug-356**: the HTTP request loop wraps each `request.send()` in a per-message timeout (`HTTP_PER_MESSAGE_TIMEOUT_SECS=30`) on top of the reqwest client's global 60s, so one slow message can't stall the serial queue. The SSE response stream is intentionally not wrapped.
- **bug-357**: all `McpClient` sends go through `send_with_timeout(SEND_TIMEOUT_SECS=10)` — `call` / `call_tool_streaming` / `send_initialized_notification` / `send_notification`. The response timeout only covered rx; a full bounded channel could block the caller on the send path. Failed sends clean up the pending request (and, via the dropped oneshot, the stream collector).
- **bug-358**: `kill_and_wait` sends a graceful SIGTERM (Unix) and waits `SHUTDOWN_GRACE_SECS=3` before escalating to `start_kill` (SIGKILL); non-Unix goes straight to `start_kill`. Adds a unix-only `libc` dep for the signal.
- **bug-304**: no code change — `StdioTransport` already has an explicit `Drop` (`start_kill`) plus `kill_on_drop(true)`. The registry pattern was re-anchored from the meaningless struct declaration onto `impl Drop for StdioTransport` and the summary corrected.

## Verification
- `scripts/verify-issues.sh`: bug-304/355/356/357/358 all `[VERIFIED]` (fix-marker present; the original bad-forms are intentionally retained, so absent-style checks don't apply). Overall 0 errors / 0 stale.
- `cargo clippy --workspace --exclude app --all-targets -D warnings` clean; `cargo fmt --check` clean; `cargo test --workspace --exclude app` green.

## Notes
- **No new unit tests**: these are timeout guards whose failure modes need a wedged child / full pipe to exercise (process-spawn, CI-flaky). Regression is covered by the existing suite + the verify-issues.sh anchors. Open to adding `#[ignore]`d integration tests if preferred.
- Independent of the Group B1 PR (different files); both target master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)