### PR TITLE
feat(recall): knob2 v2 — A/B-gated per-channel episode axis for PerUser — Goal #120

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -132,6 +132,15 @@ pub struct AppConfig {
     /// preserve the non-streaming path; flip to true with
     /// `CLOTO_MCP_STREAMING_ENABLED=true`.
     pub mcp_streaming_enabled: bool,
+    /// knob2 v2 A/B gate (Goal #120). When enabled, the `PerUser` session scope
+    /// scopes its long-term episode `channel` axis to the concrete channel id
+    /// instead of the bridge type, giving per-channel episode separation without
+    /// opting into `channel` / `thread` scope. Off by default to preserve v1
+    /// behavior byte-for-byte (arm A); deploy with
+    /// `CLOTO_RECALL_PERUSER_CHANNEL_AXIS=true` for arm B during the A/B window.
+    /// The hardcoded default flips only after validation
+    /// (`docs/RECALL_SESSION_SCOPE_V2_DESIGN.md`).
+    pub recall_per_user_channel_axis: bool,
     /// MCP health check interval in seconds.
     pub mcp_health_interval_secs: u64,
     /// LLM proxy HTTP client timeout in seconds.
@@ -450,6 +459,9 @@ impl AppConfig {
         let mcp_streaming_enabled = env::var("CLOTO_MCP_STREAMING_ENABLED")
             .is_ok_and(|v| matches!(v.as_str(), "true" | "1" | "yes" | "on"));
 
+        let recall_per_user_channel_axis = env::var("CLOTO_RECALL_PERUSER_CHANNEL_AXIS")
+            .is_ok_and(|v| matches!(v.as_str(), "true" | "1" | "yes" | "on"));
+
         let mcp_health_interval_secs = env::var("CLOTO_MCP_HEALTH_INTERVAL_SECS")
             .unwrap_or_else(|_| "10".to_string())
             .parse::<u64>()
@@ -645,6 +657,7 @@ impl AppConfig {
             mcp_request_timeout_secs,
             mcp_stream_idle_timeout_secs,
             mcp_streaming_enabled,
+            recall_per_user_channel_axis,
             mcp_health_interval_secs,
             llm_proxy_timeout_secs,
             rate_limit_per_sec,

--- a/crates/core/src/handlers/system.rs
+++ b/crates/core/src/handlers/system.rs
@@ -218,14 +218,32 @@ impl SessionScope {
     /// into its parent channel under `Channel` needs the bridge to forward
     /// `parent_channel_id`; until that later slice lands the two coincide. When
     /// no concrete channel id is available, fall back to `base_channel`.
+    ///
+    /// v2 (A/B-gated default change): when `per_user_channel_axis` is set, the
+    /// `PerUser` default *also* scopes its episode `channel` axis to the
+    /// concrete `channel_id` (with `base_channel` fallback) instead of the
+    /// bridge type, giving per-channel episode separation without opting into
+    /// `Channel` / `Thread`. `source_id` stays per-user. The flag is off by
+    /// default — arm A reproduces v1 byte-for-byte, arm B (flag on) is the
+    /// candidate default. The hardcoded default flips only after A/B validation
+    /// (see `docs/RECALL_SESSION_SCOPE_V2_DESIGN.md`). `Channel` / `Thread` are
+    /// unaffected by the flag.
     fn derive_recall_scope(
         self,
         base_source_id: String,
         base_channel: String,
         channel_id: Option<&String>,
+        per_user_channel_axis: bool,
     ) -> (String, String) {
         match self {
-            Self::PerUser => (base_source_id, base_channel),
+            Self::PerUser => {
+                let channel = if per_user_channel_axis {
+                    channel_id.cloned().unwrap_or(base_channel)
+                } else {
+                    base_channel
+                };
+                (base_source_id, channel)
+            }
             Self::Channel | Self::Thread => {
                 let channel = channel_id.cloned().unwrap_or(base_channel);
                 (String::new(), channel)
@@ -264,6 +282,13 @@ pub struct SystemHandler {
     /// calls through `call_tool_streaming` and emits `AgentTokenStream`
     /// events. Controlled by `CLOTO_MCP_STREAMING_ENABLED`.
     mcp_streaming_enabled: bool,
+    /// knob2 v2 A/B gate (Goal #120). When true the `PerUser` session scope
+    /// scopes its long-term episode `channel` axis to the concrete channel id
+    /// instead of the bridge type — per-channel separation without opting into
+    /// `Channel` / `Thread`. Off by default (behavior-preserving v1); the
+    /// hardcoded default flips only after A/B validation. Controlled by
+    /// `CLOTO_RECALL_PERUSER_CHANNEL_AXIS`.
+    recall_per_user_channel_axis: bool,
     /// In-memory per-`(agent_id, bridge_session_id)` conversation state
     /// (T1, v0.6.3+). Wired via [`Self::set_session_manager`] from `AppState`.
     /// Defaults to an orphan store so tests don't need to construct one; the
@@ -290,6 +315,7 @@ impl SystemHandler {
         active_cron_contexts: crate::ActiveCronContexts,
         memory_timeout_secs: u64,
         mcp_streaming_enabled: bool,
+        recall_per_user_channel_axis: bool,
     ) -> Self {
         Self {
             registry,
@@ -310,6 +336,7 @@ impl SystemHandler {
             memory_timeout_secs,
             probe_cache: crate::managers::provider_probe::ProbeCache::new(),
             mcp_streaming_enabled,
+            recall_per_user_channel_axis,
             session_manager: Arc::new(crate::managers::session_manager::SessionManager::new()),
         }
     }
@@ -656,6 +683,7 @@ impl SystemHandler {
                 base_source_id,
                 base_channel,
                 msg.metadata.get("external_channel_id"),
+                self.recall_per_user_channel_axis,
             );
 
             let mcp_recall_payload = serde_json::json!({
@@ -3441,31 +3469,70 @@ mod session_scope_tests {
 
     #[test]
     fn per_user_preserves_historical_scoping() {
-        // PerUser returns the base values verbatim — the concrete channel id is
-        // ignored, so behavior is byte-for-byte the pre-knob2 recall scoping.
+        // PerUser with the v2 flag OFF (arm A) returns the base values verbatim
+        // — the concrete channel id is ignored, so behavior is byte-for-byte
+        // the pre-knob2 recall scoping.
         let cid = "discord-channel-42".to_string();
         let (source_id, channel) = SessionScope::PerUser.derive_recall_scope(
             "discord:user-7".to_string(),
             "discord".to_string(),
             Some(&cid),
+            false,
         );
         assert_eq!(source_id, "discord:user-7");
         assert_eq!(channel, "discord");
     }
 
     #[test]
+    fn per_user_channel_axis_scopes_episode_to_concrete_channel() {
+        // knob2 v2 (arm B): with the flag ON, PerUser keeps the per-user
+        // source_id but scopes the episode channel axis to the concrete channel
+        // id instead of the bridge type — per-channel separation without opting
+        // into Channel / Thread.
+        let cid = "discord-channel-42".to_string();
+        let (source_id, channel) = SessionScope::PerUser.derive_recall_scope(
+            "discord:user-7".to_string(),
+            "discord".to_string(),
+            Some(&cid),
+            true,
+        );
+        // source_id stays per-user (unlike Channel / Thread, which clear it).
+        assert_eq!(source_id, "discord:user-7");
+        // episode axis now the concrete channel, not the bridge type.
+        assert_eq!(channel, "discord-channel-42");
+    }
+
+    #[test]
+    fn per_user_channel_axis_falls_back_to_base_channel_without_concrete_id() {
+        // Arm B with no concrete channel id (non-bridge source) falls back to
+        // the base channel rather than emptying it, keeping source_id per-user.
+        let (source_id, channel) = SessionScope::PerUser.derive_recall_scope(
+            "discord:user-7".to_string(),
+            "chat".to_string(),
+            None,
+            true,
+        );
+        assert_eq!(source_id, "discord:user-7");
+        assert_eq!(channel, "chat");
+    }
+
+    #[test]
     fn channel_and_thread_share_long_term_over_concrete_channel() {
+        // Channel / Thread are unaffected by the v2 flag (tested both ways).
         let cid = "discord-channel-42".to_string();
         for sc in [SessionScope::Channel, SessionScope::Thread] {
-            let (source_id, channel) = sc.derive_recall_scope(
-                "discord:user-7".to_string(),
-                "discord".to_string(),
-                Some(&cid),
-            );
-            // source_id cleared = whole-channel shared long-term memory.
-            assert_eq!(source_id, "");
-            // episode axis scoped to the concrete channel, not the bridge type.
-            assert_eq!(channel, "discord-channel-42");
+            for per_user_channel_axis in [false, true] {
+                let (source_id, channel) = sc.derive_recall_scope(
+                    "discord:user-7".to_string(),
+                    "discord".to_string(),
+                    Some(&cid),
+                    per_user_channel_axis,
+                );
+                // source_id cleared = whole-channel shared long-term memory.
+                assert_eq!(source_id, "");
+                // episode axis scoped to the concrete channel, not the bridge type.
+                assert_eq!(channel, "discord-channel-42");
+            }
         }
     }
 
@@ -3477,6 +3544,7 @@ mod session_scope_tests {
             "discord:user-7".to_string(),
             "chat".to_string(),
             None,
+            false,
         );
         assert_eq!(source_id, "");
         assert_eq!(channel, "chat");

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -559,6 +559,7 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
             active_cron_contexts.clone(),
             config.memory_timeout_secs,
             config.mcp_streaming_enabled,
+            config.recall_per_user_channel_axis,
         );
         h.set_probe_cache(probe_cache.clone());
         h.set_usage_store(last_usage_store.clone());

--- a/crates/core/tests/event_cascading_test.rs
+++ b/crates/core/tests/event_cascading_test.rs
@@ -124,6 +124,7 @@ async fn test_event_cascading_protection() {
         Arc::new(dashmap::DashMap::new()),
         5,     // memory_timeout_secs
         false, // mcp_streaming_enabled
+        false, // recall_per_user_channel_axis
     ));
 
     let processor = EventProcessor::new(

--- a/crates/core/tests/event_memory_management_test.rs
+++ b/crates/core/tests/event_memory_management_test.rs
@@ -41,6 +41,7 @@ async fn create_test_processor(
         Arc::new(dashmap::DashMap::new()),
         5,     // memory_timeout_secs
         false, // mcp_streaming_enabled
+        false, // recall_per_user_channel_axis
     ));
 
     let processor = Arc::new(EventProcessor::new(

--- a/crates/core/tests/permission_elevation_test.rs
+++ b/crates/core/tests/permission_elevation_test.rs
@@ -119,6 +119,7 @@ async fn test_dynamic_permission_elevation_flow() {
         Arc::new(dashmap::DashMap::new()),
         5,     // memory_timeout_secs
         false, // mcp_streaming_enabled
+        false, // recall_per_user_channel_axis
     ));
 
     let processor = EventProcessor::new(

--- a/crates/core/tests/security_forging_test.rs
+++ b/crates/core/tests/security_forging_test.rs
@@ -168,6 +168,7 @@ async fn test_vulnerability_event_forging() {
         Arc::new(dashmap::DashMap::new()),
         5,     // memory_timeout_secs
         false, // mcp_streaming_enabled
+        false, // recall_per_user_channel_axis
     ));
 
     let processor = EventProcessor::new(

--- a/crates/core/tests/system_loop_test.rs
+++ b/crates/core/tests/system_loop_test.rs
@@ -40,6 +40,7 @@ async fn test_system_handler_loop_prevention() {
         Arc::new(dashmap::DashMap::new()),
         5,     // memory_timeout_secs
         false, // mcp_streaming_enabled
+        false, // recall_per_user_channel_axis
     );
 
     // Test User Message → triggers handle_message (agentic loop).
@@ -113,6 +114,7 @@ async fn build_cron_test_handler(
         active_cron_contexts.clone(),
         5,
         false, // mcp_streaming_enabled
+        false, // recall_per_user_channel_axis
     );
 
     (handler, pool, active_cron_contexts, event_rx)

--- a/docs/RECALL_SESSION_SCOPE_V2_DESIGN.md
+++ b/docs/RECALL_SESSION_SCOPE_V2_DESIGN.md
@@ -46,6 +46,18 @@ Per-channel episode separation reduces cross-channel topic-drift **contamination
 - During the A/B window, gate the change behind a flag (env or per-deployment) so A and B can be compared on the same build before flipping the hardcoded default.
 - Tests: update the `per_user_preserves_historical_scoping` unit test to reflect the new channel axis once the default flips; no new derivation surface.
 
+### 6.1 What landed (kernel + harness plumbing) — flip still pending
+
+The gated change is implemented and verified; **the hardcoded default has NOT flipped** — it is opt-in via env during the A/B window:
+
+- **Flag:** `CLOTO_RECALL_PERUSER_CHANNEL_AXIS` (`config.rs` → `Config.recall_per_user_channel_axis` → `SystemHandler`, same wiring as `CLOTO_MCP_STREAMING_ENABLED`). Off by default. Accepts `true`/`1`/`yes`/`on`.
+- **Kernel:** `derive_recall_scope` takes `per_user_channel_axis: bool`. Arm A (flag off) reproduces v1 byte-for-byte; arm B (flag on) scopes the `PerUser` episode channel axis to `external_channel_id` (with `base_channel` fallback), keeping per-user `source_id`. `Channel` / `Thread` are unaffected. Unit tests cover both arms (`per_user_preserves_historical_scoping` = arm A, `per_user_channel_axis_scopes_episode_to_concrete_channel` + `..._falls_back_to_base_channel_without_concrete_id` = arm B).
+- **Harness plumbing** (`scripts/recall_ab/run_ab.py`): per-message `external_channel_id` emission — without it the flag's divergence point is never exercised. New flags `--channel-id` (global), per-entry `channel_id` in the corpus / query-set JSON (overrides global), and `--corpus` / `--query-set` to point at per-channel fixtures. All additive; absent `channel_id` → identical to the pre-v2 harness.
+
+**Run arms on the same build** by toggling the env var per deployment: arm A = flag unset, arm B = `CLOTO_RECALL_PERUSER_CHANNEL_AXIS=true`. (The harness's `--arm` only labels output; behavior is whichever build/env is running — see `scripts/recall_ab/README.md`.)
+
+**Still pending (the actual gate, 博士-environment):** author a multi-channel corpus (§5) where the same user/agent is active across ≥2 concrete channels, run arm A vs arm B, and flip the hardcoded default in `from_metadata`'s `PerUser` branch only if cross-channel contamination drops with no recall-quality regression. The corpus is best authored against real responses during the run rather than blind.
+
 ## 7. Relationship to other deferred slices (independent of v2)
 
 - **Short-term `session_key` scoping** (bridge-owned; chunk lifecycle stays with the bridge for now) — independent of v2.
@@ -54,6 +66,8 @@ Per-channel episode separation reduces cross-channel topic-drift **contamination
 
 ## 8. Next-session entry point
 
-- **Code:** `derive_recall_scope` in `crates/core/src/handlers/system.rs` (after PR #193 merges to `master`).
-- **A/B harness:** `scripts/recall_ab/`.
+The kernel change + harness plumbing have landed (§6.1); the remaining work is the A/B run and the default flip:
+
+- **Flip point:** `from_metadata`'s `PerUser` branch / the `recall_per_user_channel_axis` default in `config.rs` — flip only after the gate passes, then remove the flag.
+- **A/B run:** deploy the same build twice (arm A flag off, arm B `CLOTO_RECALL_PERUSER_CHANNEL_AXIS=true`); author a multi-channel corpus and run `scripts/recall_ab/` with `--channel-id` / per-entry `channel_id` (see its README "Cross-channel (knob2 v2) A/B").
 - **Context:** CPersona memory `goal120-knob2-v1-pr193-20260627`; this doc; Goal #120.

--- a/scripts/recall_ab/README.md
+++ b/scripts/recall_ab/README.md
@@ -99,6 +99,34 @@ To also exercise the per-agent recall-instructions knob or the Discord channel
 path, set `--channel discord` and/or configure the test agent's
 `recall_instructions` in the agent settings, then add more arms.
 
+## Cross-channel (knob2 v2) A/B
+
+The default topic-drift experiment above is single-channel. The knob2 v2 change
+(`docs/RECALL_SESSION_SCOPE_V2_DESIGN.md`) only diverges when the **same user is
+active across several concrete channels**, so it needs a multi-channel corpus and
+the concrete-channel plumbing:
+
+- **Arms are the same build, toggled by env** — arm A = `CLOTO_RECALL_PERUSER_CHANNEL_AXIS`
+  unset, arm B = `CLOTO_RECALL_PERUSER_CHANNEL_AXIS=true`. (`--arm` still only labels
+  output.)
+- **Concrete channel id** is sent as `external_channel_id` via `--channel-id`, or
+  per-entry `channel_id` in the corpus / query-set JSON (which overrides the global
+  flag). Absent → omitted, i.e. the pre-v2 behavior. `--corpus` / `--query-set`
+  point at per-channel fixtures.
+
+Sketch (author the multi-channel corpus against real responses):
+
+1. Seed a corpus where the same `--source-id` has memories in ≥2 channels — either
+   one corpus with per-entry `channel_id`, or two `--seed` passes with different
+   `--channel-id`. Snapshot the post-seed CPersona rows.
+2. **Arm A:** run the kernel with the flag unset; probe in one channel
+   (`--channel-id <A>` or per-query `channel_id`) and measure how often memories
+   from the *other* channel contaminate. Restore the snapshot.
+3. **Arm B:** restart the same build with `CLOTO_RECALL_PERUSER_CHANNEL_AXIS=true`;
+   run the identical probe.
+4. Compare: v2 wins if cross-channel contamination drops with no recall-quality
+   (completion-rate) regression — then flip the hardcoded default.
+
 ## Reading the results
 
 Each `results_<arm>.json` has per-query verdicts (`coherent` / `mild` /

--- a/scripts/recall_ab/run_ab.py
+++ b/scripts/recall_ab/run_ab.py
@@ -69,7 +69,16 @@ def load_config() -> argparse.Namespace:
     p.add_argument("--source-id", default=os.environ.get("CLOTO_AB_SOURCE_ID", "abtest:user1"),
                    help="source.id for User messages (must match between seed and probe)")
     p.add_argument("--channel", default=os.environ.get("CLOTO_AB_CHANNEL", "chat"),
-                   help="external_source value (memory channel): chat | discord")
+                   help="external_source value (the bridge TYPE; memory channel under v1): chat | discord")
+    p.add_argument("--channel-id", default=os.environ.get("CLOTO_AB_CHANNEL_ID", ""),
+                   help="concrete external_channel_id sent with every message (empty = omit). "
+                        "This is the axis knob2 v2 scopes PerUser episodes to; set distinct ids per "
+                        "channel to exercise the cross-channel A/B. Per-entry channel_id in the corpus / "
+                        "query-set JSON overrides this.")
+    p.add_argument("--corpus", default=os.environ.get("CLOTO_AB_CORPUS", str(HERE / "seed_corpus.json")),
+                   help="seed corpus JSON (for --seed); supply a per-channel corpus for the v2 A/B")
+    p.add_argument("--query-set", default=os.environ.get("CLOTO_AB_QUERY_SET", str(HERE / "query_set.json")),
+                   help="probe query-set JSON")
     p.add_argument("--trials", type=int, default=int(os.environ.get("CLOTO_AB_TRIALS", "3")))
     p.add_argument("--response-timeout", type=float,
                    default=float(os.environ.get("CLOTO_AB_RESPONSE_TIMEOUT", "90")))
@@ -175,19 +184,27 @@ def send_and_wait(
     content: str,
     session_id: str,
     timeout: float,
+    channel_id: str = "",
 ) -> str | None:
     msg_id = f"abtest-{uuid.uuid4().hex}"
+    metadata = {
+        "external_session_id": session_id,
+        "external_source": cfg.channel,
+        "target_agent_id": cfg.agent_id,
+    }
+    # Concrete channel id — the axis knob2 v2 (CLOTO_RECALL_PERUSER_CHANNEL_AXIS)
+    # scopes PerUser episodes to. Omitted when empty so arm A behaves exactly as
+    # before. The kernel reads it as msg.metadata["external_channel_id"].
+    resolved_channel_id = channel_id or cfg.channel_id
+    if resolved_channel_id:
+        metadata["external_channel_id"] = resolved_channel_id
     body = {
         "id": msg_id,
         "source": {"type": "User", "id": cfg.source_id, "name": "ABTester"},
         "target_agent": cfg.agent_id,
         "content": content,
         "timestamp": _now_iso(),
-        "metadata": {
-            "external_session_id": session_id,
-            "external_source": cfg.channel,
-            "target_agent_id": cfg.agent_id,
-        },
+        "metadata": metadata,
     }
     headers = {"X-API-Key": cfg.api_key} if cfg.api_key else {}
     r = client.post(f"{cfg.base_url.rstrip('/')}/api/chat", json=body, headers=headers, timeout=30.0)
@@ -226,20 +243,31 @@ def classify(resp: str | None, q: dict, memory_topics: list[str]) -> str:
 # Phases
 # --------------------------------------------------------------------------- #
 def do_seed(client: httpx.Client, bus: ResponseBus, cfg: argparse.Namespace) -> None:
-    corpus = json.loads((HERE / "seed_corpus.json").read_text(encoding="utf-8"))["memories"]
+    corpus = json.loads(Path(cfg.corpus).read_text(encoding="utf-8"))["memories"]
     print(f"Seeding {len(corpus)} memories into '{cfg.agent_id}' (source_id={cfg.source_id}) ...")
-    for i, mem in enumerate(corpus):
+    for i, entry in enumerate(corpus):
+        # An entry is either a plain string (no channel) or {text, channel_id}
+        # so a single corpus can plant memories across several channels for the
+        # knob2 v2 cross-channel A/B. A per-entry channel_id overrides --channel-id.
+        if isinstance(entry, dict):
+            mem = entry["text"]
+            channel_id = entry.get("channel_id", "")
+        else:
+            mem = entry
+            channel_id = ""
         sess = f"abtest-seed-{i}-{uuid.uuid4().hex[:8]}"
-        resp = send_and_wait(client, bus, cfg, mem, sess, timeout=cfg.response_timeout)
+        resp = send_and_wait(client, bus, cfg, mem, sess,
+                             timeout=cfg.response_timeout, channel_id=channel_id)
         status = "ok" if resp is not None else "no-reply(stored anyway)"
-        print(f"  [{i + 1}/{len(corpus)}] {status}: {mem[:32]}...")
+        chan = f" ch={channel_id or cfg.channel_id}" if (channel_id or cfg.channel_id) else ""
+        print(f"  [{i + 1}/{len(corpus)}]{chan} {status}: {mem[:32]}...")
     # The store call is spawned during handling; give it a moment to flush.
     time.sleep(3.0)
     print("Seeding complete. Snapshot the agent's CPersona rows now, then run each arm.")
 
 
 def do_probe(client: httpx.Client, bus: ResponseBus, cfg: argparse.Namespace) -> dict:
-    spec = json.loads((HERE / "query_set.json").read_text(encoding="utf-8"))
+    spec = json.loads(Path(cfg.query_set).read_text(encoding="utf-8"))
     queries = spec["queries"]
     memory_topics = spec["memory_topics"]
     cells: dict[str, list[str]] = {q["id"]: [] for q in queries}
@@ -248,7 +276,10 @@ def do_probe(client: httpx.Client, bus: ResponseBus, cfg: argparse.Namespace) ->
         session_id = f"abtest-probe-{cfg.arm}-t{trial}-{uuid.uuid4().hex[:8]}"
         print(f"\n--- trial {trial + 1}/{cfg.trials}  session={session_id} ---")
         for q in queries:
-            resp = send_and_wait(client, bus, cfg, q["text"], session_id, timeout=cfg.response_timeout)
+            # A per-query channel_id (overriding --channel-id) lets a probe run
+            # in a specific channel for the v2 cross-channel A/B.
+            resp = send_and_wait(client, bus, cfg, q["text"], session_id,
+                                 timeout=cfg.response_timeout, channel_id=q.get("channel_id", ""))
             verdict = classify(resp, q, memory_topics)
             cells[q["id"]].append(verdict)
             print(f"  {q['id']:>3} [{verdict:<8}] {q['text']}")
@@ -267,6 +298,7 @@ def summarize(cfg: argparse.Namespace, queries: list[dict], cells: dict[str, lis
         "arm": cfg.arm,
         "agent_id": cfg.agent_id,
         "channel": cfg.channel,
+        "channel_id": cfg.channel_id,
         "trials": cfg.trials,
         "generated_at": _now_iso(),
         "counts": counts,


### PR DESCRIPTION
## What

knob2 v2 of the recall session-scope work (Goal #120). Under the `PerUser` session scope, scope the long-term episode `channel` axis to the concrete `external_channel_id` instead of the bridge type, giving **per-channel episode separation without opting into `channel`/`thread` scope**. `source_id` stays per-user; `Channel`/`Thread` are unaffected.

## Why gated, not additive

This is a **default behavior change** (every existing agent's episode channel axis moves from `"discord"` to the concrete channel id), so it ships behind a flag rather than flipping the default. Same discipline as knob1's deferred default flip.

- Flag `CLOTO_RECALL_PERUSER_CHANNEL_AXIS` (**off by default**) → `Config.recall_per_user_channel_axis` → `SystemHandler`, same wiring as `CLOTO_MCP_STREAMING_ENABLED`.
- **Arm A** (flag off) reproduces v1 byte-for-byte; **arm B** (flag on) is the candidate default.
- The hardcoded default flips only **after** the cross-channel A/B validates that contamination drops with no recall-quality regression. See `docs/RECALL_SESSION_SCOPE_V2_DESIGN.md` §6.1.

So merging this is safe (behavior-preserving, default off); it does **not** change any agent's recall until the A/B-gated flip in a later PR.

## Changes

- `derive_recall_scope` takes `per_user_channel_axis: bool`; `PerUser` uses the concrete channel id (with `base_channel` fallback) when set. Unit tests cover both arms.
- A/B harness (`scripts/recall_ab/run_ab.py`): per-message `external_channel_id` plumbing (`--channel-id`, per-entry `channel_id`, `--corpus`/`--query-set`) — without it the flag's divergence point is never exercised. README cross-channel procedure. All additive/backward-compatible.

## Verification

`cargo fmt --all -- --check`, clippy (CI Lint flags), `cargo test --workspace --exclude app` (session_scope 7/7 incl. 2 new arm-B tests; all integration green), `tsc`/`biome`/`vite build` — all green.

## Not in this PR

The actual default flip + the cross-channel A/B run (multi-channel corpus, arm A/B deploys, LLM budget) — that's the gated next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)