### PR TITLE
feat(recall_ab): turnkey pre-flight + runbook for the Phase-5 A/B

### DIFF
--- a/scripts/recall_ab/TURNKEY.md
+++ b/scripts/recall_ab/TURNKEY.md
@@ -1,0 +1,109 @@
+# Turnkey runbook — recall-contamination A/B (Phase 5)
+
+Pre-filled, copy-paste steps for running the OLD-vs-NEW A/B. Read `README.md`
+for the design rationale; this file is the operational checklist.
+
+The irreducible manual parts are: (1) build & run the kernel on each arm's
+branch, (2) provide a reasoning engine (this spends LLM credits, ~$2/run), and
+(3) snapshot/restore the test agent between arms. Everything else is one command.
+
+## 0. One-time setup
+
+Create a **dedicated test agent** so production memories are never touched. It
+needs three grants and the embedding server up:
+
+- a reasoning engine (`mind.*`)
+- `memory.cpersona`
+- the embedding server running (vector recall)
+
+> **bug-396 — read before you run.** The kernel resolves an agent's engine by
+> **exact MCP server-name match**. The DeepSeek connector installs under the
+> catalog id **`deepseek`**, so its server name is `deepseek` — but an agent set
+> to `default_engine_id = "mind.deepseek"` will **not** resolve and every turn
+> returns `[Error] Engine 'mind.deepseek' not found`. The classifier scores that
+> as `coherent`, i.e. a **false 0% drift** that silently corrupts the run (this
+> is what wrecked the first Phase-5 pass). Set the test agent's
+> `default_engine_id` to the resolvable server-name (e.g. `deepseek`).
+
+Config (flags or env) — defaults shown, override as needed:
+
+| flag | env | turnkey value |
+| --- | --- | --- |
+| `--base-url` | `CLOTO_BASE_URL` | `http://127.0.0.1:8081` |
+| `--api-key` | `CLOTO_API_KEY` | set if the kernel has `admin_api_key` |
+| `--agent-id` | `CLOTO_AB_AGENT` | `agent.abtest` |
+| `--trials` | `CLOTO_AB_TRIALS` | `3` |
+
+`UV = uv run --python 3.13 --with httpx python` is used below (pin 3.13 — uv's
+default 3.14 has a hung pytest-asyncio in this monorepo).
+
+## 1. Pre-flight (do this FIRST — it costs 1 call and catches bug-396)
+
+With the kernel running and the test agent configured:
+
+```bash
+cd scripts/recall_ab
+uv run --python 3.13 --with httpx python preflight.py \
+  --agent-id agent.abtest --api-key "$CLOTO_API_KEY"
+```
+
+- `PREFLIGHT OK` → the engine resolves; proceed.
+- `PREFLIGHT FAIL (3)` → engine did not resolve (bug-396); fix `default_engine_id`.
+- `PREFLIGHT FAIL (2)` → no reply; kernel / engine / embedding server is down.
+
+**Do not run the full A/B until pre-flight passes** — otherwise you spend ~84
+LLM calls on a silently-corrupted result.
+
+## 2. Seed once (additive), then snapshot
+
+On the OLD-branch kernel:
+
+```bash
+uv run --python 3.13 --with httpx python run_ab.py --agent-id agent.abtest --seed
+```
+
+Then **snapshot the test agent's CPersona rows** (the clean post-seed state).
+Follow the destructive-DB rules — never `rm` the DB. Snapshot the DB file
+(`cp ~/.claude/cpersona.db cpersona.db.postseed`) or use CPersona
+export / `delete_agent_data` scoped to **`agent.abtest` only**.
+
+## 3. OLD arm
+
+```bash
+uv run --python 3.13 --with httpx python run_ab.py --agent-id agent.abtest --arm old
+# → results/results_old.json
+```
+
+## 4. Restore the post-seed snapshot
+
+Probe turns are themselves stored as memories and would leak into the NEW arm.
+Restore the snapshot from step 2 (test agent only) so both arms start identical.
+
+## 5. NEW arm
+
+Rebuild & run the kernel on the NEW branches (ClotoCore
+`feat/discord-recall-gating`, clotohub-servers `feat/discord-per-channel-session`,
+cpersona `feat/episode-channel-scoping`), same seeded test agent, then:
+
+```bash
+uv run --python 3.13 --with httpx python run_ab.py --agent-id agent.abtest --arm new
+# → results/results_new.json
+```
+
+## 6. Compare
+
+```bash
+python compare.py results/results_old.json results/results_new.json
+```
+
+The redesign is working if the NEW arm's `severe_pct_of_completed` drops
+materially vs OLD **without** a completion-rate (timeout) regression — the
+original L2 experiment failed by cutting drift but spiking timeouts.
+
+## Notes
+
+- Cost: ~19 seed + 14 × `trials` per arm (~42 at trials=3) ≈ ~84 calls both
+  arms, ~$2, engine-dependent.
+- `classify()` is a heuristic; it is good for relative OLD-vs-NEW comparison but
+  not a substitute for human review on borderline cases (see README "Classifier
+  caveat"). For higher fidelity, wire an LLM judge against the §2.3 rubric.

--- a/scripts/recall_ab/preflight.py
+++ b/scripts/recall_ab/preflight.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Pre-flight check for the recall-contamination A/B harness.
+
+Sends ONE probe to the target agent and fails loudly if the reply looks like an
+engine-resolution error. This guards against bug-396: a test agent whose
+``default_engine_id`` is an id the kernel cannot resolve (e.g. ``mind.deepseek``
+after the catalog renamed the connector to ``deepseek``) makes every turn return
+the literal string ``[Error] Engine '...' not found``. The A/B classifier scores
+that as ``coherent`` — a *false 0% drift* that silently corrupts the whole run
+(this is exactly what wrecked the first Phase-5 pass on 2026-06-14).
+
+Run this before spending ~84 LLM calls on a full OLD/NEW A/B:
+
+    uv run --python 3.13 --with httpx python preflight.py \
+      --agent-id agent.abtest --api-key "$CLOTO_API_KEY"
+
+Exit codes: 0 = engine resolves, 2 = no reply (kernel/engine/embedding down),
+3 = engine did not resolve (fix the test agent's default_engine_id).
+
+It reuses run_ab.py's config / SSE bus / send path, so it accepts the same
+flags (``--base-url`` / ``--api-key`` / ``--agent-id`` / ``--source-id`` /
+``--channel`` / ``--response-timeout``).
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+
+import httpx
+
+from run_ab import ResponseBus, load_config, send_and_wait
+
+# A reply is treated as an engine-resolution failure when it carries an error
+# marker AND names the engine machinery — conservative, so a normal answer that
+# merely contains "not found" in prose is not flagged.
+_ERROR_MARKERS = ("[error]", "not found", "no engine", "unresolved")
+
+
+def looks_like_engine_error(resp: str) -> bool:
+    low = resp.lower()
+    has_marker = any(m in low for m in _ERROR_MARKERS)
+    names_engine = "engine" in low
+    return has_marker and names_engine
+
+
+def main() -> int:
+    cfg = load_config()
+    bus = ResponseBus(cfg.base_url, cfg.api_key)
+    bus.start()
+    try:
+        with httpx.Client() as client:
+            session_id = f"abtest-preflight-{uuid.uuid4().hex[:8]}"
+            resp = send_and_wait(
+                client,
+                bus,
+                cfg,
+                "preflight check: reply with one short sentence.",
+                session_id,
+                timeout=cfg.response_timeout,
+            )
+    finally:
+        bus.stop()
+
+    if resp is None:
+        print(
+            "PREFLIGHT FAIL (2): no reply within "
+            f"{cfg.response_timeout}s. The kernel, the agent's reasoning engine, "
+            "or the embedding server is not responding. Check the kernel is up at "
+            f"{cfg.base_url} and the test agent '{cfg.agent_id}' has an engine + "
+            "memory.cpersona granted and the embedding server running.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if looks_like_engine_error(resp):
+        print(
+            "PREFLIGHT FAIL (3): the agent's engine did not resolve (bug-396). "
+            f"Reply was:\n  {resp!r}\n"
+            f"Fix: set the test agent '{cfg.agent_id}' default_engine_id to the "
+            "engine's RESOLVABLE MCP server-name (the kernel matches engine ids "
+            "by exact server name) -- e.g. 'deepseek', NOT 'mind.deepseek'. "
+            "Running the A/B in this state produces a false 0% drift.",
+            file=sys.stderr,
+        )
+        return 3
+
+    print(
+        f"PREFLIGHT OK: agent '{cfg.agent_id}' engine resolves and replied.\n"
+        f"  {resp[:200]}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Makes the recall-contamination A/B (Goal #119 Phase 5) turnkey by adding two files to `scripts/recall_ab/`:

- **`preflight.py`** — sends one probe and fails loudly if the test agent's engine does not resolve. This guards against **bug-396**: a `default_engine_id` like `mind.deepseek` (the catalog renamed the connector to `deepseek`) returns `[Error] Engine '...' not found`, which `classify()` scores as `coherent` — a **false 0% drift** that silently corrupted the first Phase-5 pass. Run it before spending ~84 LLM calls. Reuses run_ab.py's config / SSE bus / send path, so it takes the same flags. Exit 0 = resolves, 2 = no reply, 3 = engine unresolved.
- **`TURNKEY.md`** — pre-filled, copy-paste runbook: engine-setup gotcha (the bug-396 warning), pre-flight, seed + snapshot (destructive-DB compliant, test agent only), OLD/NEW arms, compare, cost.

The irreducible manual parts remain the operator's: build & run the kernel on each arm's branch and provide a reasoning engine (spends LLM credits). Everything else is one command.

Verified: `py_compile` clean; `preflight.py` imports run_ab's `ResponseBus`/`load_config`/`send_and_wait`; the engine-error heuristic flags `[Error] Engine ... not found` while ignoring normal replies and Japanese 'not found' prose. No behaviour change to existing harness files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)