### PR TITLE
feat(recall): precision read-back so the knob-3 control is read-edit-save — Goal #120

### DIFF
--- a/crates/core/src/handlers.rs
+++ b/crates/core/src/handlers.rs
@@ -537,6 +537,7 @@ pub async fn get_memories(
         "lock_memory": state.mcp_manager.has_capability_tool(cap, "lock_memory").await,
         "unlock_memory": state.mcp_manager.has_capability_tool(cap, "unlock_memory").await,
         "set_recall_precision": state.mcp_manager.has_capability_tool(cap, "set_recall_precision").await,
+        "get_recall_precision": state.mcp_manager.has_capability_tool(cap, "get_recall_precision").await,
     });
     data.as_object_mut()
         .map(|o| o.insert("capabilities".into(), capabilities));
@@ -846,6 +847,43 @@ pub async fn set_recall_precision(
     let result = state
         .mcp_manager
         .call_capability_tool(cap, "set_recall_precision", args, None)
+        .await
+        .map_err(AppError::Internal)?;
+    ok_data(parse_mcp_tool_result(&result).unwrap_or(serde_json::json!({})))
+}
+
+/// **Route:** `GET /api/agents/:id/recall-precision`
+///
+/// Read an agent's effective recall precision (Goal #120, knob 3) — the read-back
+/// companion to [`set_recall_precision`], so the dashboard can load the current value
+/// and present the control as read-edit-save rather than write-only. Same OPTIONAL,
+/// feature-detected memory-capability contract: it routes through the capability
+/// dispatcher to whichever memory server backs the agent (no hardcoded provider) and
+/// returns 400 when the active memory server does not advertise `get_recall_precision`.
+/// Read-only — the memory server returns the resolved precision/beta without mutating
+/// state. See `docs/MEMORY_CAPABILITY_CONTRACT.md`.
+pub async fn get_recall_precision(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> AppResult<Json<serde_json::Value>> {
+    check_auth(&state, &headers)?;
+
+    let cap = crate::managers::CapabilityType::Memory;
+    if !state
+        .mcp_manager
+        .has_capability_tool(cap, "get_recall_precision")
+        .await
+    {
+        return Err(AppError::Validation(
+            "The agent's memory server does not support recall precision".into(),
+        ));
+    }
+
+    let args = serde_json::json!({ "agent_id": id });
+    let result = state
+        .mcp_manager
+        .call_capability_tool(cap, "get_recall_precision", args, None)
         .await
         .map_err(AppError::Internal)?;
     ok_data(parse_mcp_tool_result(&result).unwrap_or(serde_json::json!({})))

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1061,7 +1061,7 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
         // routed to the agent's memory server via the capability dispatcher.
         .route(
             "/agents/:id/recall-precision",
-            post(handlers::set_recall_precision),
+            get(handlers::get_recall_precision).post(handlers::set_recall_precision),
         )
         .route("/speech/:filename", get(handlers::serve_speech_file))
         .route("/events/publish", post(handlers::post_event_handler))

--- a/crates/core/src/managers/capability_dispatcher.rs
+++ b/crates/core/src/managers/capability_dispatcher.rs
@@ -338,7 +338,8 @@ fn classify_tool(server_id: &str, tool_name: &str) -> Option<CapabilityType> {
         | "update_memory"
         | "lock_memory"
         | "unlock_memory"
-        | "set_recall_precision" => Some(CapabilityType::Memory),
+        | "set_recall_precision"
+        | "get_recall_precision" => Some(CapabilityType::Memory),
         "think" | "think_with_tools" => Some(CapabilityType::Reasoning),
         "analyze_image" | "capture_screenshot" => Some(CapabilityType::Vision),
         "transcribe" => Some(CapabilityType::Stt),
@@ -431,6 +432,26 @@ mod tests {
         let (server, tool) = result.unwrap();
         assert_eq!(server, "cpersona");
         assert_eq!(tool, "set_recall_precision");
+    }
+
+    #[tokio::test]
+    async fn test_get_recall_precision_is_memory_capability() {
+        // The read-back companion classifies as Memory via the same whitelist, so the
+        // dashboard can feature-detect it and load an agent's current precision.
+        let dispatcher = CapabilityDispatcher::new();
+        let tools = vec![make_tool("recall"), make_tool("get_recall_precision")];
+        dispatcher.build_from_tools("cpersona", &tools).await;
+
+        let result = dispatcher
+            .resolve(CapabilityType::Memory, "get_recall_precision")
+            .await;
+        assert!(
+            result.is_some(),
+            "get_recall_precision should resolve as Memory"
+        );
+        let (server, tool) = result.unwrap();
+        assert_eq!(server, "cpersona");
+        assert_eq!(tool, "get_recall_precision");
     }
 
     #[tokio::test]

--- a/dashboard/src/components/AgentPluginWorkspace.tsx
+++ b/dashboard/src/components/AgentPluginWorkspace.tsx
@@ -10,6 +10,7 @@ import { AvatarSection } from './AvatarSection';
 import { ProfileSection } from './ProfileSection';
 import {
   applyRecallMetadata,
+  normalizePrecision,
   normalizeRecallPolicy,
   normalizeSessionScope,
   PRECISION_DEFAULT,
@@ -52,8 +53,9 @@ export function AgentPluginWorkspace({ agent, onBack }: Props) {
   const [sessionScope, setSessionScope] = useState<SessionScopeValue>(
     normalizeSessionScope(agent.metadata?.session_scope),
   );
-  // knob 3 (precision) is owned by the memory server and has no read-back yet, so
-  // it is write-only: the pill starts at the default and only POSTs if the user
+  // knob 3 (precision) is owned by the memory server. The pill loads the agent's
+  // current value via get_recall_precision (read-edit-save) when the server advertises
+  // read-back, else starts at the default (write-only). It only POSTs when the user
   // touches it. `precisionSupported` is feature-detected from the memory server.
   const [precision, setPrecision] = useState<PrecisionValue>(PRECISION_DEFAULT);
   const [precisionDirty, setPrecisionDirty] = useState(false);
@@ -98,15 +100,34 @@ export function AgentPluginWorkspace({ agent, onBack }: Props) {
       .finally(() => setIsLoading(false));
   }, [agent.id, api.getAgentAccess]);
 
-  // Feature-detect whether the active memory server supports recall precision (knob 3).
+  // Feature-detect whether the active memory server supports recall precision (knob 3),
+  // and when it can be read back, load the agent's current value so the pill is
+  // read-edit-save rather than write-only.
   useEffect(() => {
+    let cancelled = false;
     api
       .getMemories()
-      .then((res) => setPrecisionSupported(res.capabilities?.set_recall_precision ?? false))
+      .then((res) => {
+        if (cancelled) return;
+        setPrecisionSupported(res.capabilities?.set_recall_precision ?? false);
+        if (res.capabilities?.get_recall_precision) {
+          api
+            .getRecallPrecision(agent.id)
+            .then((info) => {
+              if (!cancelled) setPrecision(normalizePrecision(info.precision));
+            })
+            .catch((e) => {
+              if (import.meta.env.DEV) console.error('Failed to load recall precision:', e);
+            });
+        }
+      })
       .catch((e) => {
         if (import.meta.env.DEV) console.error('Failed to load memory capabilities:', e);
       });
-  }, [api.getMemories]);
+    return () => {
+      cancelled = true;
+    };
+  }, [api.getMemories, api.getRecallPrecision, agent.id]);
 
   const grantServer = (serverId: string) => {
     setGrantedIds((prev) => new Set([...prev, serverId]));

--- a/dashboard/src/components/MemoryCore.tsx
+++ b/dashboard/src/components/MemoryCore.tsx
@@ -60,6 +60,7 @@ export const MemoryCore = memo(function MemoryCore({ isWindowMode = false }: { i
     lock_memory: false,
     unlock_memory: false,
     set_recall_precision: false,
+    get_recall_precision: false,
   });
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editContent, setEditContent] = useState('');

--- a/dashboard/src/components/RecallSection.tsx
+++ b/dashboard/src/components/RecallSection.tsx
@@ -17,6 +17,7 @@ export const PRECISION_DEFAULT: PrecisionValue = 'balanced';
 
 const RECALL_POLICY_VALUES: RecallPolicyValue[] = ['always', 'session_start+active', 'session_start', 'manual_only'];
 const SESSION_SCOPE_VALUES: SessionScopeValue[] = ['per_user', 'channel', 'thread'];
+const PRECISION_VALUES: PrecisionValue[] = ['strict', 'balanced', 'lenient'];
 
 /** Normalize an arbitrary metadata string to a known policy (unknown → default). */
 export function normalizeRecallPolicy(raw: string | undefined): RecallPolicyValue {
@@ -26,6 +27,15 @@ export function normalizeRecallPolicy(raw: string | undefined): RecallPolicyValu
 /** Normalize an arbitrary metadata string to a known scope (unknown → default). */
 export function normalizeSessionScope(raw: string | undefined): SessionScopeValue {
   return SESSION_SCOPE_VALUES.includes(raw as SessionScopeValue) ? (raw as SessionScopeValue) : SESSION_SCOPE_DEFAULT;
+}
+
+/**
+ * Normalize a read-back precision level to one of the three pills (unknown → default).
+ * The memory server may report 'custom' for a raw beta override set outside this UI; the
+ * pill has no 'custom' option, so it falls back to the default rather than misrepresenting.
+ */
+export function normalizePrecision(raw: string | undefined): PrecisionValue {
+  return PRECISION_VALUES.includes(raw as PrecisionValue) ? (raw as PrecisionValue) : PRECISION_DEFAULT;
 }
 
 /**

--- a/dashboard/src/components/__tests__/RecallSection.test.tsx
+++ b/dashboard/src/components/__tests__/RecallSection.test.tsx
@@ -7,7 +7,13 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k }),
 }));
 
-import { applyRecallMetadata, normalizeRecallPolicy, normalizeSessionScope, RecallSection } from '../RecallSection';
+import {
+  applyRecallMetadata,
+  normalizePrecision,
+  normalizeRecallPolicy,
+  normalizeSessionScope,
+  RecallSection,
+} from '../RecallSection';
 
 describe('normalizeRecallPolicy', () => {
   it('passes through known values', () => {
@@ -29,6 +35,19 @@ describe('normalizeSessionScope', () => {
   it('falls back to per_user for unknown/absent', () => {
     expect(normalizeSessionScope(undefined)).toBe('per_user');
     expect(normalizeSessionScope('nope')).toBe('per_user');
+  });
+});
+
+describe('normalizePrecision', () => {
+  it('passes through the three named levels', () => {
+    expect(normalizePrecision('strict')).toBe('strict');
+    expect(normalizePrecision('balanced')).toBe('balanced');
+    expect(normalizePrecision('lenient')).toBe('lenient');
+  });
+  it('falls back to balanced for custom/unknown/absent', () => {
+    expect(normalizePrecision('custom')).toBe('balanced');
+    expect(normalizePrecision(undefined)).toBe('balanced');
+    expect(normalizePrecision('bogus')).toBe('balanced');
   });
 });
 

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -15,6 +15,7 @@ import type {
   MemoryCapabilities,
   Metrics,
   PermissionRequest,
+  RecallPrecisionInfo,
   SetupStatus,
   StrictSystemEvent,
 } from '../types';
@@ -120,6 +121,7 @@ export const api = {
         lock_memory: false,
         unlock_memory: false,
         set_recall_precision: false,
+        get_recall_precision: false,
       },
     };
   },
@@ -154,6 +156,11 @@ export const api = {
       { precision },
       { 'X-API-Key': apiKey },
     ).then(() => {}),
+
+  /** Read back an agent's current recall precision (knob 3). Read-only companion to
+   *  setRecallPrecision so the control can be read-edit-save instead of write-only. */
+  getRecallPrecision: (id: string, apiKey: string) =>
+    fetchJson<RecallPrecisionInfo>(`/agents/${id}/recall-precision`, 'fetch recall precision', apiKey),
 
   getPluginPermissions: async (pluginId: string, apiKey: string): Promise<string[]> => {
     const res = await fetch(`${API_BASE}/plugins/${pluginId}/permissions`, {
@@ -797,6 +804,7 @@ export function createAuthenticatedApi(apiKey: string) {
     createAgent: (payload: Parameters<typeof api.createAgent>[0]) => api.createAgent(payload, k),
     updateAgent: (id: string, payload: Parameters<typeof api.updateAgent>[1]) => api.updateAgent(id, payload, k),
     setRecallPrecision: (id: string, precision: string) => api.setRecallPrecision(id, precision, k),
+    getRecallPrecision: (id: string) => api.getRecallPrecision(id, k),
     deleteAgent: (agentId: string, password?: string) => api.deleteAgent(agentId, k, password),
     toggleAgentPower: (agentId: string, enabled: boolean, password?: string) =>
       api.toggleAgentPower(agentId, enabled, k, password),

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -171,6 +171,20 @@ export interface MemoryCapabilities {
   unlock_memory: boolean;
   /** Memory server supports per-agent recall precision (knob 3). Optional, feature-detected. */
   set_recall_precision: boolean;
+  /** Memory server supports reading back an agent's current precision (knob 3 read-back). Optional. */
+  get_recall_precision: boolean;
+}
+
+/** An agent's effective recall precision, read back from its memory server (knob 3). */
+export interface RecallPrecisionInfo {
+  /** Named level: 'strict' | 'balanced' | 'lenient', or 'custom' for a raw beta override. */
+  precision: string;
+  /** Resolved specificity weight. */
+  beta: number;
+  /** True when this is a per-agent override; false when it falls back to the global default. */
+  overridden: boolean;
+  /** The memory server's global default precision level. */
+  global_precision: string;
 }
 
 export interface Episode {

--- a/docs/MEMORY_CAPABILITY_CONTRACT.md
+++ b/docs/MEMORY_CAPABILITY_CONTRACT.md
@@ -26,7 +26,7 @@ A server is classified as a memory provider in one of two ways:
        "mgp": {
          "version": "0.6.3",
          "tools_for_capability": {
-           "Memory": ["store", "recall", "list_memories", "archive_episode", "set_recall_precision"]
+           "Memory": ["store", "recall", "list_memories", "archive_episode", "set_recall_precision", "get_recall_precision"]
          }
        }
      }
@@ -75,6 +75,7 @@ advertises it. A provider that omits an optional op is still fully conformant.
 | `delete_agent_data`   | Remove all data for an agent.                                  |
 | `update_profile`      | Update the agent's profile/summary.                            |
 | `set_recall_precision`| Tune the agent's recall precision (recall tuning). See below.  |
+| `get_recall_precision`| Read back the agent's current recall precision. See below.     |
 
 ### Recall tuning: `set_recall_precision`
 
@@ -96,15 +97,26 @@ provider's quality gate — on a **per-agent** basis.
   `handlers::set_recall_precision` → `call_capability_tool(Memory, "set_recall_precision", …)`.
   The endpoint returns 400 if the active memory server does not advertise the op.
 
-#### Read-back (planned)
+### Recall tuning read-back: `get_recall_precision`
 
-There is currently **no** standard read-back op, so the ClotoCore UI treats
-precision as **write-only**: the control starts at `balanced` and only sends a
-request when the operator changes it. Precision state is **not** mirrored into
-`agent.metadata` — that would put provider-owned state into kernel data the
-kernel ignores. Read-back is planned as a future **optional** op,
-`get_recall_precision(agent_id) -> { precision, beta }`, which a provider may add
-and the UI will feature-detect to switch precision to a read→edit→save control.
+The read companion to `set_recall_precision`, so the control is **read→edit→save**
+rather than write-only.
+
+- **Args**: `{ "agent_id": string }`.
+- **Returns**: `{ "precision": "strict" | "balanced" | "lenient" | "custom",
+  "beta": number, "overridden": boolean, "global_precision": string,
+  "global_beta": number }`. `precision` is the effective named level (`custom` when
+  a raw `beta` override has no named level); `overridden` distinguishes a per-agent
+  override from the provider's global default.
+- **Semantics**: **read-only** — the provider must not recalibrate or persist on
+  this call (it is not gated by no-persist pause, like `recall`). Precision state
+  is **not** mirrored into `agent.metadata` — that would put provider-owned state
+  into kernel data the kernel ignores.
+- **ClotoCore path**: `GET /api/agents/:id/recall-precision` →
+  `handlers::get_recall_precision` → `call_capability_tool(Memory, "get_recall_precision", …)`.
+  The endpoint returns 400 if the active memory server does not advertise the op.
+  The UI feature-detects it: when present, it loads the agent's current precision on
+  open; when absent, precision stays write-only (starts at `balanced`).
 
 ## Conformance checklist (third-party memory server)
 


### PR DESCRIPTION
The precision pill landed in #195 as **write-only** (started at `balanced`, no read-back). This adds the read companion across the stack, as an **OPTIONAL, feature-detected memory-capability op** (no hardcoded provider; mirrors `set_recall_precision`).

Pairs with **cpersona v2.4.30** `get_recall_precision` (Cloto-dev/cpersona#21) — **merge that first** so feature detection succeeds.

## Backend

- `capability_dispatcher`: classify `get_recall_precision` as Memory (+ classify test).
- `GET /api/memories` capabilities adds `get_recall_precision` (feature detection).
- `GET /api/agents/:id/recall-precision` routes via `call_capability_tool(Memory, …)`; **400** when the active memory server doesn't advertise the op. Read-only — the memory server returns the resolved precision/beta without mutating state.

## Frontend

- `AgentPluginWorkspace` loads the agent's current precision on open when the server supports read-back (**read-edit-save**); falls back to **write-only** when absent.
- `normalizePrecision` (`custom`/unknown → `balanced`) + normalizer test. Precision state is **not** mirrored into `agent.metadata`.

## Docs

- `MEMORY_CAPABILITY_CONTRACT.md` documents `get_recall_precision` (read-only, not metadata-mirrored), so third-party memory servers stay swappable.

## Safety / verification

- **Additive + behavior-preserving**: when a server doesn't advertise read-back, the UI keeps the prior write-only behavior; default stays `balanced`. No schema/migration.
- `cargo fmt --check` clean; `cargo clippy` (CI flags) clean; `cargo test capability_dispatcher` 14/14.
- `biome` clean; `tsc --noEmit` 0; `vitest` 39 passed (+2); `vite build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)