### PR TITLE
docs: recall-contamination report (§1-13) + bug-396 + A/B harness

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -179,7 +179,9 @@ pub struct AppConfig {
     pub allow_unsigned: bool,
     /// Master switch for OS-level isolation. Default: true.
     pub isolation_enabled: bool,
-    /// Base directory for MCP server sandboxes. Default: "data/mcp-sandbox".
+    /// Base directory for MCP server sandboxes. Default: `data_dir()/mcp-sandbox`
+    /// (absolute, exe-anchored — its parent doubles as the Magic Seal key dir,
+    /// so it must not depend on the process CWD; see bug-395).
     pub sandbox_base_dir: PathBuf,
     /// Run a quick health scan on startup. Default: true.
     pub health_scan_on_startup: bool,
@@ -663,8 +665,17 @@ impl AppConfig {
             allow_unsigned: env::var("CLOTO_ALLOW_UNSIGNED").is_ok_and(|v| v == "true" || v == "1"),
             isolation_enabled: env::var("CLOTO_ISOLATION_ENABLED")
                 .map_or(true, |v| v != "false" && v != "0"), // Default: true
+            // Anchor the default sandbox dir to the absolute `data_dir()`, NOT a
+            // CWD-relative path. The Magic Seal key lives at
+            // `sandbox_base_dir.parent()/seal.key`; if this defaulted to the
+            // relative "data/mcp-sandbox" it resolved against the process CWD,
+            // which diverges from `data_dir()` (exe-relative) whenever the kernel
+            // is launched from elsewhere (e.g. `tauri dev`, CWD = dashboard/
+            // src-tauri). That made the kernel read the wrong seal.key and fail
+            // every sealed MCP server with "Magic Seal verification failed" even
+            // though the seals were valid for the real data dir (bug-395).
             sandbox_base_dir: env::var("CLOTO_SANDBOX_DIR")
-                .map_or_else(|_| PathBuf::from("data/mcp-sandbox"), PathBuf::from),
+                .map_or_else(|_| data_dir().join("mcp-sandbox"), PathBuf::from),
             health_scan_on_startup: env::var("CLOTO_HEALTH_SCAN_ON_STARTUP")
                 .map_or(true, |v| v != "false" && v != "0"),
         })

--- a/docs/RECALL_CONTAMINATION_AB_2026-06-14.md
+++ b/docs/RECALL_CONTAMINATION_AB_2026-06-14.md
@@ -322,6 +322,95 @@ re-measure on the embeddings-on bench. Environment used: kernel launched headles
 with `CPERSONA_EMBEDDING_MODE=http CPERSONA_EMBEDDING_URL=http://127.0.0.1:8401/embed
 CPERSONA_VECTOR_SEARCH_MODE=local`.
 
+## 10. Controlled re-measurement (2026-06-14, post-§9): the naive trigram-OR fix is FALSIFIED
+
+§9.4 recommended fixing Bug B by decomposing CJK query runs into overlapping
+trigram OR-terms. A prototype of exactly that was built (`_build_fts_query`,
+saved as `/tmp/cpersona_bugB_trigram_prototype.patch`) and measured. **It does
+not reduce contamination — it makes it slightly worse.**
+
+### 10.1 Method (confound removed)
+
+The §9.2 (pre-fix) and the first post-fix run used *different* embedding
+providers, so their absolute cosines (~0.78 vs ~0.50) were not comparable. This
+run holds the provider **fixed** (`onnx_bge_m3`, quantised, @ :8401, local
+cosine) and toggles **only** the FTS query builder in-process — OLD
+(`query.split()`) vs NEW (trigram-OR). 40-memory embedded DB, `agent.cpersona_bench`,
+RRF, autocut on. Metric: count of raspberry-bearing items in the final recall.
+
+### 10.2 Result
+
+| query | OLD (split) | NEW (trigram-OR) |
+| --- | --- | --- |
+| `この前のパンの話覚えてる?` | 2 / 8 | **1 / 4, but raspberry pie ranks #1** |
+| `パン` | 1 / 4 | 1 / 4 |
+| `ラズベリーパイについて覚えてる?` (correct target) | 5 / 8 | 5 / 5 |
+| `git push の件` | 0 / 1 | **2 / 3, raspberry #1** |
+| `今日の天気` | 0 / 8 | 0 / 8 |
+| **TOTAL raspberry items** | **8** | **9 (+1, worse)** |
+
+### 10.3 Mechanism — single root cause: RRF rank-flattening (bm25-measured)
+
+> **Correction.** An earlier draft of this section blamed "grammatical-trigram
+> bridges" (the query's `覚えて` matching assistant replies). **That was wrong.**
+> Direct df/bm25 measurement (`/tmp/bm25b.out`) shows every grammatical trigram
+> has **df = 0** — it matches nothing. The real, *single* root cause is RRF
+> discarding bm25 magnitude.
+
+For the bread query, only the **content** trigram fires; the glue trigrams are inert:
+
+| trigram | df | trigram | df |
+| --- | --- | --- | --- |
+| `のパン` | **6** | `覚えて` | 0 |
+| `この前` / `の前の` / `前のパ` / `パンの` | 0 | `ンの話` / `の話覚` / `話覚え` / `えてる` | 0 |
+
+The keyword channel's bm25 then ranks correctly (lower = better). The RRF
+contribution at each rank (K=60) shows the flattening that erases it:
+
+| doc | bm25 | RRF (K=60) |
+| --- | --- | --- |
+| 🥐 bread | −2.396 | 1/61 = 0.01639 |
+| 🥐 bread | −2.370 | 1/62 = 0.01613 |
+| 🥐 bread (store-ack) | −2.208 | 1/63 = 0.01587 |
+| 🍓 pie reply | −1.662 | 1/64 = 0.01562 |
+
+bm25 separates bread from pie by a **44 % margin** (−2.40 vs −1.66); RRF compresses
+it to a **5 %** gap (0.01639 vs 0.01562). The near-equal *vector* channel (pie ≈
+bread in cosine) then tips the merge to the contaminant. The `git push` case is
+identical — real git memory bm25 −7.75 vs the git-conflict reply −2.87, flattened
+to 1/61 vs 1/62. (The pie reply matches `のパン` only because the seed corpus bundles
+multi-topic assistant replies — `…先日は近所のパン屋さんのク…` — a fixture artifact, not a
+query-construction flaw.)
+
+### 10.4 Selected fix: direction B (merge-layer, magnitude-aware)
+
+The trigram-OR query builder is **not** the problem and needs no morphological
+stopword removal — the glue trigrams it emits are inert (df = 0), so direction (A)
+is unnecessary. The fix is at the **merge layer (B)**: make the merge respect bm25
+magnitude instead of pure rank, so the large, correct keyword margins survive into
+the final ranking. This is dependency-free and answers the open question "can the
+merge account for bm25/cosine magnitude?".
+
+Caveats:
+- Bug B's *query builder* fix (trigram decomposition) is still a **precondition** —
+  without it the keyword channel is empty for Japanese — but it MUST ship paired
+  with the magnitude-aware merge, never alone (alone it regresses, §10.2).
+- Bug A (env-key mismatch) is independent and still real.
+- **Provider fidelity.** The `onnx_bge_m3` provider here is quantised (cosines ~0.5
+  vs the seed BLOBs' ~0.78). The relative bread-vs-pie cosine gap is robust (so the
+  §9.2 "cosine cannot separate" conclusion stands), but a definitive end-to-end A/B
+  of the merge fix should embed seed corpus and queries with the **same
+  high-fidelity** bge-m3 provider. (The bm25 evidence above is provider-independent —
+  it is pure FTS.)
+
+### 10.5 Status
+
+Prototype reverted (canonical cpersona is clean; patch at
+`/tmp/cpersona_bugB_trigram_prototype.patch`). bm25 evidence: `/tmp/bm25b.out`.
+Decisions taken (doctor, 2026-06-14): fix = **direction B**; register Bug A + Bug B
+in a **new `cpersona/qa/issue-registry.json`**. Next: stand up that registry +
+entries, then design the magnitude-aware merge.
+
 ---
 
 *Report author: ClotoCore Project*

--- a/docs/RECALL_CONTAMINATION_AB_2026-06-14.md
+++ b/docs/RECALL_CONTAMINATION_AB_2026-06-14.md
@@ -1,0 +1,330 @@
+# CPersona Recall Contamination — Redesign AB Test Report (2026-06-14)
+
+> **Status:** Measurement complete. The Discord-recall redesign (session-start-gated
+> recall + per-channel episodic loop), measured same-conditions against the pre-redesign
+> baseline on DeepSeek, **regresses** topic-drift contamination (+28.5 pp severe).
+> Root cause is unchanged from the [2026-04-24 report](RECALL_CONTAMINATION_AB_2026-04-24.md)
+> §4.4: recall **precision**, not recall **timing**.
+>
+> **⚠️ CORRECTION — see §9 (added later the same day).** §2–§6 below were written
+> while CPersona embeddings were **off** (mode=none) — so the §3 numbers are an
+> FTS-only path, and the §6.2 "improve cpersona precision (RSF / MMR / gap filter)"
+> recommendation is **superseded**. Follow-up investigation (with embeddings enabled,
+> bge-m3) found the real root cause is **two concrete bugs** (env-key mismatch +
+> FTS whitespace-split); cosine-magnitude techniques (RSF/hybrid/gap) do **not** fix
+> it. §9 is authoritative for the conclusion and next steps.
+> **Scope:** ClotoCore kernel recall path (`handlers/system.rs`) + CPersona recall pipeline.
+> **Successor to:** [`RECALL_CONTAMINATION_AB_2026-04-24.md`](RECALL_CONTAMINATION_AB_2026-04-24.md)
+> (which found ~23% severe drift and identified the cosine-distribution root cause).
+
+## 1. Background
+
+### 1.1 What the redesign changed
+
+The Discord-recall redesign (CSC Goal #119) hypothesised that **per-turn long-term
+recall** is the contamination source, and gated it. The branches under test:
+
+- **ClotoCore** `feat/discord-recall-gating` — Phase 2a: the kernel pulls long-term
+  recall only on the **first turn** of a bridge session (`is_session_start =
+  snapshot_transcript(session_key).is_empty()`); continuing turns skip auto-recall.
+  Plus Phase 2b transcript bound, Phase 3a episode archival on Cold eviction, and
+  Phase 3c session-start episode grounding (`channel`-scoped recall, `[Episode]`-prefix
+  filtered).
+- **clotohub-servers** `feat/discord-per-channel-session` — Phase 1 (1 channel = 1
+  session) + Phase 4 operator-configurable recall discipline.
+- **cpersona** `feat/episode-channel-scoping` — `episodes.channel` column.
+
+### 1.2 Premise under test
+
+> "Per-turn recall injects recalled memories as chat-turns every turn and drives
+> topic-drift; gating recall to session-start will reduce contamination."
+
+This report tests that premise empirically and finds it **inverted** on DeepSeek.
+
+## 2. AB Test Methodology
+
+### 2.1 Fixed inputs
+
+- **Agent**: `agent.cpersona_bench` (dedicated bench agent; production agents untouched)
+- **Engine**: `deepseek` (DeepSeek API via the `deepseek` MCP connector)
+- **Memory**: `cpersona` (flat install, catalog version), embedding server up
+- **Corpus**: the 19-memory `seed_corpus.json` (pan/croissant breakfast → raspberry
+  pie → unrelated topics), the same contamination setup as 2026-04-24
+- **Query set**: 14 queries / 6 categories (`scripts/recall_ab/query_set.json`),
+  identical to 2026-04-24 (`この前のパンの話覚えてる?` … `週末の予定`)
+- **N = 3 trials per query per arm**, each trial an **accumulating** session (the
+  redesign's gate only acts on continuing turns, so a multi-turn session is required)
+- **Common baseline**: a clean post-seed (19-memory) snapshot of the kernel's
+  CPersona DB, restored before **both** arms via file snapshot/restore — never a
+  destructive delete (`scripts/recall_ab/README.md`)
+
+### 2.2 Arms
+
+| Arm | Kernel build | Recall behaviour |
+|---|---|---|
+| `old` | `master` @ 4afb050 (bug-395 seal fix only) | per-turn recall (pre-redesign) |
+| `new` | `feat/discord-recall-gating` (rebased on master) | session-start-gated recall + Phase 3 grounding |
+
+The only variable is the kernel build. Engine, corpus, query set, classifier, and
+starting memory state are identical. (`master` carries the bug-395 seal fix so the
+`deepseek` connector verifies and connects under both arms.)
+
+### 2.3 Metric
+
+`scripts/recall_ab/run_ab.py` classifies each response via the §2.3 rubric of the
+2026-04-24 report (heuristic): severe = unrelated-topic keyword present + elaboration;
+mild = present but disclaimed; coherent = otherwise. `severe%` is severe ÷
+(non-timeout, non-error) trials. The harness performs no destructive DB operations.
+
+### 2.4 Methodology caveat — a corrected first pass (bug-396)
+
+The first measurement pass reported a **false 0% drift for both arms**. Root cause:
+the bench agent's `default_engine_id` was `mind.deepseek`, but the connector installs
+under the ClotoHub catalog id `deepseek`, and the kernel resolves engines by **exact**
+server-name match (`run_agentic_loop`: `if mcp.has_server(engine_id).await`,
+`handlers/system.rs` ~L1369, no `mind.` alias). `has_server("mind.deepseek")` is false,
+so every turn returned the literal string `"[Error] Engine 'mind.deepseek' not found"`
+as its content. That string contains no contaminant keyword, so the heuristic
+classifier scored all 42 turns `coherent` — a spurious 0%. This is filed as **bug-396**
+(`qa/issue-registry.json`). The measurement below was re-run after repointing the bench
+agent to `default_engine_id=deepseek`. **Lesson: the harness should treat an
+`[Error]`/engine-error response as `error`, not `coherent`.**
+
+## 3. Results
+
+### 3.1 Aggregate (14 queries × 3 trials = 42 per arm, same clean-19 baseline)
+
+| Arm | Coherent | Mild | Severe | Timeout | Error | Sev%/Completed |
+|---|---|---|---|---|---|---|
+| `old` (per-turn recall) | 21 | 9 | 12 | 0 | 0 | **28.6%** |
+| `new` (session-start gated) | 9 | 9 | 24 | 0 | 0 | **57.1%** |
+
+**Delta (new − old): +28.5 pp — a regression.** No completion-rate cost (0 timeout /
+0 error in both arms), so this is not the L2 timeout-spike failure mode of 2026-04-24;
+it is a pure drift increase. The `old` arm's 28.6% reproduces the 2026-04-24 baseline
+(~23%) closely, validating the harness.
+
+### 3.2 Per-query × arm (3 trials per cell)
+
+`C` = coherent, `m` = mild, `S` = severe.
+
+| Query | `old` | `new` |
+|---|---|---|
+| A1 `この前のパンの話覚えてる?` | CCS | SCS |
+| A2 `昨日話したパンの件、どうなった?` | CmS | CSS |
+| B3 `ラズベリーパイについて覚えてる?` | CCC | SSS |
+| B4 `Raspberry Pi って何?` | SmS | mmS |
+| C5 `パン` | CSm | SSS |
+| C6 `朝食` | CSS | SCS |
+| C7 `ラズベリーパイ` | CCC | mSS |
+| D8 `昨日何話してたっけ` | SmS | SSS |
+| D9 `このセッションで何話した?` | mmS | mSS |
+| D10 `私の好きな食べ物は?` | mSS | mmC |
+| E11 `git push の件` | CCC | CCS |
+| E12 `Discord の話` | CCC | CCS |
+| F13 `今日の天気` | CCC | SmC |
+| F14 `週末の予定` | mmC | mmS |
+
+Notable inversions: B3/C7 (on-topic raspberry-pie queries) and E11/E12 (git/Discord
+queries unrelated to the food cluster) are clean under `old` but drift under `new`.
+
+## 4. Findings
+
+### 4.1 The redesign regresses on DeepSeek
+
+Gating recall to session-start raised severe drift from 28.6% to 57.1%. The premise
+("per-turn recall is the contamination source") is **inverted** for this engine.
+
+### 4.2 Mechanism — per-turn recall is also *corrective grounding*
+
+Reading both context-assembly paths (`old` = `master:handlers/system.rs` L442/L541;
+`new` = `feat:handlers/system.rs` L449–621):
+
+- **`old`** builds, every turn, `context = recall(current query) + T1 transcript`.
+  The per-turn recall is **query-specific**: a "git push" turn recalls git memories
+  and pulls the model back on-topic (E11 `CCC`).
+- **`new`** recalls only on turn 1; continuing turns use `context = T1 transcript`
+  alone.
+
+Both arms keep turn-1's response in the accumulating T1 transcript. The decisive
+difference is what turn 1 does and what corrects it afterward. Raw responses confirm:
+the `new` arm's turn-1 recall (triggered by the bread query A1) surfaces the loosely
+related cluster (pan/croissant/raspberry-pie/Raspberry Pi); DeepSeek fuses them into a
+"double-meaning" narrative; that narrative is pinned in the transcript and, with **no
+per-turn corrective recall**, dominates every subsequent turn — even unrelated ones
+(E11/E12, F13/F14). Per-turn recall, while it can inject off-topic memories, also
+provides per-query relevant grounding that self-corrects drift. Gating it removes the
+correction.
+
+### 4.3 Root cause is unchanged: recall *precision*, not *timing*
+
+This confirms [2026-04-24 §4.4](RECALL_CONTAMINATION_AB_2026-04-24.md): the contaminant
+(`人生で初めてラズベリーパイを食べた`, cos ≈ 0.31) sits just above the adaptive threshold
+(≈ 0.29) for the bread query, because `パン`↔`パイ` share katakana, the past-tense
+"…食べた" frame matches, and jina-v5-nano is not fine-tuned for Japanese food semantics.
+No recall *timing* policy (per-turn vs session-start) changes which memories cross that
+threshold. The 2026-04-24 L2 presentation change regressed; the 2026-06-14 timing change
+regresses. Both are downstream of a precision problem.
+
+## 5. Design-principles analysis (ARCHITECTURE.md §1, DEVELOPMENT.md §1.4)
+
+The redesign and the candidate fixes were reviewed against the architecture manifesto.
+
+- **§1.1 Core Minimalism — "the Kernel is the stage, not the actor."** Prohibits
+  hard-coding "processing logic for specific memory formats" in the kernel. The Phase 3c
+  grounding step filters recall results by the `[Episode]` content prefix **inside the
+  kernel** (`handlers/system.rs`), i.e. the kernel interprets a memory-format convention.
+  This is in tension with §1.1.
+- **§1.4 Data Sovereignty — "the Kernel holds the data but does not interpret its
+  contents."** Recall *relevance/precision* is interpretation of memory content; per the
+  principle it belongs to the Memory capability (cpersona), not the kernel.
+- **§1.2 Capability over Concrete Type — "not who it is, but what it can do."** The
+  proposed bug-396 fix (c) — a kernel-side `mind.`-prefix alias in engine resolution —
+  branches kernel logic on a name convention, which §1.2 discourages. The compliant
+  fixes are data-side: **(a)** restore the catalog connector id to `mind.deepseek`
+  (matching the `mind.local` convention agents already reference), or **(b)** update
+  agents' `default_engine_id` to `deepseek`.
+
+**Conclusion:** the principle-aligned locus for contamination work is the **CPersona
+memory plugin** (recall precision), not kernel-side recall orchestration. The kernel
+should call the Memory capability and let the plugin decide what is relevant.
+
+## 6. Recommendation
+
+1. **Do not land the recall-gating redesign as a contamination fix.** It regresses on
+   DeepSeek and adds kernel-side memory logic that is in tension with §1.1/§1.4. (Its
+   Phase 1 "1 channel = 1 session" bridge change is orthogonal and may stand on its own
+   merits; the kernel gating/grounding is what this report argues against.)
+2. **Pursue recall precision in cpersona** (the 2026-04-24 §5.3 "future work", all
+   plugin-side): threshold recalibration against the jina-v5-nano distribution; MMR /
+   diversity-aware reranking; a top-1-anchored relevance-gap filter (drop results far
+   below the top match so a 0.59 hit suppresses a 0.31 contaminant while a query whose
+   best hit is 0.30 still returns it); or a stronger / fine-tuned embedding model.
+3. **Fix bug-396 data-side** ((a) catalog id or (b) agent config), not kernel-side (c).
+4. **Harden the harness**: classify `[Error]`/engine-error responses as `error`, not
+   `coherent`, so an engine misconfiguration can never masquerade as 0% drift again.
+
+## 7. Reproducing the measurement
+
+Prerequisites: ClotoCore reachable on `http://127.0.0.1:8081`; a bench agent with a
+working reasoning engine (`default_engine_id` must equal the **registered** MCP server
+name — see bug-396) and `cpersona` memory; embedding server up; DeepSeek credits
+(~$2 for 2 × 42 trials).
+
+```bash
+# harness is branch-independent; copy out of the feat tree if checking out master:
+git archive feat/discord-recall-gating:scripts/recall_ab | tar -x -C /tmp/recall_ab
+cd /tmp/recall_ab
+export CLOTO_API_KEY=...                       # from .env
+
+# 1. seed clean-19 on whichever build is up, snapshot the kernel cpersona DB
+python run_ab.py --agent-id agent.cpersona_bench --seed
+sqlite3 <data>/cpersona.db ".backup /tmp/seed19.db"
+
+# 2. OLD arm on master (bug-395 seal fix), then restore the snapshot
+python run_ab.py --agent-id agent.cpersona_bench --arm old --trials 3
+# 3. NEW arm on feat from the same snapshot
+#    (restore /tmp/seed19.db over the kernel cpersona DB while the kernel is stopped)
+python run_ab.py --agent-id agent.cpersona_bench --arm new --trials 3
+
+# 4. compare
+python compare.py results/results_old.json results/results_new.json
+```
+
+Run via `uv run --python 3.13 --with httpx python …` (uv's default 3.14 hangs
+pytest-asyncio in this monorepo). Use `--python 3.13`.
+
+## 8. Artifacts
+
+- Harness: `scripts/recall_ab/` (query_set.json, seed_corpus.json, run_ab.py,
+  compare.py, README.md)
+- Results captured this run: `results_old.json` (28.6%), `results_new.json` (57.1%)
+- Related: **bug-396** (`qa/issue-registry.json`) — `mind.deepseek` engine unresolvable
+- Predecessor: [`RECALL_CONTAMINATION_AB_2026-04-24.md`](RECALL_CONTAMINATION_AB_2026-04-24.md)
+
+---
+
+## 9. Addendum & Correction (later 2026-06-14) — embeddings were off; two real bugs
+
+After §1–§8 were written, a pre-prototype recall measurement (per the doctor's
+request to *measure before fixing*) overturned the framing above. This section is
+authoritative.
+
+### 9.1 The §3 A/B ran with CPersona embeddings OFF
+
+Kernel log (cpersona): `Embedding disabled (mode=none), using FTS5 + keyword only`.
+`memories.embedding` was NULL for 0/79 rows. The embedding server (`tool.embedding`,
+auto_bge_m3, `:8401`) was running but cpersona was **not wired to it**. So the §3
+numbers (28.6% / 57.1%) reflect an **FTS-only** recall path, not the production
+semantic path (2026-04-24 ran with embeddings on, jina-v5-nano). The NEW-vs-OLD
+*regression* still holds mechanistically (§4.2 — it is about transcript pinning +
+loss of per-turn corrective recall, independent of recall content), but the absolute
+rates are not production-representative.
+
+### 9.2 With embeddings enabled (bge-m3, local cosine), the contaminant IS recalled — and cosine can't separate it
+
+Wired cpersona to `:8401` via `CPERSONA_EMBEDDING_MODE=http`, re-seeded, re-measured
+the bread query `この前のパンの話覚えてる?`:
+
+| cosine | memory |
+|---|---|
+| 0.783 / 0.769 / 0.762 | パン屋 / クロワッサン (correct) |
+| **0.751 / 0.747** | **ラズベリーパイ (contaminant)** |
+
+The contaminant sits ~0.01–0.03 below the correct match. No gap/ratio/RSF threshold
+separates 0.76 from 0.75 (`gap/top ≈ 0.04 ≪ autocut 0.15`; `ratio ≈ 0.96 ≫ 0.7`).
+**bge-m3 semantically conflates パン/ラズベリーパイ** (katakana + food/pie + past-tense
+frame), reproducing 2026-04-24 §4.4 even more tightly. ⇒ **cosine-magnitude techniques
+(RSF, hybrid, gap filter) cannot fix this** — there is no magnitude to exploit.
+
+### 9.3 The discriminating signal is keyword — and it is broken by two bugs
+
+The only signal that separates the two (the contaminant does **not** contain `パン`)
+is the keyword/FTS retriever. It is dead for Japanese due to:
+
+- **Bug A — embedding env-key mismatch (semantic recall silently off).** The catalog /
+  connector docs declare the generic keys `EMBEDDING_MODE` / `EMBEDDING_HTTP_URL`
+  (with "falls back to `CPERSONA_EMBEDDING_MODE`"), but `cpersona/config.py` reads
+  **only** `CPERSONA_EMBEDDING_MODE` / `CPERSONA_EMBEDDING_URL`. Setting the documented
+  generic keys is a no-op → embeddings stay `none`. (Default is `none` too.)
+  *Location:* `cpersona/config.py:10-11`; catalog `optional_env_vars` for cpersona.
+- **Bug B — FTS keyword query splits on whitespace (Japanese keyword search dead).**
+  `cpersona/memory_handlers.py::_search_memories_keyword` does
+  `words = re.sub(r"[^\w\s]","",query).split()` then `" ".join(f'"{w}"' …)`. Japanese
+  has no spaces → the whole sentence becomes **one** quoted FTS phrase → matches only
+  an exact full-sentence substring → ~0 hits. The `trigram` tokenizer (already in use —
+  `memories_fts … tokenize='trigram'`, so this is **not** a tokenizer-choice bug) is
+  wasted because the query is never broken into searchable n-grams. ASCII queries
+  (`git push`, `Discord`) split fine → keyword works → RRF discriminates → clean
+  (matches the §3.2 pattern: E11/E12 are `CCC`).
+
+### 9.4 Corrected recommendation
+
+1. **Fix Bug B** — build the FTS query for spaceless languages: split CJK runs into
+   overlapping bi-/tri-grams as separate OR terms (or per-segment terms) so the
+   `trigram` index is actually exercised. This restores the keyword retriever that
+   lets RRF separate topically-distinct-but-semantically-near memories. **Highest
+   leverage; it is what actually fixes the bread/raspberry case.**
+2. **Fix Bug A** — make cpersona read the generic `EMBEDDING_MODE` / `EMBEDDING_HTTP_URL`
+   (with `CPERSONA_*` as documented fallback), or correct the catalog/docs to the
+   `CPERSONA_*` names. Either way, ensure marketplace-installed cpersona can actually
+   enable semantic recall.
+3. **Do NOT pursue RSF / hybrid / gap-filter for this contamination** — the cosines are
+   near-equal; magnitude carries no separating signal here. (RSF may still help other
+   cases where cosine *is* discriminative; it is simply not the fix for this one.)
+4. The kernel-side recall-gating redesign remains a non-fix (§6.1).
+
+### 9.5 Status / next (pending doctor's go-ahead)
+
+Formally register Bug A + Bug B (cpersona has no `qa/issue-registry.json`; needs a
+location decision), then prototype Bug B (Japanese FTS query construction) and
+re-measure on the embeddings-on bench. Environment used: kernel launched headless
+with `CPERSONA_EMBEDDING_MODE=http CPERSONA_EMBEDDING_URL=http://127.0.0.1:8401/embed
+CPERSONA_VECTOR_SEARCH_MODE=local`.
+
+---
+
+*Report author: ClotoCore Project*
+*Measurement date: 2026-06-14*
+*Arms: `master` @ 4afb050 (old) vs `feat/discord-recall-gating` rebased (new); engine `deepseek`; agent `agent.cpersona_bench`; clean-19 common baseline; N=3.*
+*§9 correction: embeddings were off during §3; real root cause = Bug A (env-key mismatch) + Bug B (FTS whitespace-split). bge-m3 re-measurement confirms cosine cannot separate the contaminant.*

--- a/docs/RECALL_CONTAMINATION_AB_2026-06-14.md
+++ b/docs/RECALL_CONTAMINATION_AB_2026-06-14.md
@@ -441,6 +441,39 @@ opt-in, A/B-able). Requires: (a) the trigram query builder [bug-002 fix, precond
 sums, plus plumbing the fused `_rsf_score` through `_apply_quality_gate` and `_autocut`.
 Bug A (env-key) is independent and still tracked separately.
 
+## 12. High-fidelity confirmation (fp32 bge-m3 on CPU) — resolves the provider caveat
+
+The §10.4 / §11 caveat (the quantised `onnx_bge_m3` provider, cosines ~0.5) is now
+resolved by re-running against **full-precision fp32 bge-m3** (`Xenova/bge-m3`
+`onnx/model.onnx` + `model.onnx_data`, CPU EP, `ONNX_MAX_SEQ_LEN=256`). The test DB's
+BLOBs were re-embedded with fp32 and queries embedded with the same provider — seed and
+query fully self-consistent (`self-cosine = 1.0000`).
+
+**Finding 1 — quantisation was a non-issue.** fp32 cosines are essentially identical to
+int8: `cos(bread_query, bread) = 0.539` (fp32) vs `0.50` (int8); `cos(bread_query, pie)
+= 0.477` vs `0.47`. The earlier `~0.78` figures (§9.2, pre-`/compact`) did **not** come
+from a higher-fidelity bge-m3 — genuine bge-m3 self-consistent cosines for these texts
+are ~0.5. So "cosine cannot separate bread from pie" holds **at full fidelity** (0.539
+vs 0.477, ratio 0.88).
+
+**Finding 2 — RSF's advantage is confirmed and slightly stronger at fp32.** End-to-end
+`do_recall` A/B, RECALL_MODE rrf vs rsf, fp32 BLOBs + fp32 query provider:
+
+| query | RRF raspberry | RSF raspberry |
+| --- | --- | --- |
+| `この前のパンの話覚えてる?` | 1 / 4 (pie #1) | **0 / 3** |
+| `パン` | 1 / 4 (pie #1) | **0 / 3** (int8 still had 1; fp32 clean) |
+| `ラズベリーパイについて覚えてる?` (target) | 5 / 5 | **2 / 2** |
+| `git push の件` | 2 / 3 | **0 / 1** |
+| `今日の天気` | 0 / 1 | 0 / 2 |
+| **TOTAL** | **9** | **2 (−78 %)** |
+
+vs the int8 run (9 → 3, −67 %). RSF eliminates contamination on every off-target query
+(bread / パン / git → 0) and keeps the raspberry target tight (2 / 2 correct); no correct
+result is dropped. **Conclusion: on this contamination benchmark RSF is clearly higher
+precision than RRF, and the result is not a quantisation artifact.** (Scope unchanged:
+single 40-memory synthetic corpus, recall-layer only; LLM-output drift is still Phase 5.)
+
 ---
 
 *Report author: ClotoCore Project*

--- a/docs/RECALL_CONTAMINATION_AB_2026-06-14.md
+++ b/docs/RECALL_CONTAMINATION_AB_2026-06-14.md
@@ -474,6 +474,25 @@ result is dropped. **Conclusion: on this contamination benchmark RSF is clearly 
 precision than RRF, and the result is not a quantisation artifact.** (Scope unchanged:
 single 40-memory synthetic corpus, recall-layer only; LLM-output drift is still Phase 5.)
 
+## 13. Default-mode decision (2026-06-15): keep `rrf` default, `rsf` opt-in
+
+Promoting `rsf` to the *global* default was considered and **deferred**. Running the
+full cpersona suite under `CPERSONA_RECALL_MODE=rsf` regresses one test
+(`test_isolation.py::test_recall_keyword_path_gamma_filter` — 82 passed / 1 failed): a
+2-result keyword recall drops a valid second item. Root cause: RSF's min-max
+normalization maps a 2-item channel to `{1.0, 0.0}`, and relative-gap `autocut` then
+cuts the lower item — a recall-completeness regression on small / closely-scored result
+sets (the min-max small-sample weakness the literature flags). Where the 40-item
+contamination case *wants* that cut, the small-set case does not.
+
+**Decision:** `rrf` stays the default; `rsf` is opt-in (`CPERSONA_RECALL_MODE=rsf`) and
+recommended for topic-drift-prone / space-less-language (Japanese) contexts (documented
+in the cpersona README). Promoting `rsf` to default first requires hardening the
+min-max + autocut interaction (relax autocut on small result sets, a normalization that
+does not pin the minimum to 0, or DBSF / z-score) and re-validating both the
+contamination bench and the full suite — with the Phase-5 LLM-output A/B as the final
+arbiter.
+
 ---
 
 *Report author: ClotoCore Project*

--- a/docs/RECALL_CONTAMINATION_AB_2026-06-14.md
+++ b/docs/RECALL_CONTAMINATION_AB_2026-06-14.md
@@ -411,6 +411,36 @@ Decisions taken (doctor, 2026-06-14): fix = **direction B**; register Bug A + Bu
 in a **new `cpersona/qa/issue-registry.json`**. Next: stand up that registry +
 entries, then design the magnitude-aware merge.
 
+## 11. RSF prototype validation — direction B1 confirmed (−64 % contamination)
+
+A standalone prototype (`/tmp/rsf2.out`) fuses the same channels by **relative-score
+fusion**: per-query min-max normalization of each channel's *raw* score (cosine for
+vector, −bm25 for FTS), summed — instead of RRF's rank. Both arms use the trigram
+query builder; identical `onnx_bge_m3` vector + bm25 FTS; relative-gap autocut applied.
+
+| query | RRF raspberry | RSF raspberry |
+| --- | --- | --- |
+| `この前のパンの話覚えてる?` | 1 / 4 (pie #4) | **0 / 3** (pie cut) |
+| `パン` | 3 / 10 | 2 / 5 |
+| `ラズベリーパイについて覚えてる?` (target) | 5 / 5 | 2 / 2 (tighter) |
+| `git push の件` | 2 / 3 | **0 / 1** |
+| `今日の天気` | 0 / 1 | 0 / 2 |
+| **TOTAL** | **11** | **4 (−64 %)** |
+
+RSF eliminates contamination on the bread and git queries: per-channel normalization
+preserves bm25's large margin (bread norm ≈ 1.0 vs pie ≈ 0.44 — cf. RRF's 5 % rank
+spread), and the relative-gap autocut then drops the contaminant. The residual on
+`パン` is a vector-only artifact (a 2-char query yields no trigram, so the prototype's
+keyword channel is empty; the production LIKE fallback returns bread-only and should
+remove it).
+
+**Implementation plan.** Add RSF as a new `RECALL_MODE=rsf` (rrf stays the default —
+opt-in, A/B-able). Requires: (a) the trigram query builder [bug-002 fix, precondition];
+(b) surfacing raw bm25 from the FTS searches (`_search_memories_keyword` /
+`_search_episodes_fts`); (c) a `_recall_rsf` that min-max-normalizes each channel and
+sums, plus plumbing the fused `_rsf_score` through `_apply_quality_gate` and `_autocut`.
+Bug A (env-key) is independent and still tracked separately.
+
 ---
 
 *Report author: ClotoCore Project*

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -2987,6 +2987,20 @@
       "status": "fixed",
       "github_issue": null,
       "fix_note": "PROPER FIX landed (Goal #112, roadmap item 6) on top of the interim (b'): the catalog serves the seal's dual-signature record (RegistryEntry.signature_payload, mgp-sdk v0.5.0, clotohub-web PR #30); local_seal_for_install verifies the Ed25519 signature over mgp_seal::canonical_message(id, version, entry_point_sha256) against the hub JWKS (/api/seal/keys, in-memory 1h-TTL cache + kid-miss refetch) and mints a LOCAL seal only on signature + hash match (declared tier preserved). D2 bifurcation: unsigned / JWKS-unavailable / malformed register unsealed (spawn forces untrusted per §10 inv 3); signature_invalid / integrity_mismatch hard-block as tamper suspects. Trust anchor upgraded from 'HTTPS to the catalog' to 'the hub's Ed25519 key'. The remaining `seal: entry.seal.clone()` occurrence is the display-only catalog UI projection. Interim history: keyless hash check + local re-seal (mgp-sdk v0.4.0, clotohub-web PR #29, ClotoCore PR #176)."
+    },
+    {
+      "id": "bug-395",
+      "summary": "HIGH: sandbox_base_dir (and therefore the Magic Seal key directory, sandbox_base_dir.parent()/seal.key) defaulted to the CWD-relative \"data/mcp-sandbox\" instead of being anchored to the absolute data_dir(). data_dir() resolves to exe_dir()/data (e.g. target/debug/data) where the install-time seal.key lives and every server seal is minted, but the relative default resolves against the process CWD. Launching the kernel from a different CWD (notably `tauri dev`, CWD = dashboard/src-tauri) makes load_or_generate_seal_key read dashboard/src-tauri/data/seal.key — a DIFFERENT key — so check_seal recomputes a non-matching HMAC and every sealed MCP server (cpersona, deepseek, cscheduler, terminal, websearch) hard-blocks at spawn with 'Magic Seal verification failed — binary may be tampered'. This is NOT bug-394 (the stored seals are valid local HMACs for the real data dir; only the key path is wrong). Proven: cpersona's stored seal HMAC-matches ONLY target/debug/data/seal.key (not dashboard/src-tauri/data/seal.key), and the running kernel (CWD=dashboard/src-tauri, no CLOTO_SANDBOX_DIR/CLOTO_SEAL_KEY set) created dashboard/src-tauri/data/mcp-sandbox.",
+      "severity": "HIGH",
+      "discovered": "2026-06-14T03:00:00Z",
+      "version": "0.6.8-beta.1",
+      "commit": "3b4bde7",
+      "file": "crates/core/src/config.rs",
+      "pattern": "PathBuf::from\\(\"data/mcp-sandbox\"\\)",
+      "expected": "absent",
+      "status": "fixed",
+      "github_issue": null,
+      "fix_note": "Fixed: the default sandbox_base_dir now resolves to data_dir().join(\"mcp-sandbox\") (absolute, exe-anchored) so sandbox_base_dir.parent() == data_dir() and the seal.key path is CWD-independent. The CLOTO_SANDBOX_DIR override path is unchanged. After the fix the kernel reads the correct target/debug/data/seal.key and sealed servers whose entry-point files are intact verify. Separate, still-open issue (not this entry): cscheduler/deepseek carry doubled install paths (mcp-servers/servers/<id>/servers/<id>/server.py) pointing at wrong/stub files, which fail seal under any key — to be tracked on its own."
     }
   ]
 }

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -3001,6 +3001,20 @@
       "status": "fixed",
       "github_issue": null,
       "fix_note": "Fixed: the default sandbox_base_dir now resolves to data_dir().join(\"mcp-sandbox\") (absolute, exe-anchored) so sandbox_base_dir.parent() == data_dir() and the seal.key path is CWD-independent. The CLOTO_SANDBOX_DIR override path is unchanged. After the fix the kernel reads the correct target/debug/data/seal.key and sealed servers whose entry-point files are intact verify. Separate, still-open issue (not this entry): cscheduler/deepseek carry doubled install paths (mcp-servers/servers/<id>/servers/<id>/server.py) pointing at wrong/stub files, which fail seal under any key — to be tracked on its own."
+    },
+    {
+      "id": "bug-396",
+      "summary": "HIGH: Agent.default_engine_id 'mind.deepseek' is unresolvable — the agentic loop resolves an engine by EXACT server-name match (run_agentic_loop: `if mcp.has_server(engine_id).await`, system.rs ~1369, with no 'mind.' prefix/alias normalization), but the DeepSeek connector installs under the ClotoHub catalog id 'deepseek' (the catalog renamed the connector mind.deepseek -> deepseek), so its registered MCP server name is 'deepseek'. has_server(\"mind.deepseek\") is false and no Rust plugin matches, so every think / think_with_tools for an agent whose default_engine_id is 'mind.deepseek' (agent.cloto_default, agent.karin, agent.cpersona_bench) returns the literal string \"[Error] Engine 'mind.deepseek' not found\" as the response content. mind.local works only because its server name literally is 'mind.local'. Runtime-proven 2026-06-14: with the deepseek MCP server Connected (2 tools, seal verified) the Phase 5 A/B probe got the not-found error for all 14 queries until agent.cpersona_bench was repointed to default_engine_id='deepseek'. This silently corrupted the first A/B pass (the error string contains no contaminant keyword, so the heuristic classifier scored all turns 'coherent' = a false 0% drift). NOTE: the real evidence is runtime (the error string + the agents / mcp_servers DB rows); the pattern below only pins the exact-match resolution locus, so this stays expected=present until a fix changes that line.",
+      "severity": "HIGH",
+      "discovered": "2026-06-14T06:30:00Z",
+      "version": "0.6.8-beta.1",
+      "commit": "742519c",
+      "file": "crates/core/src/handlers/system.rs",
+      "pattern": "if mcp\\.has_server\\(engine_id\\)\\.await",
+      "expected": "present",
+      "status": "open",
+      "github_issue": null,
+      "fix_note": "Open — three fix options to decide: (a) catalog-side: restore the connector id to 'mind.deepseek' in the ClotoHub catalog (clotohub-web) so installs register the mind.* name agents already reference, matching the mind.local convention; (b) data-side: change agents' default_engine_id from 'mind.deepseek' to 'deepseek' (diverges from the mind.* convention and re-breaks if other mind.* connectors are renamed); (c) kernel-side: make engine resolution tolerant — when has_server(engine_id) misses and engine_id starts with 'mind.', retry with the bare suffix (and vice versa), bridging the catalog/agent naming gap centrally. Design-principles review (ARCHITECTURE.md §1.2 Capability over Concrete Type — 'do not branch logic by directly referencing plugin IDs or names'): (c) makes the kernel branch on the 'mind.' name convention, so it is in TENSION with §1.2 and is NOT preferred despite being the in-repo locus this entry's file/pattern anchor to. The principle-compliant fixes are data-side: prefer (a) catalog id, else (b) agent config. Interim A/B workaround only: agent.cpersona_bench.default_engine_id set to 'deepseek' directly in cloto_memories.db. See docs/RECALL_CONTAMINATION_AB_2026-06-14.md §5."
     }
   ]
 }

--- a/scripts/recall_ab/.gitignore
+++ b/scripts/recall_ab/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+results/

--- a/scripts/recall_ab/README.md
+++ b/scripts/recall_ab/README.md
@@ -1,0 +1,125 @@
+# Recall-contamination A/B harness (Phase 5)
+
+Measures topic-drift ("pan → raspberry pie") severity on a running ClotoCore
+kernel so the **OLD** recall behaviour (long-term recall every turn) can be
+compared against the **NEW** behaviour from the Discord-recall redesign
+(session-start-gated recall + per-channel episodic loop + per-agent recall
+instructions).
+
+It is the redesign-era successor to the one-off harness described in
+[`docs/RECALL_CONTAMINATION_AB_2026-04-24.md`](../../docs/RECALL_CONTAMINATION_AB_2026-04-24.md),
+which found a persistent ~23% severe-drift rate that the redesign aims to cut.
+
+## Why one accumulating session matters
+
+The NEW gate only suppresses recall on **continuing** turns (the in-flight T1
+transcript is non-empty). So the benefit only shows up across a multi-turn
+conversation: turn 1 is a session-start (recall fires), turns 2–N do not
+auto-recall. The harness therefore sends the 14 probe queries as a single
+**accumulating** session, repeated `--trials` times. Running each query in its
+own fresh session would make every query a session-start and erase the gate's
+effect (≈ the OLD behaviour).
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `query_set.json` | 14 probe queries (6 categories) + per-query contaminant keywords |
+| `seed_corpus.json` | ~19 memories that reproduce the bread/raspberry-pie contamination |
+| `run_ab.py` | seeds, runs the probe via `/api/chat` + SSE, classifies, writes `results_<arm>.json` |
+| `compare.py` | side-by-side OLD vs NEW + aggregate severe-drift delta |
+
+## Prerequisites
+
+- A running ClotoCore kernel reachable over HTTP (default `http://127.0.0.1:8081`).
+- A **dedicated test agent** (recommended) so production memories are untouched,
+  with a reasoning engine granted (`mind.*`) and a memory server granted
+  (`memory.cpersona`). The embedding server must be up for vector recall.
+- The kernel's `X-API-Key` if `admin_api_key` is configured.
+- Python with `httpx` (e.g. `uv run --with httpx python run_ab.py ...`).
+  Use Python 3.13 if running under `uv` — `uv`'s default 3.14 has hung
+  pytest-asyncio in this monorepo (unrelated to this script, but pin to be safe:
+  `uv run --python 3.13 --with httpx python run_ab.py ...`).
+
+Configuration is via flags or env vars:
+
+| flag | env | default |
+| --- | --- | --- |
+| `--base-url` | `CLOTO_BASE_URL` | `http://127.0.0.1:8081` |
+| `--api-key` | `CLOTO_API_KEY` | (none) |
+| `--agent-id` | `CLOTO_AB_AGENT` | `agent.cloto_default` |
+| `--arm` | `CLOTO_AB_ARM` | `unset` (output label only) |
+| `--source-id` | `CLOTO_AB_SOURCE_ID` | `abtest:user1` |
+| `--channel` | `CLOTO_AB_CHANNEL` | `chat` (use `discord` to mimic the bridge) |
+| `--trials` | `CLOTO_AB_TRIALS` | `3` |
+| `--response-timeout` | `CLOTO_AB_RESPONSE_TIMEOUT` | `90` (seconds) |
+
+`--arm` does **not** change behaviour — the arm is whichever kernel build is
+running. It only labels the output file.
+
+## Procedure
+
+> The script performs **no** destructive DB operations. You snapshot/restore the
+> test agent's CPersona rows between arms so each arm sees the same seed corpus
+> (probe turns are themselves stored as memories and would otherwise leak into
+> the next arm). Follow the project's destructive-DB rules — never `rm` the DB;
+> snapshot the file or use the CPersona export/`delete_agent_data` tooling on the
+> **test** agent only.
+
+1. **Build & run the kernel on the OLD branch** (e.g. `main`), with the test agent.
+2. **Seed once** (additive):
+   ```bash
+   uv run --python 3.13 --with httpx python run_ab.py \
+     --agent-id agent.abtest --seed
+   ```
+   Then snapshot the test agent's CPersona rows (the clean post-seed state).
+3. **Run the OLD arm:**
+   ```bash
+   uv run --python 3.13 --with httpx python run_ab.py \
+     --agent-id agent.abtest --arm old
+   ```
+   → writes `results/results_old.json`.
+4. **Restore** the post-seed snapshot (undo the probe-turn memories).
+5. **Build & run the kernel on the NEW branch** (the feature branches:
+   ClotoCore `feat/discord-recall-gating`, clotohub-servers
+   `feat/discord-per-channel-session`, cpersona `feat/episode-channel-scoping`),
+   restart against the same seeded test agent.
+6. **Run the NEW arm:**
+   ```bash
+   uv run --python 3.13 --with httpx python run_ab.py \
+     --agent-id agent.abtest --arm new
+   ```
+   → writes `results/results_new.json`.
+7. **Compare:**
+   ```bash
+   python compare.py results/results_old.json results/results_new.json
+   ```
+
+To also exercise the per-agent recall-instructions knob or the Discord channel
+path, set `--channel discord` and/or configure the test agent's
+`recall_instructions` in the agent settings, then add more arms.
+
+## Reading the results
+
+Each `results_<arm>.json` has per-query verdicts (`coherent` / `mild` /
+`severe` / `timeout` / `error`) across the trials and an aggregate
+`severe_pct_of_completed` (severe ÷ non-timeout/non-error trials, matching the
+original report's metric). The redesign is working if the NEW arm's severe%
+drops materially vs OLD, **without** a completion-rate (timeout) regression —
+the original L2 experiment failed exactly because it cut drift but spiked
+timeouts.
+
+## Classifier caveat
+
+`classify()` is a heuristic approximation of the report's §2.3 rubric
+(unrelated-topic keyword present + elaboration → severe; with a disclaimer →
+mild; otherwise coherent). It is good for relative OLD-vs-NEW comparison but is
+not a substitute for human judgement on borderline cases. The raw responses are
+not stored by default; add a dump if you want manual re-grading, or wire an
+LLM judge that scores each response against the rubric for higher fidelity.
+
+## Cost
+
+One LLM call per turn: ~19 (seed, once) + 14 × `trials` per arm. At `trials=3`
+that is ~42 calls/arm, ~84 across both arms, plus the one-time seed — on the
+order of the original report's ~$2 run, engine-dependent.

--- a/scripts/recall_ab/compare.py
+++ b/scripts/recall_ab/compare.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Compare two recall-A/B result files (e.g. OLD vs NEW arm).
+
+Usage: python compare.py results/results_old.json results/results_new.json
+Prints a per-query side-by-side and the aggregate severe-drift delta.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_SHORT = {"coherent": "C", "mild": "m", "severe": "S", "timeout": "T", "error": "E"}
+
+
+def _marks(verdicts: list[str]) -> str:
+    return "".join(_SHORT.get(v, "?") for v in verdicts)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    a = json.loads(Path(argv[1]).read_text(encoding="utf-8"))
+    b = json.loads(Path(argv[2]).read_text(encoding="utf-8"))
+    print(f"A = arm '{a['arm']}'   B = arm '{b['arm']}'   (C=coherent m=mild S=severe T=timeout E=error)\n")
+    print(f"{'id':>3}  {'A':<8} {'B':<8}  query")
+    for qid, info in a["per_query"].items():
+        bm = b["per_query"].get(qid, {}).get("verdicts", [])
+        print(f"{qid:>3}  {_marks(info['verdicts']):<8} {_marks(bm):<8}  {info['text']}")
+    sa = a["severe_pct_of_completed"]
+    sb = b["severe_pct_of_completed"]
+    print("\n--- aggregate ---")
+    print(f"A severe%: {sa}   counts={a['counts']}")
+    print(f"B severe%: {sb}   counts={b['counts']}")
+    print(f"delta (B - A): {round(sb - sa, 1)} pp  "
+          f"({'improvement' if sb < sa else 'regression' if sb > sa else 'no change'})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/recall_ab/query_set.json
+++ b/scripts/recall_ab/query_set.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Recall-contamination A/B probe set. Reconstructed from docs/RECALL_CONTAMINATION_AB_2026-04-24.md §2.1 (14 queries, 6 categories). Japanese is intentional — this is a Japanese-NLP test fixture (parent CLAUDE.md exempts JA fixtures from the English-only rule). `contaminant_keywords` = the unrelated topic that, if the model elaborates on it, counts as topic-drift. `false_positive: true` queries have no relevant memory, so ANY memory topic appearing is drift (classifier checks against `memory_topics`).",
+  "memory_topics": ["ラズベリーパイ", "ラズベリー", "raspberry", "パン", "パン屋", "クロワッサン", "git push", "rebase", "Discord", "寿司", "マグロ", "映画", "キーボード", "ランニング", "猫", "ミケ", "Rust"],
+  "queries": [
+    {"id": "A1", "category": "known-bad-drift", "text": "この前のパンの話覚えてる?", "contaminant_keywords": ["ラズベリーパイ", "ラズベリー", "raspberry", "パイ"]},
+    {"id": "A2", "category": "known-bad-drift", "text": "昨日話したパンの件、どうなった?", "contaminant_keywords": ["ラズベリーパイ", "ラズベリー", "raspberry", "パイ"]},
+    {"id": "B3", "category": "reverse", "text": "ラズベリーパイについて覚えてる?", "contaminant_keywords": ["パン屋", "クロワッサン", "git push", "Discord"]},
+    {"id": "B4", "category": "reverse", "text": "Raspberry Pi って何?", "contaminant_keywords": ["ラズベリーパイ", "パン屋", "クロワッサン"]},
+    {"id": "C5", "category": "short-keyword", "text": "パン", "contaminant_keywords": ["ラズベリーパイ", "ラズベリー", "raspberry", "パイ"]},
+    {"id": "C6", "category": "short-keyword", "text": "朝食", "contaminant_keywords": ["ラズベリーパイ", "ラズベリー", "raspberry", "パイ"]},
+    {"id": "C7", "category": "short-keyword", "text": "ラズベリーパイ", "contaminant_keywords": ["パン屋", "クロワッサン", "git push", "Discord"]},
+    {"id": "D8", "category": "open-meta", "text": "昨日何話してたっけ", "contaminant_keywords": ["ラズベリーパイ", "ラズベリー", "raspberry"]},
+    {"id": "D9", "category": "open-meta", "text": "このセッションで何話した?", "contaminant_keywords": ["ラズベリーパイ", "ラズベリー", "raspberry"]},
+    {"id": "D10", "category": "open-meta", "text": "私の好きな食べ物は?", "contaminant_keywords": ["ラズベリーパイ", "ラズベリー", "raspberry"]},
+    {"id": "E11", "category": "specific-topic", "text": "git push の件", "contaminant_keywords": ["ラズベリーパイ", "ラズベリー", "raspberry", "パン屋"]},
+    {"id": "E12", "category": "specific-topic", "text": "Discord の話", "contaminant_keywords": ["ラズベリーパイ", "ラズベリー", "raspberry", "パン屋"]},
+    {"id": "F13", "category": "false-positive", "text": "今日の天気", "false_positive": true, "contaminant_keywords": []},
+    {"id": "F14", "category": "false-positive", "text": "週末の予定", "false_positive": true, "contaminant_keywords": []}
+  ]
+}

--- a/scripts/recall_ab/run_ab.py
+++ b/scripts/recall_ab/run_ab.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Recall-contamination A/B harness for the Discord-recall redesign (Phase 5).
+
+Measures topic-drift ("pan -> raspberry pie") severity on a running ClotoCore
+kernel, so the OLD behaviour (recall every turn) can be compared against the
+NEW behaviour (session-start-gated recall + per-channel episodic loop). It is
+the redesign-era successor to the one-off harness described in
+docs/RECALL_CONTAMINATION_AB_2026-04-24.md.
+
+What it does
+------------
+1. (optional, --seed) Plants the seed corpus as per-user memories by sending
+   each entry as a USER message in its own throwaway session, so the kernel
+   stores it via the normal per-turn store path.
+2. Runs the 14-query probe set as an ACCUMULATING conversation in a single
+   session, repeated N_TRIALS times (one fresh session per trial). The single
+   accumulating session is what lets the NEW arm's gate matter: only the first
+   turn is a session-start, so later turns do not auto-recall.
+3. Captures each response via the SSE event stream (ThoughtResponse correlated
+   by source_message_id) and classifies it coherent / mild / severe drift.
+4. Writes results_<arm>.json and prints a summary table.
+
+Arms are selected by which kernel build is running (this script does not switch
+behaviour) — pass --arm old|new (or CLOTO_AB_ARM) purely to label the output.
+
+It performs NO destructive DB operations. For clean arms, snapshot/restore the
+target agent's CPersona rows yourself between runs (see README.md).
+
+Transport facts (verified against the kernel source, 2026-06-14):
+- POST {base}/api/chat   body = a full ClotoMessage JSON; fire-and-forget.
+- GET  {base}/api/events?token=<key>   SSE; the reply arrives as an event
+  {"type":"ThoughtResponse","data":{"content","source_message_id",...}}.
+- Auth: X-API-Key header (POST) / ?token= query (SSE). Omit if the kernel has
+  no admin_api_key configured.
+
+Run:  uv run --with httpx python run_ab.py --seed         # once, to plant memories
+      uv run --with httpx python run_ab.py --arm old      # against the OLD build
+      uv run --with httpx python run_ab.py --arm new      # against the NEW build
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import queue
+import sys
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+HERE = Path(__file__).resolve().parent
+
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+def load_config() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Recall-contamination A/B harness")
+    p.add_argument("--base-url", default=os.environ.get("CLOTO_BASE_URL", "http://127.0.0.1:8081"))
+    p.add_argument("--api-key", default=os.environ.get("CLOTO_API_KEY", ""))
+    p.add_argument("--agent-id", default=os.environ.get("CLOTO_AB_AGENT", "agent.cloto_default"))
+    p.add_argument("--arm", default=os.environ.get("CLOTO_AB_ARM", "unset"),
+                   help="label for the output file (old|new|...); does not change behaviour")
+    p.add_argument("--source-id", default=os.environ.get("CLOTO_AB_SOURCE_ID", "abtest:user1"),
+                   help="source.id for User messages (must match between seed and probe)")
+    p.add_argument("--channel", default=os.environ.get("CLOTO_AB_CHANNEL", "chat"),
+                   help="external_source value (memory channel): chat | discord")
+    p.add_argument("--trials", type=int, default=int(os.environ.get("CLOTO_AB_TRIALS", "3")))
+    p.add_argument("--response-timeout", type=float,
+                   default=float(os.environ.get("CLOTO_AB_RESPONSE_TIMEOUT", "90")))
+    p.add_argument("--seed", action="store_true", help="plant the seed corpus, then exit")
+    p.add_argument("--out-dir", default=os.environ.get("CLOTO_AB_OUT", str(HERE / "results")))
+    return p.parse_args()
+
+
+# --------------------------------------------------------------------------- #
+# SSE listener — captures ThoughtResponse events keyed by source_message_id
+# --------------------------------------------------------------------------- #
+class ResponseBus:
+    def __init__(self, base_url: str, api_key: str):
+        self._base = base_url.rstrip("/")
+        self._key = api_key
+        self._responses: dict[str, str] = {}
+        self._lock = threading.Lock()
+        self._ready = threading.Event()
+        self._stop = threading.Event()
+        self._err: queue.Queue[str] = queue.Queue()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+        if not self._ready.wait(timeout=15):
+            extra = ""
+            try:
+                extra = f" ({self._err.get_nowait()})"
+            except queue.Empty:
+                pass
+            raise RuntimeError(f"SSE stream did not connect within 15s{extra}")
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _run(self) -> None:
+        url = f"{self._base}/api/events"
+        params = {"token": self._key} if self._key else {}
+        try:
+            # No read timeout: the stream is long-lived.
+            with httpx.Client(timeout=httpx.Timeout(10.0, read=None)) as client:
+                with client.stream("GET", url, params=params) as resp:
+                    if resp.status_code != 200:
+                        self._err.put(f"HTTP {resp.status_code} from {url}")
+                        return
+                    data_lines: list[str] = []
+                    for line in resp.iter_lines():
+                        if self._stop.is_set():
+                            return
+                        if line == "":  # event boundary
+                            self._dispatch(data_lines)
+                            data_lines = []
+                            continue
+                        if line.startswith("event:") and "handshake" in line:
+                            self._ready.set()
+                        elif line.startswith("data:"):
+                            data_lines.append(line[5:].lstrip())
+        except Exception as e:  # noqa: BLE001 — surface any transport failure to the main thread
+            self._err.put(repr(e))
+            self._ready.set()  # unblock start() so it can raise
+
+    def _dispatch(self, data_lines: list[str]) -> None:
+        if not data_lines:
+            return
+        raw = "\n".join(data_lines)
+        if raw == "connected":
+            self._ready.set()
+            return
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError:
+            return
+        if obj.get("type") != "ThoughtResponse":
+            return
+        data = obj.get("data") or {}
+        smid = data.get("source_message_id")
+        content = data.get("content", "")
+        if smid:
+            with self._lock:
+                self._responses[smid] = content
+
+    def wait_for(self, msg_id: str, timeout: float) -> str | None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._lock:
+                if msg_id in self._responses:
+                    return self._responses.pop(msg_id)
+            time.sleep(0.2)
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Sending
+# --------------------------------------------------------------------------- #
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def send_and_wait(
+    client: httpx.Client,
+    bus: ResponseBus,
+    cfg: argparse.Namespace,
+    content: str,
+    session_id: str,
+    timeout: float,
+) -> str | None:
+    msg_id = f"abtest-{uuid.uuid4().hex}"
+    body = {
+        "id": msg_id,
+        "source": {"type": "User", "id": cfg.source_id, "name": "ABTester"},
+        "target_agent": cfg.agent_id,
+        "content": content,
+        "timestamp": _now_iso(),
+        "metadata": {
+            "external_session_id": session_id,
+            "external_source": cfg.channel,
+            "target_agent_id": cfg.agent_id,
+        },
+    }
+    headers = {"X-API-Key": cfg.api_key} if cfg.api_key else {}
+    r = client.post(f"{cfg.base_url.rstrip('/')}/api/chat", json=body, headers=headers, timeout=30.0)
+    r.raise_for_status()
+    return bus.wait_for(msg_id, timeout)
+
+
+# --------------------------------------------------------------------------- #
+# Classification — heuristic approximation of the §2.3 rubric.
+#   severe  = unrelated topic present AND elaborated (>=3 mentions or a question)
+#   mild    = unrelated topic present but disclaimed
+#   coherent= no unrelated topic (or disclaimed without elaboration)
+# Manual review remains the gold standard; see README "Classifier caveat".
+# --------------------------------------------------------------------------- #
+_DISCLAIMERS = ["以前", "別の話", "前に話した", "とは別", "今回は関係", "余談", "別件"]
+
+
+def classify(resp: str | None, q: dict, memory_topics: list[str]) -> str:
+    if resp is None:
+        return "timeout"
+    contaminants = memory_topics if q.get("false_positive") else q.get("contaminant_keywords", [])
+    hits = [kw for kw in contaminants if kw and kw in resp]
+    if not hits:
+        return "coherent"
+    # A disclaiming reference ("以前話した…とは別") is the rubric's MILD signal.
+    if any(d in resp for d in _DISCLAIMERS):
+        return "mild"
+    # Count the most-mentioned single keyword (not the sum — overlapping
+    # substrings like ラズベリーパイ ⊃ ラズベリー ⊃ パイ would triple-count one mention).
+    mentions = max((resp.count(kw) for kw in hits), default=0)
+    elaborated = mentions >= 3 or "?" in resp or "？" in resp
+    return "severe" if elaborated else "mild"
+
+
+# --------------------------------------------------------------------------- #
+# Phases
+# --------------------------------------------------------------------------- #
+def do_seed(client: httpx.Client, bus: ResponseBus, cfg: argparse.Namespace) -> None:
+    corpus = json.loads((HERE / "seed_corpus.json").read_text(encoding="utf-8"))["memories"]
+    print(f"Seeding {len(corpus)} memories into '{cfg.agent_id}' (source_id={cfg.source_id}) ...")
+    for i, mem in enumerate(corpus):
+        sess = f"abtest-seed-{i}-{uuid.uuid4().hex[:8]}"
+        resp = send_and_wait(client, bus, cfg, mem, sess, timeout=cfg.response_timeout)
+        status = "ok" if resp is not None else "no-reply(stored anyway)"
+        print(f"  [{i + 1}/{len(corpus)}] {status}: {mem[:32]}...")
+    # The store call is spawned during handling; give it a moment to flush.
+    time.sleep(3.0)
+    print("Seeding complete. Snapshot the agent's CPersona rows now, then run each arm.")
+
+
+def do_probe(client: httpx.Client, bus: ResponseBus, cfg: argparse.Namespace) -> dict:
+    spec = json.loads((HERE / "query_set.json").read_text(encoding="utf-8"))
+    queries = spec["queries"]
+    memory_topics = spec["memory_topics"]
+    cells: dict[str, list[str]] = {q["id"]: [] for q in queries}
+
+    for trial in range(cfg.trials):
+        session_id = f"abtest-probe-{cfg.arm}-t{trial}-{uuid.uuid4().hex[:8]}"
+        print(f"\n--- trial {trial + 1}/{cfg.trials}  session={session_id} ---")
+        for q in queries:
+            resp = send_and_wait(client, bus, cfg, q["text"], session_id, timeout=cfg.response_timeout)
+            verdict = classify(resp, q, memory_topics)
+            cells[q["id"]].append(verdict)
+            print(f"  {q['id']:>3} [{verdict:<8}] {q['text']}")
+
+    return summarize(cfg, queries, cells)
+
+
+def summarize(cfg: argparse.Namespace, queries: list[dict], cells: dict[str, list[str]]) -> dict:
+    counts = {"coherent": 0, "mild": 0, "severe": 0, "timeout": 0, "error": 0}
+    for verdicts in cells.values():
+        for v in verdicts:
+            counts[v] = counts.get(v, 0) + 1
+    completed = counts["coherent"] + counts["mild"] + counts["severe"]
+    severe_pct = (100.0 * counts["severe"] / completed) if completed else 0.0
+    return {
+        "arm": cfg.arm,
+        "agent_id": cfg.agent_id,
+        "channel": cfg.channel,
+        "trials": cfg.trials,
+        "generated_at": _now_iso(),
+        "counts": counts,
+        "severe_pct_of_completed": round(severe_pct, 1),
+        "per_query": {q["id"]: {"text": q["text"], "category": q["category"],
+                                "verdicts": cells[q["id"]]} for q in queries},
+    }
+
+
+def print_summary(result: dict) -> None:
+    c = result["counts"]
+    print("\n========== SUMMARY ==========")
+    print(f"arm={result['arm']}  agent={result['agent_id']}  trials={result['trials']}")
+    print(f"coherent={c['coherent']} mild={c['mild']} severe={c['severe']} "
+          f"timeout={c['timeout']} error={c['error']}")
+    print(f"SEVERE drift rate (of completed): {result['severe_pct_of_completed']}%")
+    print("per-query (C=coherent m=mild S=severe T=timeout E=error):")
+    short = {"coherent": "C", "mild": "m", "severe": "S", "timeout": "T", "error": "E"}
+    for qid, info in result["per_query"].items():
+        marks = "".join(short.get(v, "?") for v in info["verdicts"])
+        print(f"  {qid:>3} {marks:<6} {info['text']}")
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    cfg = load_config()
+    bus = ResponseBus(cfg.base_url, cfg.api_key)
+    try:
+        bus.start()
+    except RuntimeError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        print("Is the kernel running and is the API key correct? "
+              "(set --base-url / --api-key or CLOTO_BASE_URL / CLOTO_API_KEY)", file=sys.stderr)
+        return 1
+
+    with httpx.Client() as client:
+        if cfg.seed:
+            do_seed(client, bus, cfg)
+            bus.stop()
+            return 0
+        result = do_probe(client, bus, cfg)
+
+    bus.stop()
+    print_summary(result)
+    out_dir = Path(cfg.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"results_{cfg.arm}.json"
+    out_path.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"\nWrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/recall_ab/seed_corpus.json
+++ b/scripts/recall_ab/seed_corpus.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "Seed memory corpus that reproduces the pan->raspberry-pie contamination scenario from docs/RECALL_CONTAMINATION_AB_2026-04-24.md. run_ab.py --seed sends each entry as a USER message (one per throwaway session) so the kernel stores it as a per-user memory. The bread/raspberry-pie pair is the key contaminant; the rest is realistic noise to build a borderline cosine neighbourhood. Japanese is intentional (JA-NLP fixture). Add more noise entries to approach the original 108-memory corpus density if desired.",
+  "memories": [
+    "今日の朝食で近所のパン屋さんのクロワッサンを買って食べた。バターが効いていて本当に美味しかった。",
+    "人生で初めてラズベリーパイを食べた。甘酸っぱいフィリングとサクサクの生地が最高だった。",
+    "Raspberry Pi 5 を購入してホームサーバーをセットアップした。Linux のセットアップが楽しい。",
+    "git push でリモートとコンフリクトして、rebase で解決するのに苦労した。",
+    "Discord の bot に新しい通知設定を追加した。メンションされた時だけ通知するようにした。",
+    "私の一番好きな食べ物は寿司です。特にマグロが好き。",
+    "朝食はいつもブラックコーヒーとトーストで簡単に済ませている。",
+    "週末に映画館で SF 映画を観た。映像がすごくて引き込まれた。",
+    "新しいメカニカルキーボードを買った。打鍵感が気持ちいい。",
+    "ランニングを始めて3週間が経った。少し体が軽くなった気がする。",
+    "仕事で大きなプレゼンがあって緊張したが、なんとかうまくいった。",
+    "猫を飼い始めた。名前はミケで、よく膝の上で寝る。",
+    "コーヒーの淹れ方をハンドドリップに変えてみた。香りが全然違う。",
+    "図書館で歴史の本を借りた。週末に読むつもり。",
+    "電車が遅延して打ち合わせに遅れそうになり焦った。",
+    "スマホを新しい機種に変えた。カメラがとても綺麗。",
+    "ベランダで家庭菜園を始めた。まずはミニトマトを植えた。",
+    "友人と居酒屋で久しぶりに飲んだ。話が弾んで楽しかった。",
+    "プログラミングで Rust を勉強し始めた。所有権の概念が難しい。"
+  ]
+}


### PR DESCRIPTION
Docs / qa / test-harness only — **excludes the kernel recall-gating redesign** (Phase 2-4), which regressed contamination on DeepSeek (28.6% → 57.1%) and is held on `feat/discord-recall-gating`, not landed.

## Contents (cherry-picked from `feat/discord-recall-gating`, kernel + dashboard commits dropped)

- `docs/RECALL_CONTAMINATION_AB_2026-06-14.md` (§1-13) — the full investigation: redesign A/B, the §9 correction (root cause = two cpersona bugs, not the kernel), bm25 mechanism (RRF rank-flattening), RSF validation, fp32 high-fidelity confirmation (contamination rrf=9 → rsf=2), and the rsf-default decision.
- `qa/issue-registry.json` — registers **bug-396** (agent `default_engine_id='mind.deepseek'` unresolvable; engine resolves by exact MCP server name, catalog id is `deepseek`). Verified `[VERIFIED]` against `crates/core/src/handlers/system.rs` on master.
- `scripts/recall_ab/` — the Phase-5 recall-contamination A/B harness (read-only test scripts).

## Not included

- The kernel changes (`crates/core/src/handlers/system.rs` recall gate, `session_manager.rs`, `token_budget.rs`, `lib.rs`) and the dashboard `recall_instructions` field — those stay on `feat/discord-recall-gating` pending a non-regressing redesign.

The actual cpersona-side fix (bug-001 / bug-002 / RSF mode) ships separately in cpersona PR #14 (v2.4.23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)