### PR TITLE
chore(deps): bump quinn-proto 0.11.14 → 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5756,9 +5756,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary

Bumps `quinn-proto` `0.11.14 → 0.11.15` to clear **RUSTSEC-2026-0185** (remote memory exhaustion from unbounded out-of-order stream reassembly, CVSS **7.5 high**), the one vulnerability failing the **Security Audit** CI job (`cargo audit`).

**Lockfile-only change** — no source, dependency, or feature changes.

## Exposure

`quinn-proto` reaches `Cargo.lock` only transitively through `reqwest`'s optional `http3`/QUIC feature:

```
quinn-proto ← quinn ← reqwest (optional http3 feature)
```

That feature is **not enabled** in this workspace — `cargo tree -i quinn-proto` finds no consumer in the active dependency tree — so the vulnerable QUIC reassembly path is never compiled or exercised. Runtime exposure is effectively nil; this bump is purely to restore a green `cargo audit` gate.

`cargo update -p quinn-proto --precise 0.11.15` produced no other churn.

## Note

The remaining 24 `cargo audit` warnings (unmaintained `core2` / `encoding` / gtk-rs GTK3 bindings) are *allowed* warnings and were not failing the job — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)