### PR TITLE
ci: cross-platform release gate — windows test + headless `--smoke` (L1/L2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,60 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: bash scripts/check-test-count.sh
 
+  smoke:
+    name: Smoke (${{ matrix.os }})
+    # Release-gate keystone (harness-engineering FACET 2): build the real `app`
+    # binary and run `app --smoke`, which boots the kernel headlessly — no window,
+    # no display, since the smoke exits before the Tauri event loop — and asserts
+    # the liveness route serves 200. The exit code IS the gate: this proves the
+    # shipped binary *launches and wires up* on each OS, not merely that it
+    # compiled. Non-blocking (experimental) until green on both, mirroring `test`;
+    # placement (per-PR vs pre-promotion) is an open item in the harness doctrine.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        include:
+          - os: windows-latest
+            experimental: true
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental || false }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ci-smoke-${{ matrix.os }}
+
+      # Build-time only — `app --smoke` never initializes GTK/WebKit at runtime
+      # (it exits before the Tauri builder), so no xvfb/display is needed to run it.
+      # Dep list matches release.yml so the smoke exercises the release build surface.
+      - name: Install Tauri system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev \
+            librsvg2-dev patchelf libxdo-dev libpipewire-0.3-dev \
+            libgbm-dev libegl-dev libxcb1-dev
+
+      - name: Create dashboard dist placeholder
+        shell: bash
+        run: |
+          mkdir -p dashboard/dist
+          echo '<html><body></body></html>' > dashboard/dist/index.html
+
+      - name: Build app
+        run: cargo build --package app
+
+      - name: Run headless smoke (kernel boot + health 200; exit code is the gate)
+        run: cargo run --package app -- --smoke
+        env:
+          RUST_LOG: warn
+
   verify-issues:
     name: Issue Registry
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,20 @@ jobs:
         run: cargo audit
 
   test:
-    name: Test
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        include:
+          # Windows is the real cross-platform blind spot (CRLF / path / process
+          # spawning). Added non-blocking first (experimental) to surface divergence
+          # without holding PRs hostage; flip to blocking once green. macOS is the
+          # dev platform (continuously dogfooded) so it is intentionally omitted here.
+          - os: windows-latest
+            experimental: true
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental || false }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
@@ -75,9 +87,10 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
-          shared-key: ci-test
+          shared-key: ci-test-${{ matrix.os }}
 
       - name: Create dashboard dist placeholder
+        shell: bash
         run: |
           mkdir -p dashboard/dist
           echo '<html><body></body></html>' > dashboard/dist/index.html
@@ -88,6 +101,7 @@ jobs:
           RUST_LOG: warn
 
       - name: Test count ratchet
+        if: matrix.os == 'ubuntu-latest'
         run: bash scripts/check-test-count.sh
 
   verify-issues:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "tokio",
  "xcap",
 ]
 

--- a/dashboard/src-tauri/Cargo.toml
+++ b/dashboard/src-tauri/Cargo.toml
@@ -39,3 +39,8 @@ base64 = "0.21"
 cloto_core = { path = "../../crates/core" }
 dotenvy = "0.15"
 rand = "0.8"
+
+# Headless `--smoke` release-gate self-check: own async runtime + raw-TCP health
+# probe (no HTTP-client/TLS dep for a loopback call). Feature set unions with the
+# kernel's `tokio = full`, so this adds no extra build cost.
+tokio = { version = "1", features = ["rt-multi-thread", "time", "net", "io-util"] }

--- a/dashboard/src-tauri/src/lib.rs
+++ b/dashboard/src-tauri/src/lib.rs
@@ -201,6 +201,148 @@ fn get_auto_api_key() -> Option<String> {
     DASHBOARD_API_KEY.get().cloned()
 }
 
+/// Headless release-gate self-check, invoked by `app --smoke`.
+///
+/// Boots the **real** kernel (config load, SQLite open + migrations, plugin / MCP
+/// manager init, HTTP server bind) and then asserts the no-auth liveness route
+/// actually serves `200 {"status":"ok"}` before exiting. No Tauri event loop, no
+/// window, no display — so it runs unmodified on a headless CI runner / VM and the
+/// **exit code is the assertion** (no flaky GUI screenshotting). This is the
+/// cross-platform release gate's keystone: it proves the shipped binary *launches and
+/// wires up* on the target OS, not merely that it compiled. See
+/// `bin/docs/harness-engineering-doctrine.md` §7 (FACET 2) / §2 (tier-doctrine).
+///
+/// Hermetic by construction — and by the CLAUDE.md Destructive-DB rule, the smoke must
+/// never touch real state: it points `DATABASE_URL` at a throwaway temp DB, so it runs
+/// migrations from scratch (catching cross-platform migration breakage such as the
+/// SQLx CRLF-checksum class) and starts with zero registered MCP servers to spawn.
+///
+/// Returns a process exit code: `0` healthy; non-zero identifies the failed stage
+/// (`10` runtime, `2` kernel boot/wiring, `3` health route never OK).
+fn run_smoke() -> i32 {
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
+
+    // Isolate state: a fresh temp DB per run, keyed by PID. Never touch the user's
+    // real DB (2026-04-21 incident: a destructive op on the dev DB lost ~30 min of
+    // unrecoverable state). A from-scratch DB also exercises the migration path.
+    let tmp = std::env::temp_dir().join(format!("clotocore-smoke-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let db_path = tmp.join("cloto_smoke.db");
+    std::env::set_var("DATABASE_URL", format!("sqlite:{}", db_path.display()));
+
+    // Use a smoke-specific port unless one was pinned, so a dev instance already on
+    // the default 8081 does not make the smoke bind-fail (and vice versa).
+    if std::env::var("PORT").is_err() {
+        std::env::set_var("PORT", "8097");
+    }
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(8097);
+
+    // Mirror the GUI boot's key handling so admin-gated wiring initializes the same way.
+    if std::env::var("CLOTO_API_KEY").is_err() {
+        std::env::set_var("CLOTO_API_KEY", generate_api_key());
+    }
+
+    let rt = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("SMOKE FAIL [runtime]: could not build async runtime: {e}");
+            return 10;
+        }
+    };
+
+    let exit_code = rt.block_on(async move {
+        cloto_core::init_tracing();
+
+        let handle = match cloto_core::start_kernel().await {
+            Ok(h) => h,
+            Err(e) => {
+                eprintln!("SMOKE FAIL [boot]: start_kernel returned an error: {e:#}");
+                return 2;
+            }
+        };
+
+        let deadline = std::time::Instant::now() + TIMEOUT;
+        let code = match smoke_health_check(port, deadline).await {
+            Ok(()) => {
+                println!(
+                    "SMOKE OK: kernel booted + GET /api/system/health -> 200 on 127.0.0.1:{port}"
+                );
+                0
+            }
+            Err(reason) => {
+                eprintln!("SMOKE FAIL [health]: {reason}");
+                3
+            }
+        };
+        // Best-effort graceful shutdown; process::exit follows regardless.
+        handle.shutdown.notify_one();
+        code
+    });
+
+    // Best-effort cleanup of the throwaway DB dir on success; on failure it is kept
+    // for forensics. Always safe — this is the smoke's own temp dir, never real state.
+    if exit_code == 0 {
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+    exit_code
+}
+
+/// Poll the kernel's no-auth liveness route over a raw HTTP/1.0 request until it
+/// returns `200` with a `"status":"ok"` body, or `deadline` elapses. Raw TCP (no HTTP
+/// client dependency) keeps the smoke's own surface minimal and TLS-free for what is
+/// always a loopback call.
+async fn smoke_health_check(port: u16, deadline: std::time::Instant) -> Result<(), String> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let addr = format!("127.0.0.1:{port}");
+    let req = "GET /api/system/health HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+
+    loop {
+        // One self-contained attempt; its Err payload is the most recent failure reason.
+        let attempt: Result<(), String> = async {
+            let mut stream = tokio::net::TcpStream::connect(&addr)
+                .await
+                .map_err(|e| format!("connect failed: {e}"))?;
+            stream
+                .write_all(req.as_bytes())
+                .await
+                .map_err(|e| format!("write failed: {e}"))?;
+            let mut buf = Vec::new();
+            stream
+                .read_to_end(&mut buf)
+                .await
+                .map_err(|e| format!("read failed: {e}"))?;
+            let resp = String::from_utf8_lossy(&buf);
+            let status_line = resp.lines().next().unwrap_or("");
+            if status_line.contains(" 200") && resp.contains("\"status\":\"ok\"") {
+                Ok(())
+            } else {
+                Err(format!(
+                    "unexpected response (status line: {status_line:?})"
+                ))
+            }
+        }
+        .await;
+
+        match attempt {
+            Ok(()) => return Ok(()),
+            Err(last) if std::time::Instant::now() >= deadline => {
+                return Err(format!(
+                    "health route never returned 200/ok within timeout; last error: {last}"
+                ));
+            }
+            Err(_) => {}
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -219,6 +361,14 @@ pub fn run() {
         format!("{},{}", existing_cors, tauri_origins)
     };
     std::env::set_var("CORS_ORIGINS", combined);
+
+    // Headless release-gate self-check. `app --smoke` boots the kernel, asserts the
+    // liveness route serves, and exits with a status code — no window, no display.
+    // Placed AFTER the loopback BIND_ADDRESS + CORS setup above so it exercises the
+    // same environment the GUI boot would. See harness-engineering-doctrine.md §7.
+    if std::env::args().skip(1).any(|a| a == "--smoke") {
+        std::process::exit(run_smoke());
+    }
 
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(


### PR DESCRIPTION
## What

Adds the cross-platform release-verification gate (harness-engineering FACET 2 — the L1/L2 layers):

- **L1 — Windows test matrix**: run `cargo test --workspace` on `windows-latest` alongside `ubuntu-latest`. Windows is the real cross-platform blind spot (CRLF / path / process spawning). Added **non-blocking** first (`experimental: true` + `continue-on-error`) to surface divergence without holding PRs hostage; flip to blocking once it soaks green.
- **L2 — Headless `--smoke` keystone**: a new `app --smoke` entrypoint that boots the **real** kernel (config load, SQLite open + migrations, plugin/MCP manager init, HTTP bind) and asserts the no-auth liveness route serves `200 {"status":"ok"}`, then exits — before the Tauri event loop, so no window/display is needed. **The exit code is the assertion** (0 = healthy / 2 = boot fail / 3 = health unreachable / 10 = runtime), so it runs unmodified on a headless CI runner. Hermetic: points `DATABASE_URL` at a PID-scoped temp DB and never touches real state. Wired as a `smoke` CI job (ubuntu blocking / windows non-blocking).

## Why

A green `cargo build` only proves the binary compiled — not that it *launches and wires up* on the target OS. The smoke gate closes that gap: it proves the shipped binary actually boots the kernel and serves health on each OS, which is exactly the class of cross-platform divergence (CRLF migration checksums, path handling, process spawning) that a compile check misses.

## Gate placement

L0 build/static + L1 test + L2 smoke run **per-PR**; the windows matrix rows stay **non-blocking** until they soak green, then flip to blocking. Heavier L3 webview/e2e (tauri-driver + xvfb) is deferred to pre-promotion on a dedicated runner.

## Verification

`app --smoke` verified locally on macOS: success = exit 0 + `SMOKE OK`; a forced `PORT=1` bind failure = exit 2; the real dev DB confirmed untouched. **This PR's CI run is the first execution of the windows `test` + `smoke` jobs** — observing them run (green/red) is the purpose of the PR.

## Note (out of scope)

`rust-analyzer` surfaces a pre-existing latent build error in `crates/core/benches/helpers/mod.rs:45` — the `AppState` initializer there is missing the `install_task` field added for bug-366. It does **not** affect this PR (the `test` / `smoke` jobs don't compile benches), but is worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
