### PR TITLE
fix(core): bug-399 — stop doubling the marketplace install path

### DIFF
--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -2431,11 +2431,25 @@ fn resolve_servers_dir(state: &AppState) -> PathBuf {
 /// for every empty-directory entry, and worse: lets uninstall
 /// `remove_dir_all` walk the parent).
 fn effective_install_dir(entry: &RegistryEntry) -> &str {
-    if entry.directory.is_empty() {
+    let raw = if entry.directory.is_empty() {
         entry.id.as_str()
     } else {
         entry.directory.as_str()
-    }
+    };
+    // The install directory is a single path component under mcp-servers. A
+    // catalog `directory` that carries the monorepo-relative path (e.g.
+    // "servers/websearch") would otherwise be joined with the source `subdir`
+    // (also "servers/websearch") at the extract / register / uninstall sites,
+    // doubling the on-disk path to
+    // mcp-servers/servers/<name>/servers/<name>/server.py — the launch then
+    // fails because no server.py exists there (bug-399, Task #105). Collapse to
+    // the final path component so a malformed multi-segment value stays flat;
+    // well-formed ids (incl. dotted "memory.cpersona") pass through unchanged.
+    raw.trim_matches('/')
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(raw)
 }
 
 /// Derive the on-disk install directory from a registered server's `args`
@@ -3964,6 +3978,28 @@ mod tests {
         assert_eq!(
             effective_install_dir(&entry("memory.cpersona", "")),
             "memory.cpersona"
+        );
+    }
+
+    #[test]
+    fn effective_install_dir_collapses_monorepo_relative_directory() {
+        // bug-399 / Task #105: a stale catalog `directory` carrying the
+        // monorepo-relative path must not double with the source `subdir`. Only
+        // the final component is used as the on-disk install dir, so
+        // mcp-servers/<dir>/<subdir> stays single-nested instead of
+        // mcp-servers/servers/<name>/servers/<name>.
+        assert_eq!(
+            effective_install_dir(&entry("tool.websearch", "servers/websearch")),
+            "websearch"
+        );
+        assert_eq!(
+            effective_install_dir(&entry("tool.cscheduler", "servers/cscheduler/")),
+            "cscheduler"
+        );
+        // Well-formed flat directories and ids are unchanged.
+        assert_eq!(
+            effective_install_dir(&entry("tool.websearch", "websearch")),
+            "websearch"
         );
     }
 

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -3052,6 +3052,20 @@
       "fixed_in": "0.6.8-beta.1",
       "fix_note": "Added validate_entry_point_exists() called in StdioTransport::start before spawn: resolves the entry-point via resolve_sealable_entry_point and, only for absolute paths, bails with 'entry-point not found — reinstall this server from the marketplace' when it is missing. Skips `python -m module` (bare module name) and relative scripts (cwd-dependent) to avoid false negatives; also covers missing Rust binaries. Guarded by 4 unit tests (managers::mcp_transport::tests::entry_point_*).",
       "github_issue": 206
+    },
+    {
+      "id": "bug-399",
+      "summary": "HIGH: marketplace install writes a DOUBLED on-disk path for monorepo connectors, so the server fails to launch. effective_install_dir returned the catalog `directory` verbatim, and the install/extract/register/uninstall sites join it with the source `subdir`. When the (hub-served) catalog `directory` carries the monorepo-relative path 'servers/<name>' AND `subdir` is the same 'servers/<name>', target_dir = mcp-servers/servers/<name> and server_path = target_dir/servers/<name> → entry-point mcp-servers/servers/<name>/servers/<name>/server.py, which does not exist → 'error, 0 tools'. Reproduced after a reinstall on 2026-06-29 (cscheduler/terminal/deepseek error; websearch only worked because its files happened to land at the doubled path). The local cloto-mcp-servers/registry.json already has the flat directory ('websearch' etc.), so the deployed hub catalog is stale — but the kernel should not double regardless. Continuation of Task #105 / bug-398 (which only clarified the resulting error).",
+      "severity": "HIGH",
+      "discovered": "2026-06-29T00:00:00Z",
+      "version": "0.6.8-beta.1",
+      "commit": "9d311a3",
+      "file": "crates/core/src/handlers/marketplace.rs",
+      "pattern": "effective_install_dir_collapses_monorepo_relative_directory",
+      "expected": "present",
+      "status": "fixed",
+      "fixed_in": "0.6.8-beta.1",
+      "fix_note": "effective_install_dir now collapses a multi-segment value to its final path component (trim slashes + rsplit on '/'\\\\'), so a malformed catalog directory='servers/<name>' becomes the flat install dir '<name>'; target_dir/subdir then stays single-nested (mcp-servers/<name>/servers/<name>/server.py, matching a nested git clone). Well-formed flat directories and dotted ids (memory.cpersona) are unchanged; all three lock-step sites (extract/register/uninstall) use this fn so they stay consistent. Upstream follow-up: republish the hub catalog from the corrected registry.json. Guarded by effective_install_dir_collapses_monorepo_relative_directory."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes **bug-399**: marketplace install wrote a *doubled* on-disk path for monorepo connectors, so the server failed to launch with "error, 0 tools". This is the live root cause behind the recurring `cscheduler` / `terminal` / `deepseek` failures (PR #204's bug-398 only made the resulting error legible; it did not stop the doubling). Continuation of CSC Task #105.

## Root cause

`effective_install_dir` returned the catalog `directory` verbatim, and the extract / register / uninstall sites join it with the install source `subdir`:

```
target_dir  = mcp-servers / effective_install_dir(directory)
server_path = target_dir / subdir
entry_point = server_path / server.py
```

When the (hub-served) catalog `directory` carries the monorepo-relative path `servers/<name>` **and** `subdir` is the same `servers/<name>`, the two stack:

```
mcp-servers/servers/<name>/servers/<name>/server.py   ← does not exist
```

so python is spawned on a missing file and the server reports `error, 0 tools`. Reproduced 2026-06-29 after a reinstall: `cscheduler` / `terminal` / `deepseek` errored, while `websearch` worked only because its files happened to land at the doubled path. The local `cloto-mcp-servers/registry.json` already has the flat `directory` (`websearch`, etc.), so the deployed hub catalog is stale — but the kernel should not double regardless.

## Fix

`effective_install_dir` now collapses a multi-segment value to its final path component (trim slashes + `rsplit('/', '\\')`), so a malformed `directory="servers/<name>"` becomes the flat install dir `<name>`. `target_dir` / `subdir` then stays single-nested:

```
mcp-servers/<name>/servers/<name>/server.py           ← matches a nested git clone
```

Well-formed flat directories and dotted ids (`memory.cpersona`) pass through unchanged, and all three lock-step sites (extract / register / uninstall) use this function so they stay consistent.

## Follow-up (out of scope here)

- **Upstream**: republish the hub catalog from the corrected `registry.json` so the `directory` field is flat. (This kernel-side normalization is defense-in-depth; the catalog should also be fixed.)
- After merge, the three erroring servers need one more **uninstall → reinstall** to write the corrected path. The old `mcp-servers/servers/` tree is harmless orphan cruft.

## Test plan

- `cargo test -p cloto_core --lib` → 325 passed (new: `effective_install_dir_collapses_monorepo_relative_directory`)
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --exclude app -- -D warnings -A …` (CI flags) clean
- `bash scripts/verify-issues.sh` green (0 stale / 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
