### PR TITLE
docs(claude): require Rust fmt+clippy before pushing crates/ changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ If a proposed change conflicts with any of these, flag it before proceeding.
 - Bug verify: `bash scripts/verify-issues.sh`
 - Test ratchet: `bash scripts/check-test-count.sh`
 
+**MUST (pre-push lint for Rust changes):** before pushing any change under `crates/`, run **both** `cargo fmt --all -- --check` **and** clippy locally — the CI **Lint** job gates on both and a formatting/clippy diff fails the PR. Running the dashboard `biome` check alone does **not** cover the Rust Lint job. The clippy command above (`--all-targets`) is stricter than CI; to reproduce CI exactly use the flags in `.github/workflows/ci.yml` (Lint job: no `--all-targets`, plus an `-A clippy::*` allowlist). `.github/workflows/ci.yml` is the authoritative gate.
+
 ## SQLx Migration Rules (CRITICAL)
 
 `.gitattributes` enforces **CRLF** line endings for `crates/core/migrations/*.sql`.


### PR DESCRIPTION
Adds a **MUST** note to `CLAUDE.md` → Commands: before pushing any `crates/` change, run **both** `cargo fmt --all -- --check` and clippy locally — the CI **Lint** job gates on both, and the dashboard `biome` check alone does not cover the Rust Lint job.

Motivation: a `cargo fmt` diff in a Rust change (PR #195) slipped through because only the frontend lint was run locally, failing the CI Lint job on first push. The note also flags that `ci.yml`'s clippy flags differ from the `--all-targets` command listed in CLAUDE.md (`ci.yml` is the authoritative gate).

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)