### PR TITLE
fix(core): scope MemoryCore dashboard fetch per agent (bug-413)

### DIFF
--- a/crates/core/src/handlers.rs
+++ b/crates/core/src/handlers.rs
@@ -462,12 +462,20 @@ async fn call_memory_tool_with_fallback(
 /// **Route:** `GET /api/memories`
 ///
 /// Returns recent memories enriched with lock status and server capabilities.
+#[allow(clippy::implicit_hasher)]
 pub async fn get_memories(
     State(state): State<Arc<AppState>>,
+    axum::extract::Query(query): axum::extract::Query<std::collections::HashMap<String, String>>,
     headers: HeaderMap,
 ) -> AppResult<Json<serde_json::Value>> {
     check_auth(&state, &headers)?;
-    let args = serde_json::json!({ "agent_id": "", "limit": 100 });
+    // Per-agent scoping: when the dashboard selects an agent it passes `agent_id`,
+    // and we scope `list_memories` to that agent so its full recent set is returned.
+    // An empty `agent_id` keeps the global most-recent view for the "All" tab.
+    // Without this, the global top-N fetch was filtered client-side, hiding any
+    // agent whose memories were not among the N most recent across all agents.
+    let agent_id = query.get("agent_id").map_or("", String::as_str);
+    let args = serde_json::json!({ "agent_id": agent_id, "limit": 100 });
 
     // Fetch memories from MCP server
     let mut data = match state
@@ -549,12 +557,16 @@ pub async fn get_memories(
 ///
 /// # Response
 /// Returns recent episodes from CPersona memory server.
+#[allow(clippy::implicit_hasher)]
 pub async fn get_episodes(
     State(state): State<Arc<AppState>>,
+    axum::extract::Query(query): axum::extract::Query<std::collections::HashMap<String, String>>,
     headers: HeaderMap,
 ) -> AppResult<Json<serde_json::Value>> {
     check_auth(&state, &headers)?;
-    let args = serde_json::json!({ "agent_id": "", "limit": 50 });
+    // Per-agent scoping (see `get_memories`): empty `agent_id` = global "All" view.
+    let agent_id = query.get("agent_id").map_or("", String::as_str);
+    let args = serde_json::json!({ "agent_id": agent_id, "limit": 50 });
     call_memory_tool_with_fallback(
         &state,
         "list_episodes",

--- a/dashboard/src/components/MemoryCore.tsx
+++ b/dashboard/src/components/MemoryCore.tsx
@@ -76,13 +76,17 @@ export const MemoryCore = memo(function MemoryCore({ isWindowMode = false }: { i
     return m;
   }, [agents]);
 
-  // Unique agent IDs that have memories or episodes
+  // Filter tabs: every configured agent, plus any agent_id present in the current
+  // data (covers legacy/orphaned memories whose agent is no longer configured).
+  // Derived from the global agent list (not just the fetched memory set) so the
+  // tab list stays stable when the fetch is scoped to a single selected agent.
   const agentTabs = useMemo(() => {
     const ids = new Set<string>();
+    for (const a of agents) ids.add(a.id);
     for (const mem of memories) ids.add(mem.agent_id);
     for (const ep of episodes) ids.add(ep.agent_id);
     return Array.from(ids).sort();
-  }, [memories, episodes]);
+  }, [agents, memories, episodes]);
 
   // Filtered data
   const filteredMemories = useMemo(
@@ -96,7 +100,16 @@ export const MemoryCore = memo(function MemoryCore({ isWindowMode = false }: { i
 
   const fetchData = useCallback(async () => {
     try {
-      const [memResult, episodes, agents] = await Promise.all([api.getMemories(), api.getEpisodes(), api.getAgents()]);
+      // Scope memory/episode fetch to the selected agent (null = global "All" view)
+      // so an agent whose memories aren't among the global most-recent set is still
+      // shown in full. The agent list is fetched globally to keep every filter tab
+      // visible regardless of the active scope.
+      const scope = selectedAgent ?? undefined;
+      const [memResult, episodes, agents] = await Promise.all([
+        api.getMemories(scope),
+        api.getEpisodes(scope),
+        api.getAgents(),
+      ]);
       setMemories(memResult.memories);
       setCapabilities(memResult.capabilities);
       setEpisodes(episodes);
@@ -104,7 +117,7 @@ export const MemoryCore = memo(function MemoryCore({ isWindowMode = false }: { i
     } catch (error) {
       if (import.meta.env.DEV) console.error('Failed to fetch data', error);
     }
-  }, [api.getAgents, api.getEpisodes, api.getMemories]);
+  }, [api.getAgents, api.getEpisodes, api.getMemories, selectedAgent]);
 
   // H-18: Debounce fetchData to prevent cascading API calls on rapid events
   const fetchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -108,9 +108,14 @@ export const api = {
     fetchJson<PermissionRequest[]>('/permissions/pending', 'fetch pending permissions', apiKey),
   getVersion: () => fetchJson<{ version: string; build_target: string }>('/system/version', 'fetch version'),
   getMetrics: (apiKey?: string) => fetchJson<Metrics>('/metrics', 'fetch metrics', apiKey),
-  getMemories: async (apiKey?: string): Promise<{ memories: Memory[]; capabilities: MemoryCapabilities }> => {
+  getMemories: async (
+    apiKey?: string,
+    agentId?: string,
+  ): Promise<{ memories: Memory[]; capabilities: MemoryCapabilities }> => {
+    // Scope to one agent when selected; omit for the global "All" view.
+    const path = agentId ? `/memories?agent_id=${encodeURIComponent(agentId)}` : '/memories';
     const data = await fetchJson<{ memories: Memory[]; count: number; capabilities?: MemoryCapabilities }>(
-      '/memories',
+      path,
       'fetch memories',
       apiKey,
     );
@@ -125,8 +130,10 @@ export const api = {
       },
     };
   },
-  getEpisodes: async (apiKey?: string): Promise<Episode[]> => {
-    const data = await fetchJson<{ episodes: Episode[]; count: number }>('/episodes', 'fetch episodes', apiKey);
+  getEpisodes: async (apiKey?: string, agentId?: string): Promise<Episode[]> => {
+    // Scope to one agent when selected; omit for the global "All" view.
+    const path = agentId ? `/episodes?agent_id=${encodeURIComponent(agentId)}` : '/episodes';
+    const data = await fetchJson<{ episodes: Episode[]; count: number }>(path, 'fetch episodes', apiKey);
     return data.episodes ?? [];
   },
   getHistory: (apiKey?: string) => fetchJson<StrictSystemEvent[]>('/history', 'fetch history', apiKey),
@@ -791,8 +798,8 @@ export function createAuthenticatedApi(apiKey: string) {
     getAgents: () => api.getAgents(k),
     getPendingPermissions: () => api.getPendingPermissions(k),
     getMetrics: () => api.getMetrics(k),
-    getMemories: () => api.getMemories(k),
-    getEpisodes: () => api.getEpisodes(k),
+    getMemories: (agentId?: string) => api.getMemories(k, agentId),
+    getEpisodes: (agentId?: string) => api.getEpisodes(k, agentId),
     getHistory: () => api.getHistory(k),
     getPlugins: () => api.getPlugins(k),
     getAgentAccess: (agentId: string) => api.getAgentAccess(agentId, k),

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -3245,6 +3245,18 @@
       "status": "open",
       "notes": "Fix: acquire the write lock up front — BEGIN IMMEDIATE for this tx (sqlx 0.8 custom begin), or serialize audit writes through a single-connection writer.",
       "github_issue": 222
+    },
+    {
+      "id": "bug-413",
+      "summary": "MEDIUM: Memory dashboard (MemoryCore) under-displays an agent's memories. The /memories and /episodes endpoints fetched a GLOBAL most-recent top-N (agent_id='' , limit 100/50) and the UI filtered by agent client-side, so any agent whose memories are not among the N most recent across ALL agents shows an incomplete or empty set. Observed: agent.karin had 9 memories in the DB but only its 2 most-recent rows were shown because 133 newer memories from other agents pushed the rest out of the top-100 window; the empty episode stream had the same cause.",
+      "severity": "MEDIUM",
+      "discovered": "2026-06-29T00:00:00Z",
+      "version": "0.6.8-beta.1",
+      "file": "crates/core/src/handlers.rs",
+      "pattern": "\"agent_id\": \"\", \"limit\": 100",
+      "expected": "absent",
+      "status": "fixed",
+      "notes": "Fixed by per-agent scoping. Backend: get_memories/get_episodes read an agent_id query param and pass it to list_memories/list_episodes (empty = global 'All' view). Frontend: api.getMemories/getEpisodes take an agentId and append ?agent_id=; MemoryCore.fetchData scopes the fetch to selectedAgent and re-fetches on change, and agentTabs is derived from the global getAgents() list (unioned with agent_ids in the data) so scoping no longer collapses the filter tabs."
     }
   ]
 }


### PR DESCRIPTION
## Problem (bug-413, MEDIUM)

The `/memories` and `/episodes` endpoints fetched a **global most-recent top-N** (`agent_id=""`, limit 100/50) and the dashboard filtered by agent client-side. Any agent whose memories were not among the N most recent across **all** agents showed an incomplete or empty set.

Observed: `agent.karin` had 9 memories in the DB but only its 2 most-recent rows appeared, because 133 newer rows from other agents pushed the rest out of the top-100 window. The empty episode stream had the same cause.

## Fix

Per-agent scoping, with an empty `agent_id` preserving the existing global "All" view (behavior-preserving default).

- **Backend** (`handlers.rs`): `get_memories` / `get_episodes` read an `agent_id` query param and pass it to `list_memories` / `list_episodes`.
- **Frontend** (`api.ts`): `getMemories` / `getEpisodes` take an `agentId` and append `?agent_id=`.
- **Component** (`MemoryCore.tsx`): `fetchData` scopes the fetch to the selected agent and re-fetches on change; `agentTabs` is derived from the global agent list (unioned with `agent_id`s present in the data) so scoping no longer collapses the filter tabs.
- **Registry**: `bug-413` marked `fixed`.

## Verification

- `tsc --noEmit` clean
- `cargo check -p cloto_core` clean
- CI-exact clippy (`--workspace --exclude app -- -D warnings -A ...`) clean
- pre-commit registry verification passed

Additive and behavior-preserving (empty `agent_id` = prior global behavior); no schema/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)