### PR TITLE
chore(deps): migrate to axum 0.8 (supersedes #120)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -176,7 +176,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -533,13 +533,13 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -552,8 +552,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -567,19 +566,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -1845,7 +1842,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2239,7 +2236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4162,9 +4159,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maybe-rayon"
@@ -4450,7 +4447,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4978,7 +4975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6388,7 +6385,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6446,7 +6443,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6989,7 +6986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7968,7 +7965,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8494,7 +8491,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9175,7 +9172,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ async-trait = "0.1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "uuid", "chrono"] }
 uuid = { version = "1.23", features = ["v4", "v5", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
-axum = { version = "0.7" }
+axum = { version = "0.8" }
 tower-http = { version = "0.6", features = ["fs", "cors"] }
 futures = "0.3"
 tokio-stream = "0.1"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1020,109 +1020,109 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
         .route("/health/repair", post(handlers::health::repair_handler))
         .route("/system/shutdown", post(handlers::shutdown_handler))
         .route("/plugins/apply", post(handlers::apply_plugin_settings))
-        .route("/plugins/:id/config", post(handlers::update_plugin_config))
+        .route("/plugins/{id}/config", post(handlers::update_plugin_config))
         .route(
-            "/plugins/:id/permissions",
+            "/plugins/{id}/permissions",
             get(handlers::get_plugin_permissions).delete(handlers::revoke_permission_handler),
         )
         .route(
-            "/plugins/:id/permissions/grant",
+            "/plugins/{id}/permissions/grant",
             post(handlers::grant_permission_handler),
         )
         .route("/agents", post(handlers::create_agent))
         .route(
-            "/agents/:id",
+            "/agents/{id}",
             post(handlers::update_agent).delete(handlers::delete_agent),
         )
-        .route("/agents/:id/power", post(handlers::power_toggle))
+        .route("/agents/{id}/power", post(handlers::power_toggle))
         .route(
-            "/agents/:id/avatar",
+            "/agents/{id}/avatar",
             get(handlers::get_avatar)
                 .post(handlers::upload_avatar)
                 .delete(handlers::delete_avatar),
         )
         .route(
-            "/agents/:id/vrm",
+            "/agents/{id}/vrm",
             get(handlers::get_vrm)
                 .post(handlers::upload_vrm)
                 .delete(handlers::delete_vrm),
         )
-        .route("/agents/:id/visemes", post(handlers::generate_visemes))
+        .route("/agents/{id}/visemes", post(handlers::generate_visemes))
         // Agent-centric bulk MCP access update (batch replacement of server_grant entries)
         .route(
-            "/agents/:id/mcp-access",
+            "/agents/{id}/mcp-access",
             axum::routing::put(handlers::put_agent_mcp_access),
         )
         .route(
-            "/agents/:id/last-usage",
+            "/agents/{id}/last-usage",
             get(handlers::get_agent_last_usage),
         )
         // Recall precision (Goal #120 knob 3) — optional memory-capability op,
         // routed to the agent's memory server via the capability dispatcher.
         .route(
-            "/agents/:id/recall-precision",
+            "/agents/{id}/recall-precision",
             get(handlers::get_recall_precision).post(handlers::set_recall_precision),
         )
-        .route("/speech/:filename", get(handlers::serve_speech_file))
+        .route("/speech/{filename}", get(handlers::serve_speech_file))
         .route("/events/publish", post(handlers::post_event_handler))
         // Cron job management (Layer 2: Autonomous Trigger)
         .route(
             "/cron/jobs",
             get(handlers::list_cron_jobs).post(handlers::create_cron_job),
         )
-        .route("/cron/jobs/:id", delete(handlers::delete_cron_job))
-        .route("/cron/jobs/:id/toggle", post(handlers::toggle_cron_job))
-        .route("/cron/jobs/:id/run", post(handlers::run_cron_job_now))
+        .route("/cron/jobs/{id}", delete(handlers::delete_cron_job))
+        .route("/cron/jobs/{id}/toggle", post(handlers::toggle_cron_job))
+        .route("/cron/jobs/{id}/run", post(handlers::run_cron_job_now))
         // LLM Provider management (MGP §13.4 — centralized key management)
         .route("/llm/providers", get(handlers::list_llm_providers))
         .route(
-            "/llm/providers/:id/key",
+            "/llm/providers/{id}/key",
             post(handlers::set_llm_provider_key).delete(handlers::delete_llm_provider_key),
         )
         .route(
-            "/llm/providers/:id/model",
+            "/llm/providers/{id}/model",
             post(handlers::set_llm_provider_model),
         )
         .route(
-            "/llm/providers/:id/models",
+            "/llm/providers/{id}/models",
             get(handlers::list_provider_models),
         )
         .route(
-            "/llm/providers/:id/context-length",
+            "/llm/providers/{id}/context-length",
             post(handlers::set_llm_provider_context_length),
         )
         .route(
-            "/llm/providers/:id/thinking-mode",
+            "/llm/providers/{id}/thinking-mode",
             post(handlers::set_llm_provider_thinking_mode),
         )
         .route(
-            "/llm/providers/:id/test",
+            "/llm/providers/{id}/test",
             post(handlers::test_provider_connection),
         )
         .route(
-            "/permissions/:id/approve",
+            "/permissions/{id}/approve",
             post(handlers::approve_permission),
         )
-        .route("/permissions/:id/deny", post(handlers::deny_permission))
+        .route("/permissions/{id}/deny", post(handlers::deny_permission))
         // Command approval endpoints
-        .route("/commands/:id/approve", post(handlers::approve_command))
-        .route("/commands/:id/trust", post(handlers::trust_command))
-        .route("/commands/:id/deny", post(handlers::deny_command))
+        .route("/commands/{id}/approve", post(handlers::approve_command))
+        .route("/commands/{id}/trust", post(handlers::trust_command))
+        .route("/commands/{id}/deny", post(handlers::deny_command))
         // M-08: chat_handler moved here to apply rate limiting
         .route("/chat", post(handlers::chat_handler))
         // Chat persistence endpoints
         .route(
-            "/chat/:agent_id/messages",
+            "/chat/{agent_id}/messages",
             get(handlers::chat::get_messages)
                 .post(handlers::chat::post_message)
                 .delete(handlers::chat::delete_messages),
         )
         .route(
-            "/chat/:agent_id/messages/:message_id/retry",
+            "/chat/{agent_id}/messages/{message_id}/retry",
             post(handlers::chat::retry_response),
         )
         .route(
-            "/chat/attachments/:attachment_id",
+            "/chat/attachments/{attachment_id}",
             get(handlers::chat::get_attachment),
         )
         // MCP dynamic server management
@@ -1131,25 +1131,28 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
             get(handlers::list_mcp_servers).post(handlers::create_mcp_server),
         )
         .route(
-            "/mcp/servers/:name",
+            "/mcp/servers/{name}",
             axum::routing::delete(handlers::delete_mcp_server),
         )
         // MCP server settings & access control (MCP_SERVER_UI_DESIGN.md §4)
         .route(
-            "/mcp/servers/:name/settings",
+            "/mcp/servers/{name}/settings",
             get(handlers::get_mcp_server_settings).put(handlers::update_mcp_server_settings),
         )
         .route(
-            "/mcp/servers/:name/access",
+            "/mcp/servers/{name}/access",
             get(handlers::get_mcp_server_access).put(handlers::put_mcp_server_access),
         )
         // MCP server lifecycle
         .route(
-            "/mcp/servers/:name/restart",
+            "/mcp/servers/{name}/restart",
             post(handlers::restart_mcp_server),
         )
-        .route("/mcp/servers/:name/start", post(handlers::start_mcp_server))
-        .route("/mcp/servers/:name/stop", post(handlers::stop_mcp_server))
+        .route(
+            "/mcp/servers/{name}/start",
+            post(handlers::start_mcp_server),
+        )
+        .route("/mcp/servers/{name}/stop", post(handlers::stop_mcp_server))
         // Direct tool call for coordinator-pattern servers (MGP §5.6, §19.1)
         .route("/mcp/call", post(handlers::call_mcp_tool))
         // Settings
@@ -1171,7 +1174,7 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
             post(handlers::batch_install_handler),
         )
         .route(
-            "/marketplace/servers/:id",
+            "/marketplace/servers/{id}",
             delete(handlers::uninstall_handler),
         );
 
@@ -1192,16 +1195,16 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
         .route("/metrics", get(handlers::get_metrics))
         .route("/memories", get(handlers::get_memories))
         .route(
-            "/memories/:id",
+            "/memories/{id}",
             delete(handlers::delete_memory).put(handlers::update_memory),
         )
-        .route("/memories/:id/lock", post(handlers::lock_memory))
-        .route("/memories/:id/unlock", post(handlers::unlock_memory))
+        .route("/memories/{id}/lock", post(handlers::lock_memory))
+        .route("/memories/{id}/unlock", post(handlers::unlock_memory))
         .route("/episodes", get(handlers::get_episodes))
-        .route("/episodes/:id", delete(handlers::delete_episode))
+        .route("/episodes/{id}", delete(handlers::delete_episode))
         .route("/memories/import", post(handlers::import_memories))
         .route("/plugins", get(handlers::get_plugins))
-        .route("/plugins/:id/config", get(handlers::get_plugin_config))
+        .route("/plugins/{id}/config", get(handlers::get_plugin_config))
         .route("/agents", get(handlers::get_agents))
         .route(
             "/permissions/pending",
@@ -1209,7 +1212,7 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
         )
         // MCP access control (public/read)
         .route(
-            "/mcp/access/by-agent/:agent_id",
+            "/mcp/access/by-agent/{agent_id}",
             get(handlers::get_agent_access),
         )
         .merge(admin_routes)
@@ -1221,7 +1224,7 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
 
     let app = Router::new()
         .nest("/api", api_routes.with_state(app_state.clone()))
-        .route("/api/plugin/*path", any(dynamic_proxy_handler))
+        .route("/api/plugin/{*path}", any(dynamic_proxy_handler))
         .with_state(app_state.clone())
         .fallback(handlers::assets::static_handler)
         .layer(

--- a/crates/core/tests/handlers_http_test.rs
+++ b/crates/core/tests/handlers_http_test.rs
@@ -15,22 +15,22 @@ fn create_test_router(state: Arc<AppState>) -> axum::Router {
 
     let admin_routes = axum::Router::new()
         .route("/agents", post(handlers::create_agent))
-        .route("/agents/:id", post(handlers::update_agent))
+        .route("/agents/{id}", post(handlers::update_agent))
         .route(
-            "/agents/:id/mcp-access",
+            "/agents/{id}/mcp-access",
             put(handlers::put_agent_mcp_access),
         )
         .route("/cron/jobs", post(handlers::create_cron_job))
-        .route("/plugins/:id/config", post(handlers::update_plugin_config))
+        .route("/plugins/{id}/config", post(handlers::update_plugin_config))
         .route(
-            "/permissions/:id/approve",
+            "/permissions/{id}/approve",
             post(handlers::approve_permission),
         );
 
     let api_routes = axum::Router::new()
         .route("/chat", post(handlers::chat_handler))
         .route("/agents", get(handlers::get_agents))
-        .route("/plugins/:id/config", get(handlers::get_plugin_config))
+        .route("/plugins/{id}/config", get(handlers::get_plugin_config))
         .merge(admin_routes)
         .with_state(state);
 


### PR DESCRIPTION
## Why
Dependabot **#120** bumped `axum` 0.7→0.8 but only the version. axum 0.8 (matchit 0.8) changes the path-parameter syntax from `/:id` to `/{id}` and wildcards from `/*path` to `/{*path}` — building a `Router` with the old syntax **panics at runtime**. So every handler integration test that builds the router aborted (**12 failures** in `handlers_http_test`) and #120 can never go green without the route migration (the crate compiles; it dies at router build).

## What
- `Cargo.toml`: `axum` 0.7 → 0.8 (resolves `axum 0.8.9`)
- `crates/core/src/lib.rs`: rewrite all `:param` route segments → `{param}`, and `/api/plugin/*path` → `/api/plugin/{*path}`
- `crates/core/tests/handlers_http_test.rs`: same route-string rewrite in the fixture

**No extractor/middleware/trait churn.** The codebase has zero custom `FromRequest`/`FromRequestParts` impls, no `WebSocket`, and its `#[async_trait]` usage is on its own (db/capability) traits — untouched by axum 0.8. `Path<T>` extraction is unchanged (only the route *string* syntax moved). `Option<Json<T>>` in `delete_agent` still compiles (axum 0.8 `Json: OptionalFromRequest`); the only behavior delta is that a *malformed* body now yields a rejection instead of silently being `None`, which is acceptable for a DELETE. `tower-http 0.6` (already in the tree) supports axum 0.8.

## Verification
- `cargo fmt -p cloto_core --check` clean
- `cargo test -p cloto_core` **green**: `handlers_http_test` 12/12 (was 12 *failed*), lib 333/333, all integration binaries pass
- `cargo clippy -p cloto_core` introduces no new warnings (the 3 pre-existing `too-many-lines`/cast warnings in `marketplace.rs`/`mcp_transport.rs` are untouched and already tolerated by CI)

No RUSTSEC advisory motivates this; it's framework-currency hygiene. Supersedes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)