### PR TITLE
fix(consensus): make synthetic agent id and trigger prefix configurable (Consensus config)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -84,6 +84,9 @@ pub struct AppConfig {
     pub memory_context_limit: usize,
     pub admin_api_key: Option<String>,
     pub consensus_engines: Vec<String>,
+    /// Prefix that triggers consensus mode on an inbound message (bug-285:
+    /// configurable, default "consensus:"). Matched case-insensitively.
+    pub consensus_prefix: String,
     pub event_history_size: usize,
     pub event_retention_hours: u64,
     pub max_agentic_iterations: u8,
@@ -292,6 +295,10 @@ impl AppConfig {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
             .collect();
+
+        // bug-285: consensus trigger prefix is configurable (default "consensus:")
+        let consensus_prefix =
+            env::var("CONSENSUS_PREFIX").unwrap_or_else(|_| "consensus:".to_string());
 
         let event_history_size = env::var("EVENT_HISTORY_SIZE")
             .unwrap_or_else(|_| "1000".to_string())
@@ -609,6 +616,7 @@ impl AppConfig {
             memory_context_limit,
             admin_api_key,
             consensus_engines,
+            consensus_prefix,
             event_history_size,
             event_retention_hours,
             max_agentic_iterations,
@@ -690,6 +698,26 @@ mod tests {
         let config = AppConfig::load().unwrap();
         // P1: Default is empty (no hard-coded engines)
         assert!(config.consensus_engines.is_empty());
+    }
+
+    #[test]
+    fn test_consensus_prefix_default() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard("CONSENSUS_PREFIX");
+
+        let config = AppConfig::load().unwrap();
+        // bug-285: default preserves the historical "consensus:" trigger
+        assert_eq!(config.consensus_prefix, "consensus:");
+    }
+
+    #[test]
+    fn test_consensus_prefix_custom() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var("CONSENSUS_PREFIX", "vote:");
+        let _guard = EnvGuard("CONSENSUS_PREFIX");
+
+        let config = AppConfig::load().unwrap();
+        assert_eq!(config.consensus_prefix, "vote:");
     }
 
     #[test]

--- a/crates/core/src/consensus.rs
+++ b/crates/core/src/consensus.rs
@@ -12,8 +12,9 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
-/// Named constant for the synthetic consensus agent (prevents type confusion).
-const SYSTEM_CONSENSUS_AGENT: &str = "system.consensus";
+/// Default synthetic consensus agent id (bug-282: now a configurable
+/// `ConsensusConfig` field; this is only the back-compat default).
+pub(crate) const DEFAULT_CONSENSUS_AGENT_ID: &str = "system.consensus";
 
 /// How often the background cleanup task sweeps stale consensus sessions.
 /// Independent of `session_timeout_secs` (which controls per-session TTL).
@@ -31,6 +32,10 @@ pub struct ConsensusConfig {
     pub min_proposals: usize,
     /// Session timeout in seconds.
     pub session_timeout_secs: u64,
+    /// Synthetic agent id for consensus-generated responses (bug-282).
+    /// Configurable so a deployment can rename it instead of the kernel
+    /// hard-coding the literal. Defaults to `DEFAULT_CONSENSUS_AGENT_ID`.
+    pub synthetic_agent_id: String,
 }
 
 impl Default for ConsensusConfig {
@@ -39,6 +44,7 @@ impl Default for ConsensusConfig {
             synthesizer_engine: String::new(),
             min_proposals: 2,
             session_timeout_secs: 60,
+            synthetic_agent_id: DEFAULT_CONSENSUS_AGENT_ID.to_string(),
         }
     }
 }
@@ -74,16 +80,21 @@ struct ConsensusState {
 
 pub struct ConsensusOrchestrator {
     state: RwLock<ConsensusState>,
+    /// bug-282: cached from `config.synthetic_agent_id` for lock-free reads on
+    /// the thought-response hot path.
+    synthetic_agent_id: String,
 }
 
 impl ConsensusOrchestrator {
     #[must_use]
     pub fn new(config: ConsensusConfig) -> Arc<Self> {
+        let synthetic_agent_id = config.synthetic_agent_id.clone();
         let orchestrator = Arc::new(Self {
             state: RwLock::new(ConsensusState {
                 sessions: HashMap::new(),
                 config,
             }),
+            synthetic_agent_id,
         });
         orchestrator.spawn_cleanup_task();
         orchestrator
@@ -152,7 +163,7 @@ impl ConsensusOrchestrator {
         content: &str,
     ) -> Option<ClotoEventData> {
         // Ignore responses from the consensus system itself
-        if agent_id == SYSTEM_CONSENSUS_AGENT {
+        if agent_id == self.synthetic_agent_id {
             return None;
         }
 
@@ -281,7 +292,7 @@ impl ConsensusOrchestrator {
                 )
             }
             Action::Complete { content } => Some(ClotoEventData::ThoughtResponse {
-                agent_id: SYSTEM_CONSENSUS_AGENT.to_string(),
+                agent_id: self.synthetic_agent_id.clone(),
                 engine_id: "consensus".to_string(),
                 content,
                 source_message_id: "consensus".to_string(),

--- a/crates/core/src/handlers/system.rs
+++ b/crates/core/src/handlers/system.rs
@@ -116,6 +116,7 @@ pub struct SystemHandler {
     memory_context_limit: usize,
     metrics: Arc<crate::managers::SystemMetrics>,
     consensus_engines: Vec<String>,
+    consensus_prefix: String,
     max_agentic_iterations: u8,
     tool_execution_timeout_secs: u64,
     pending_approvals: PendingApprovals,
@@ -154,6 +155,7 @@ impl SystemHandler {
         memory_context_limit: usize,
         metrics: Arc<crate::managers::SystemMetrics>,
         consensus_engines: Vec<String>,
+        consensus_prefix: String,
         max_agentic_iterations: u8,
         tool_execution_timeout_secs: u64,
         pending_approvals: PendingApprovals,
@@ -171,6 +173,7 @@ impl SystemHandler {
             memory_context_limit,
             metrics,
             consensus_engines,
+            consensus_prefix,
             max_agentic_iterations,
             tool_execution_timeout_secs,
             pending_approvals,
@@ -574,7 +577,11 @@ impl SystemHandler {
 
         let trace_id = cloto_shared::ClotoId::new_trace_id();
 
-        if msg.content.to_lowercase().starts_with("consensus:") {
+        if msg
+            .content
+            .to_lowercase()
+            .starts_with(&self.consensus_prefix.to_lowercase())
+        {
             // 合意形成モード
             let thought_event_data = cloto_shared::ClotoEventData::ConsensusRequested {
                 task: msg.content.clone(),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -549,6 +549,7 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
             config.memory_context_limit,
             metrics.clone(),
             config.consensus_engines.clone(),
+            config.consensus_prefix.clone(),
             config.max_agentic_iterations,
             config.tool_execution_timeout_secs,
             pending_command_approvals.clone(),
@@ -678,6 +679,8 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
     // 6. Consensus Orchestrator (kernel-level, replaces core.moderator plugin)
     let consensus_config = consensus::ConsensusConfig {
         synthesizer_engine: std::env::var("CONSENSUS_SYNTHESIZER").unwrap_or_default(),
+        synthetic_agent_id: std::env::var("CONSENSUS_AGENT_ID")
+            .unwrap_or_else(|_| consensus::DEFAULT_CONSENSUS_AGENT_ID.to_string()),
         min_proposals: std::env::var("CONSENSUS_MIN_PROPOSALS")
             .ok()
             .and_then(|v| v.parse().ok())

--- a/crates/core/tests/event_cascading_test.rs
+++ b/crates/core/tests/event_cascading_test.rs
@@ -115,6 +115,7 @@ async fn test_event_cascading_protection() {
         10,
         metrics.clone(),
         vec![],
+        "consensus:".to_string(),
         16,
         30,
         Arc::new(dashmap::DashMap::new()),

--- a/crates/core/tests/event_memory_management_test.rs
+++ b/crates/core/tests/event_memory_management_test.rs
@@ -32,6 +32,7 @@ async fn create_test_processor(
         10,
         metrics.clone(),
         vec![],
+        "consensus:".to_string(),
         16,
         30,
         Arc::new(dashmap::DashMap::new()),

--- a/crates/core/tests/permission_elevation_test.rs
+++ b/crates/core/tests/permission_elevation_test.rs
@@ -110,6 +110,7 @@ async fn test_dynamic_permission_elevation_flow() {
         10,
         metrics.clone(),
         vec![],
+        "consensus:".to_string(),
         16,
         30,
         Arc::new(dashmap::DashMap::new()),

--- a/crates/core/tests/security_forging_test.rs
+++ b/crates/core/tests/security_forging_test.rs
@@ -159,6 +159,7 @@ async fn test_vulnerability_event_forging() {
         10,
         metrics.clone(),
         vec![],
+        "consensus:".to_string(),
         16,
         30,
         Arc::new(dashmap::DashMap::new()),

--- a/crates/core/tests/system_loop_test.rs
+++ b/crates/core/tests/system_loop_test.rs
@@ -31,6 +31,7 @@ async fn test_system_handler_loop_prevention() {
         10, // memory_context_limit
         metrics,
         vec!["mind.deepseek".to_string(), "mind.cerebras".to_string()],
+        "consensus:".to_string(),
         16, // max_agentic_iterations
         30, // tool_execution_timeout_secs
         Arc::new(dashmap::DashMap::new()),
@@ -103,6 +104,7 @@ async fn build_cron_test_handler(
         10,
         metrics,
         vec![],
+        "consensus:".to_string(),
         16,
         30,
         Arc::new(dashmap::DashMap::new()),

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -1584,8 +1584,9 @@
       "commit": "8c09a10",
       "file": "crates/core/src/consensus.rs",
       "pattern": "SYSTEM_CONSENSUS_AGENT",
-      "expected": "present",
-      "status": "open"
+      "expected": "absent",
+      "status": "fixed",
+      "fix_note": "Fixed in 0.6.8 (PR #4 Consensus config): the hard-coded `const SYSTEM_CONSENSUS_AGENT` was removed; the synthetic agent id is now `ConsensusConfig.synthetic_agent_id` (default DEFAULT_CONSENSUS_AGENT_ID, env CONSENSUS_AGENT_ID), cached lock-free on ConsensusOrchestrator. Pattern verifies the hard-coded const is gone (ARCHITECTURE.md 1.2)."
     },
     {
       "id": "bug-283",
@@ -1620,8 +1621,9 @@
       "commit": "8c09a10",
       "file": "crates/core/src/handlers/system.rs",
       "pattern": "\"consensus:\"",
-      "expected": "present",
-      "status": "open"
+      "expected": "absent",
+      "status": "fixed",
+      "fix_note": "Fixed in 0.6.8 (PR #4 Consensus config): the hard-coded 'consensus:' prefix in system.rs was replaced with the configurable AppConfig.consensus_prefix (env CONSENSUS_PREFIX, default 'consensus:' in config.rs), matched case-insensitively. Pattern verifies the literal is gone from the system handler (ARCHITECTURE.md 1.2)."
     },
     {
       "id": "bug-286",


### PR DESCRIPTION
PR #4 of the 0.6.8 P1/P2 design-violation remediation (one of the backlog PRs gating the 0.6.8 beta feature-freeze). Removes the two hard-coded literals behind consensus dispatch so both become deployment-configurable, addressing ARCHITECTURE.md §1.2 (capability over concrete type) while preserving the historical defaults.

## Fixes
- **bug-282**: dropped `const SYSTEM_CONSENSUS_AGENT`. The synthetic agent id is now `ConsensusConfig.synthetic_agent_id` (default `DEFAULT_CONSENSUS_AGENT_ID` = `"system.consensus"`, overridable via `CONSENSUS_AGENT_ID`), cached lock-free on `ConsensusOrchestrator` for the thought-response hot path.
- **bug-285**: dropped the hard-coded `"consensus:"` prefix in the system handler. It now reads `AppConfig.consensus_prefix` (default `"consensus:"`, overridable via `CONSENSUS_PREFIX`), matched case-insensitively.

`SystemHandler::new` gained a `consensus_prefix` parameter; the production call site and the six test call sites were updated.

## Scope (settled design decision)
Lean parametrization only — **no** `RoutingHint` structured field and **no** content-sniffing removal (that remains future work). Two config params, **no DB migration**, full back-compat (defaults reproduce current behaviour).

## Verification
- `scripts/verify-issues.sh`: **bug-282** and **bug-285** both `[FIXED]` (the hard-coded literals are absent). Overall 0 errors / 0 stale.
- New config tests `test_consensus_prefix_default` / `test_consensus_prefix_custom`.
- CI clippy (`--workspace --exclude app` with the repo allow-list) + `cargo fmt --check` + `cargo test --workspace --exclude app` (293+ passed) all green.

## Notes
- Branch from master; independent of the (already-merged) Group B1 / C1 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)