### PR TITLE
feat(consensus): revive consensus via in-kernel orchestration (Goal #138, bug-408)

### DIFF
--- a/crates/core/src/consensus.rs
+++ b/crates/core/src/consensus.rs
@@ -1,24 +1,26 @@
-//! Consensus Orchestrator — kernel-level collective intelligence.
+//! Consensus configuration + prompt helpers.
 //!
-//! Ported from `plugins/moderator/src/lib.rs` (~150 lines of state machine).
-//! Manages multi-engine consensus sessions: collecting proposals from engines,
-//! then synthesizing a unified response via a designated synthesizer engine.
-
-use cloto_shared::{
-    AgentMetadata, ClotoEvent, ClotoEventData, ClotoId, ClotoMessage, MessageSource,
-};
-use std::collections::HashMap;
-use std::sync::Arc;
-use tokio::sync::RwLock;
-use tracing::{info, warn};
+//! Consensus is a multi-engine deliberation mode: a `consensus:`-prefixed
+//! message is sent to every configured engine, each returns an independent
+//! proposal, and a designated synthesizer engine merges them into one answer.
+//!
+//! Since Goal #138 the orchestration runs **in-kernel**, synchronously, inside
+//! `handlers/system.rs::run_consensus` — it fans the engines out through the
+//! same `run_agentic_loop` the normal message path uses, collects the
+//! proposals, then runs the synthesizer in-kernel. The kernel stamps the
+//! `agent_id` on the synthesized response directly, so identity is structural
+//! rather than inferred from event arrival order (this is what subsumes
+//! bug-408; the reverted standalone guard `481279c` is no longer needed).
+//!
+//! This module is therefore reduced to the pieces the in-kernel path reuses:
+//! the [`ConsensusConfig`] knobs and the two prompt builders. The former
+//! event-driven `ConsensusOrchestrator` (sessions map + cleanup task +
+//! `ThoughtRequested`/`ThoughtResponse` matching) was retired with the
+//! redesign; see `docs/CONSENSUS_REVIVAL_DESIGN.md`.
 
 /// Default synthetic consensus agent id (bug-282: now a configurable
 /// `ConsensusConfig` field; this is only the back-compat default).
 pub(crate) const DEFAULT_CONSENSUS_AGENT_ID: &str = "system.consensus";
-
-/// How often the background cleanup task sweeps stale consensus sessions.
-/// Independent of `session_timeout_secs` (which controls per-session TTL).
-const SESSION_CLEANUP_INTERVAL_SECS: u64 = 30;
 
 // ============================================================
 // Configuration
@@ -26,11 +28,11 @@ const SESSION_CLEANUP_INTERVAL_SECS: u64 = 30;
 
 #[derive(Clone)]
 pub struct ConsensusConfig {
-    /// Engine ID used for synthesis. Empty = use first engine from ConsensusRequested.
+    /// Engine ID used for synthesis. Empty = use the first configured engine.
     pub synthesizer_engine: String,
     /// Minimum proposals required before synthesis starts.
     pub min_proposals: usize,
-    /// Session timeout in seconds.
+    /// Per-phase timeout in seconds (proposal collection and synthesis each).
     pub session_timeout_secs: u64,
     /// Synthetic agent id for consensus-generated responses (bug-282).
     /// Configurable so a deployment can rename it instead of the kernel
@@ -50,288 +52,55 @@ impl Default for ConsensusConfig {
 }
 
 // ============================================================
-// Session State Machine
+// Prompt builders (reused by the in-kernel orchestrator)
 // ============================================================
 
-struct Proposal {
-    content: String,
+/// Format the collected proposals into a single combined-views block for the
+/// synthesizer prompt.
+pub(crate) fn combine_views(proposals: &[String]) -> String {
+    proposals
+        .iter()
+        .enumerate()
+        .map(|(i, p)| format!("## Opinion {}:\n{}", i + 1, p))
+        .collect::<Vec<_>>()
+        .join("\n\n")
 }
 
-enum SessionState {
-    /// Collecting proposals from engines.
-    Collecting {
-        proposals: Vec<Proposal>,
-        fallback_engine: String,
-        created_at: std::time::Instant,
-    },
-    /// Waiting for the synthesizer to produce a final response.
-    Synthesizing { created_at: std::time::Instant },
+/// Build the synthesizer prompt from a combined-views block.
+pub(crate) fn synthesis_prompt(combined_views: &str) -> String {
+    format!(
+        "You are a wise moderator. Synthesize the following opinions into a single, coherent conclusion.\n\n{combined_views}"
+    )
 }
 
-// ============================================================
-// ConsensusOrchestrator
-// ============================================================
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-/// G1.3: Unified state — single RwLock avoids fragmented locking.
-struct ConsensusState {
-    sessions: HashMap<ClotoId, SessionState>,
-    config: ConsensusConfig,
-}
-
-pub struct ConsensusOrchestrator {
-    state: RwLock<ConsensusState>,
-    /// bug-282: cached from `config.synthetic_agent_id` for lock-free reads on
-    /// the thought-response hot path.
-    synthetic_agent_id: String,
-}
-
-impl ConsensusOrchestrator {
-    #[must_use]
-    pub fn new(config: ConsensusConfig) -> Arc<Self> {
-        let synthetic_agent_id = config.synthetic_agent_id.clone();
-        let orchestrator = Arc::new(Self {
-            state: RwLock::new(ConsensusState {
-                sessions: HashMap::new(),
-                config,
-            }),
-            synthetic_agent_id,
-        });
-        orchestrator.spawn_cleanup_task();
-        orchestrator
+    #[test]
+    fn config_default_preserves_back_compat() {
+        let c = ConsensusConfig::default();
+        assert_eq!(c.synthetic_agent_id, DEFAULT_CONSENSUS_AGENT_ID);
+        assert_eq!(c.min_proposals, 2);
+        assert!(c.synthesizer_engine.is_empty());
+        assert_eq!(c.session_timeout_secs, 60);
     }
 
-    /// Update configuration at runtime (e.g., from ConfigUpdated event).
-    pub async fn update_config(&self, config: ConsensusConfig) {
-        self.state.write().await.config = config;
+    #[test]
+    fn combine_views_numbers_each_opinion() {
+        let combined = combine_views(&["alpha".to_string(), "beta".to_string()]);
+        assert_eq!(combined, "## Opinion 1:\nalpha\n\n## Opinion 2:\nbeta");
     }
 
-    /// Handle a consensus-related event. Returns an optional response event.
-    pub async fn handle_event(&self, event: &ClotoEvent) -> Option<ClotoEventData> {
-        match &event.data {
-            ClotoEventData::ConsensusRequested {
-                task: _,
-                engine_ids,
-            } => {
-                self.on_consensus_requested(event.trace_id, engine_ids)
-                    .await
-            }
-
-            ClotoEventData::ThoughtResponse {
-                agent_id, content, ..
-            } => {
-                self.on_thought_response(event.trace_id, agent_id, content)
-                    .await
-            }
-
-            _ => None,
-        }
+    #[test]
+    fn combine_views_empty_is_empty() {
+        assert_eq!(combine_views(&[]), "");
     }
 
-    // ── Event Handlers ──
-
-    async fn on_consensus_requested(
-        &self,
-        trace_id: ClotoId,
-        engine_ids: &[String],
-    ) -> Option<ClotoEventData> {
-        info!(
-            trace_id = %trace_id,
-            "🤝 Consensus process started for {} engines",
-            engine_ids.len()
-        );
-
-        let fallback_engine = engine_ids.first().cloned().unwrap_or_default();
-
-        let mut state = self.state.write().await;
-        state.sessions.insert(
-            trace_id,
-            SessionState::Collecting {
-                proposals: Vec::new(),
-                fallback_engine,
-                created_at: std::time::Instant::now(),
-            },
-        );
-
-        None
-    }
-
-    #[allow(clippy::too_many_lines)]
-    async fn on_thought_response(
-        &self,
-        trace_id: ClotoId,
-        agent_id: &str,
-        content: &str,
-    ) -> Option<ClotoEventData> {
-        // Ignore responses from the consensus system itself
-        if agent_id == self.synthetic_agent_id {
-            return None;
-        }
-
-        // Determine action under a single write lock, then release before synthesis
-        enum Action {
-            None,
-            NeedsSynthesis {
-                combined_views: String,
-                synthesizer: String,
-            },
-            Complete {
-                content: String,
-            },
-        }
-
-        let action = {
-            let mut state = self.state.write().await;
-            let min_proposals = state.config.min_proposals;
-            let synthesizer_engine = state.config.synthesizer_engine.clone();
-
-            let session = state.sessions.get_mut(&trace_id)?;
-
-            match session {
-                SessionState::Collecting {
-                    proposals,
-                    fallback_engine,
-                    created_at,
-                } => {
-                    proposals.push(Proposal {
-                        content: content.to_string(),
-                    });
-
-                    info!(
-                        trace_id = %trace_id,
-                        "📥 Collected proposal from {} ({}/{})",
-                        agent_id,
-                        proposals.len(),
-                        min_proposals,
-                    );
-
-                    if proposals.len() >= min_proposals {
-                        let combined_views = proposals
-                            .iter()
-                            .enumerate()
-                            .map(|(i, p)| format!("## Opinion {}:\n{}", i + 1, p.content))
-                            .collect::<Vec<_>>()
-                            .join("\n\n");
-
-                        let fallback = fallback_engine.clone();
-                        let created = *created_at;
-
-                        let synthesizer = if synthesizer_engine.is_empty() {
-                            fallback
-                        } else {
-                            synthesizer_engine
-                        };
-
-                        *session = SessionState::Synthesizing {
-                            created_at: created,
-                        };
-
-                        Action::NeedsSynthesis {
-                            combined_views,
-                            synthesizer,
-                        }
-                    } else {
-                        Action::None
-                    }
-                }
-
-                SessionState::Synthesizing { .. } => {
-                    info!(
-                        trace_id = %trace_id,
-                        "🏁 Synthesis complete via {}",
-                        agent_id
-                    );
-                    state.sessions.remove(&trace_id);
-                    Action::Complete {
-                        content: content.to_string(),
-                    }
-                }
-            }
-        }; // state lock dropped here
-
-        match action {
-            Action::None => None,
-            Action::NeedsSynthesis {
-                combined_views,
-                synthesizer,
-            } => {
-                info!(
-                    trace_id = %trace_id,
-                    synthesizer = %synthesizer,
-                    "⚗️ Starting synthesis phase...",
-                );
-
-                let synthesis_prompt = format!(
-                    "You are a wise moderator. Synthesize the following opinions into a single, coherent conclusion.\n\n{}",
-                    combined_views
-                );
-
-                let synthesizer_agent = AgentMetadata {
-                    id: "agent.synthesizer".to_string(),
-                    name: "Synthesizer".to_string(),
-                    description: "AI Moderator".to_string(),
-                    enabled: true,
-                    last_seen: 0,
-                    status: "online".to_string(),
-                    default_engine_id: Some(synthesizer.clone()),
-                    required_capabilities: vec![],
-                    metadata: HashMap::new(),
-                    agent_type: "system".to_string(),
-                };
-
-                Some(
-                    ClotoEvent::with_trace(
-                        trace_id,
-                        ClotoEventData::ThoughtRequested {
-                            agent: synthesizer_agent,
-                            engine_id: synthesizer,
-                            message: ClotoMessage::new(MessageSource::System, synthesis_prompt),
-                            context: vec![],
-                        },
-                    )
-                    .data,
-                )
-            }
-            Action::Complete { content } => Some(ClotoEventData::ThoughtResponse {
-                agent_id: self.synthetic_agent_id.clone(),
-                engine_id: "consensus".to_string(),
-                content,
-                source_message_id: "consensus".to_string(),
-                auto_spoken: false,
-            }),
-        }
-    }
-
-    fn spawn_cleanup_task(self: &Arc<Self>) {
-        let this = Arc::downgrade(self);
-        tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(tokio::time::Duration::from_secs(
-                    SESSION_CLEANUP_INTERVAL_SECS,
-                ))
-                .await;
-                let Some(orchestrator) = this.upgrade() else {
-                    break; // Orchestrator dropped, stop cleanup
-                };
-                let mut state = orchestrator.state.write().await;
-                let timeout_secs = state.config.session_timeout_secs;
-                let before = state.sessions.len();
-                state.sessions.retain(|trace_id, session| {
-                    let created_at = match session {
-                        SessionState::Collecting { created_at, .. }
-                        | SessionState::Synthesizing { created_at } => *created_at,
-                    };
-                    if created_at.elapsed().as_secs() > timeout_secs {
-                        warn!(trace_id = %trace_id, "🕐 Consensus session timed out, removing");
-                        false
-                    } else {
-                        true
-                    }
-                });
-                let removed = before - state.sessions.len();
-                if removed > 0 {
-                    info!("🧹 Cleaned up {} stale consensus sessions", removed);
-                }
-            }
-        });
+    #[test]
+    fn synthesis_prompt_embeds_views() {
+        let p = synthesis_prompt("## Opinion 1:\nx");
+        assert!(p.contains("wise moderator"));
+        assert!(p.ends_with("## Opinion 1:\nx"));
     }
 }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -50,7 +50,6 @@ pub struct EventProcessor {
     metrics: Arc<crate::managers::SystemMetrics>,
     max_history_size: usize,
     event_retention_hours: u64, // M-10: Configurable retention period
-    consensus: Option<Arc<crate::consensus::ConsensusOrchestrator>>,
     /// Per-plugin rate limiter for InputControl actions (bug-143: Guardrail 1.6)
     action_rate_limiter: Arc<dashmap::DashMap<String, governor::DefaultDirectRateLimiter>>,
     /// Configured HAL rate limit (actions/sec/requester).
@@ -76,7 +75,6 @@ impl EventProcessor {
         metrics: Arc<crate::managers::SystemMetrics>,
         max_history_size: usize,
         event_retention_hours: u64, // M-10: Configurable retention period
-        consensus: Option<Arc<crate::consensus::ConsensusOrchestrator>>,
         system_handler: Arc<SystemHandler>,
         max_event_history: usize,
         hal_rate_limit_per_sec: u32,
@@ -91,7 +89,6 @@ impl EventProcessor {
             metrics,
             max_history_size,
             event_retention_hours,
-            consensus,
             action_rate_limiter: Arc::new(dashmap::DashMap::new()),
             hal_rate_limit_per_sec,
             hal_rate_limit_burst,
@@ -269,23 +266,11 @@ impl EventProcessor {
                 .dispatch_event(envelope.clone(), &event_tx)
                 .await;
 
-            // ── (4) Consensus Orchestrator ──
-            if let Some(ref consensus) = self.consensus {
-                if let Some(response_data) = consensus.handle_event(&event).await {
-                    let response_event = Arc::new(ClotoEvent::with_trace(trace_id, response_data));
-                    let response_envelope = crate::EnvelopedEvent {
-                        event: response_event,
-                        issuer: None,
-                        correlation_id: Some(trace_id),
-                        depth: envelope.depth + 1,
-                    };
-                    if let Err(e) = event_tx.send(response_envelope).await {
-                        error!("Failed to send consensus response event: {}", e);
-                    }
-                }
-            }
-
-            // ── (5) イベント固有の後処理 ──
+            // ── (4) イベント固有の後処理 ──
+            // (Consensus is now orchestrated in-kernel inside
+            //  SystemHandler::run_consensus — see docs/CONSENSUS_REVIVAL_DESIGN.md.
+            //  It no longer rides the event bus, so there is no orchestrator hook
+            //  here.)
             match &event.data {
                 cloto_shared::ClotoEventData::ThoughtResponse {
                     agent_id,

--- a/crates/core/src/handlers/system.rs
+++ b/crates/core/src/handlers/system.rs
@@ -261,6 +261,12 @@ pub struct SystemHandler {
     metrics: Arc<crate::managers::SystemMetrics>,
     consensus_engines: Vec<String>,
     consensus_prefix: String,
+    /// Consensus knobs (min proposals, synthesizer engine, per-phase timeout,
+    /// synthetic agent id). Defaults to `ConsensusConfig::default()` for tests;
+    /// production wires the env-derived config via [`Self::set_consensus_config`]
+    /// right after construction. Consumed by the in-kernel orchestrator
+    /// [`Self::run_consensus`].
+    consensus_config: crate::consensus::ConsensusConfig,
     max_agentic_iterations: u8,
     tool_execution_timeout_secs: u64,
     pending_approvals: PendingApprovals,
@@ -318,6 +324,7 @@ impl SystemHandler {
             metrics,
             consensus_engines,
             consensus_prefix,
+            consensus_config: crate::consensus::ConsensusConfig::default(),
             max_agentic_iterations,
             tool_execution_timeout_secs,
             pending_approvals,
@@ -330,6 +337,13 @@ impl SystemHandler {
             mcp_streaming_enabled,
             session_manager: Arc::new(crate::managers::session_manager::SessionManager::new()),
         }
+    }
+
+    /// Wire the env-derived consensus configuration into this handler.
+    /// Production code calls this right after construction; tests leave it
+    /// defaulted to [`crate::consensus::ConsensusConfig::default`].
+    pub fn set_consensus_config(&mut self, config: crate::consensus::ConsensusConfig) {
+        self.consensus_config = config;
     }
 
     /// Wire the shared `AppState::session_manager` into this handler.
@@ -760,49 +774,13 @@ impl SystemHandler {
             .to_lowercase()
             .starts_with(&self.consensus_prefix.to_lowercase())
         {
-            // 合意形成モード
-            let thought_event_data = cloto_shared::ClotoEventData::ConsensusRequested {
-                task: msg.content.clone(),
-                engine_ids: self.consensus_engines.clone(),
-            };
-
-            let envelope = crate::EnvelopedEvent {
-                event: Arc::new(cloto_shared::ClotoEvent::with_trace(
-                    trace_id,
-                    thought_event_data,
-                )),
-                issuer: None,
-                correlation_id: None,
-                depth: 0,
-            };
-            if let Err(e) = self.sender.send(envelope).await {
-                error!("Failed to dispatch ConsensusRequested: {}", e);
-            }
-
-            // 各エンジンにも個別にThoughtRequestedを投げる (Moderatorが拾うため)
-            for engine in &self.consensus_engines {
-                let inner_thought = cloto_shared::ClotoEventData::ThoughtRequested {
-                    agent: agent.clone(),
-                    engine_id: engine.clone(),
-                    message: msg.clone(),
-                    context: context.clone(),
-                };
-                let env = crate::EnvelopedEvent {
-                    event: Arc::new(cloto_shared::ClotoEvent::with_trace(
-                        trace_id,
-                        inner_thought,
-                    )),
-                    issuer: None,
-                    correlation_id: Some(trace_id),
-                    depth: 1,
-                };
-                if let Err(e) = self.sender.send(env).await {
-                    error!(
-                        "Failed to dispatch ThoughtRequested for engine {}: {}",
-                        engine, e
-                    );
-                }
-            }
+            // Consensus mode — orchestrated in-kernel (Goal #138). Every engine
+            // runs through the same `run_agentic_loop` the normal path uses; the
+            // kernel collects the proposals, runs the synthesizer in-kernel, and
+            // emits one final ThoughtResponse stamped with the synthetic agent id.
+            // See docs/CONSENSUS_REVIVAL_DESIGN.md.
+            self.run_consensus(&agent, &msg, context, &granted_server_ids, trace_id)
+                .await;
         } else if let Some(tool_name) = msg.metadata.get("tool_hint").cloned() {
             // ── Direct tool execution: bypass agentic loop ──
             // Used by I/O bridges (Discord backtick commands) and internal hints (speak).
@@ -1540,6 +1518,219 @@ impl SystemHandler {
         // active_cron_contexts cleanup is handled by the `handle_message` wrapper.
 
         Ok(HandleOutcome::Executed)
+    }
+
+    // ── Consensus (in-kernel orchestration, Goal #138) ──
+
+    /// Run a consensus session entirely in-kernel.
+    ///
+    /// Every configured engine runs concurrently through the same
+    /// [`Self::run_agentic_loop`] the normal message path uses (so engine
+    /// resolution, per-agent tool access, and fallback all behave identically);
+    /// the kernel collects their proposals, then runs the synthesizer engine
+    /// in-kernel over the combined views and emits **exactly one** terminal
+    /// `ThoughtResponse` stamped with the synthetic agent id.
+    ///
+    /// Because collection and synthesis are sequential awaits in one task — not
+    /// events matched by arrival order — a late proposal can never be mistaken
+    /// for the synthesis result. This is what subsumes bug-408; the reverted
+    /// standalone guard (`481279c`) is unnecessary. Every terminal branch emits
+    /// a response (success or error) so the caller never waits on a silent
+    /// timeout. See `docs/CONSENSUS_REVIVAL_DESIGN.md`.
+    async fn run_consensus(
+        &self,
+        agent: &AgentMetadata,
+        msg: &ClotoMessage,
+        context: Vec<ClotoMessage>,
+        granted_server_ids: &[String],
+        trace_id: ClotoId,
+    ) {
+        let cfg = &self.consensus_config;
+        let engines = &self.consensus_engines;
+        let min_proposals = cfg.min_proposals;
+        let phase_timeout = Duration::from_secs(cfg.session_timeout_secs);
+
+        info!(
+            trace_id = %trace_id,
+            engines = engines.len(),
+            min_proposals,
+            "🤝 Consensus (in-kernel) started"
+        );
+
+        // Fail-safe: not enough engines configured to ever reach quorum.
+        if engines.len() < min_proposals {
+            let detail = format!(
+                "Consensus needs at least {min_proposals} proposals but only {} engine(s) are configured (CONSENSUS_ENGINES).",
+                engines.len()
+            );
+            warn!(trace_id = %trace_id, "{detail}");
+            self.emit_consensus_response(
+                format!("[Consensus unavailable] {detail}"),
+                &msg.id,
+                trace_id,
+            )
+            .await;
+            return;
+        }
+
+        // 1. Collect proposals — run every engine concurrently, in-kernel. Each
+        //    engine gets a throwaway per-engine session key so the proposals
+        //    never pollute the user's real T1 transcript or each other's.
+        let proposal_keys: Vec<_> = engines
+            .iter()
+            .map(|e| {
+                crate::managers::session_manager::SessionKey::new(
+                    &agent.id,
+                    format!("consensus:{trace_id}:{e}"),
+                )
+            })
+            .collect();
+        let proposal_futs = engines.iter().zip(&proposal_keys).map(|(engine, key)| {
+            let ctx = context.clone();
+            async move {
+                let r = tokio::time::timeout(
+                    phase_timeout,
+                    self.run_agentic_loop(
+                        agent,
+                        engine,
+                        msg,
+                        ctx,
+                        granted_server_ids,
+                        trace_id,
+                        key,
+                    ),
+                )
+                .await;
+                (engine.clone(), r)
+            }
+        });
+        let results = futures::future::join_all(proposal_futs).await;
+
+        let mut proposals: Vec<String> = Vec::new();
+        for (engine, r) in results {
+            match r {
+                Ok(Ok(text)) => {
+                    info!(trace_id = %trace_id, engine = %engine, "📥 Consensus proposal collected");
+                    proposals.push(text);
+                }
+                Ok(Err(e)) => {
+                    warn!(trace_id = %trace_id, engine = %engine, error = %e, "⚠️ Consensus engine errored — dropping its proposal");
+                }
+                Err(_) => {
+                    warn!(trace_id = %trace_id, engine = %engine, "⏱️ Consensus engine timed out — dropping its proposal");
+                }
+            }
+        }
+
+        // Fail-safe: quorum not reached after errors / timeouts.
+        if proposals.len() < min_proposals {
+            let detail = format!(
+                "Consensus collected only {}/{min_proposals} proposals (engines errored or timed out).",
+                proposals.len()
+            );
+            warn!(trace_id = %trace_id, "{detail}");
+            self.emit_consensus_response(format!("[Consensus failed] {detail}"), &msg.id, trace_id)
+                .await;
+            return;
+        }
+
+        // 2. Synthesize — run the synthesizer engine in-kernel over the combined
+        //    views. A pure text merge → no tools (empty grant list → plain think).
+        let combined = crate::consensus::combine_views(&proposals);
+        let synthesizer_engine = if cfg.synthesizer_engine.is_empty() {
+            engines[0].clone()
+        } else {
+            cfg.synthesizer_engine.clone()
+        };
+        let synth_agent = AgentMetadata {
+            id: "agent.synthesizer".to_string(),
+            name: "Synthesizer".to_string(),
+            description: "Consensus moderator".to_string(),
+            enabled: true,
+            last_seen: 0,
+            status: "online".to_string(),
+            default_engine_id: Some(synthesizer_engine.clone()),
+            required_capabilities: vec![],
+            metadata: std::collections::HashMap::new(),
+            agent_type: "system".to_string(),
+        };
+        let synth_msg = ClotoMessage::new(
+            cloto_shared::MessageSource::System,
+            crate::consensus::synthesis_prompt(&combined),
+        );
+        let synth_key = crate::managers::session_manager::SessionKey::new(
+            &cfg.synthetic_agent_id,
+            format!("consensus-synth:{trace_id}"),
+        );
+
+        info!(
+            trace_id = %trace_id,
+            synthesizer = %synthesizer_engine,
+            proposals = proposals.len(),
+            "⚗️ Consensus synthesis started"
+        );
+
+        let synth_result = tokio::time::timeout(
+            phase_timeout,
+            self.run_agentic_loop(
+                &synth_agent,
+                &synthesizer_engine,
+                &synth_msg,
+                vec![],
+                &[],
+                trace_id,
+                &synth_key,
+            ),
+        )
+        .await;
+
+        let content = match synth_result {
+            Ok(Ok(text)) => {
+                info!(trace_id = %trace_id, "🏁 Consensus synthesis complete");
+                text
+            }
+            Ok(Err(e)) => {
+                error!(trace_id = %trace_id, error = %e, "❌ Consensus synthesis failed — returning raw proposals");
+                format!(
+                    "[Consensus synthesis failed: {e}. Individual proposals below.]\n\n{combined}"
+                )
+            }
+            Err(_) => {
+                error!(trace_id = %trace_id, "⏱️ Consensus synthesis timed out — returning raw proposals");
+                format!(
+                    "[Consensus synthesis timed out. Individual proposals below.]\n\n{combined}"
+                )
+            }
+        };
+        self.emit_consensus_response(content, &msg.id, trace_id)
+            .await;
+    }
+
+    /// Emit the single terminal consensus `ThoughtResponse`, stamped with the
+    /// configured synthetic agent id. Mirrors the normal path's emission so
+    /// downstream (`events.rs`) treats it like any other agent response.
+    async fn emit_consensus_response(
+        &self,
+        content: String,
+        source_message_id: &str,
+        trace_id: ClotoId,
+    ) {
+        let response = ClotoEventData::ThoughtResponse {
+            agent_id: self.consensus_config.synthetic_agent_id.clone(),
+            engine_id: "consensus".to_string(),
+            content,
+            source_message_id: source_message_id.to_string(),
+            auto_spoken: false,
+        };
+        let envelope = crate::EnvelopedEvent {
+            event: Arc::new(ClotoEvent::with_trace(trace_id, response)),
+            issuer: None,
+            correlation_id: None,
+            depth: 0,
+        };
+        if let Err(e) = self.sender.send(envelope).await {
+            error!(trace_id = %trace_id, error = %e, "❌ Failed to send consensus ThoughtResponse");
+        }
     }
 
     // ── Agentic Loop ──

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -541,6 +541,25 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
     // Cold sessions and clears stale tool_history on the Warm tier boundary.
     let session_manager = Arc::new(managers::session_manager::SessionManager::new());
 
+    // Consensus knobs (kernel-level; replaces the retired core.moderator plugin).
+    // The orchestration runs in-kernel inside SystemHandler::run_consensus —
+    // see docs/CONSENSUS_REVIVAL_DESIGN.md.
+    let consensus_config = consensus::ConsensusConfig {
+        synthesizer_engine: std::env::var("CONSENSUS_SYNTHESIZER").unwrap_or_default(),
+        synthetic_agent_id: std::env::var("CONSENSUS_AGENT_ID")
+            .unwrap_or_else(|_| consensus::DEFAULT_CONSENSUS_AGENT_ID.to_string()),
+        min_proposals: std::env::var("CONSENSUS_MIN_PROPOSALS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(2)
+            .max(2),
+        session_timeout_secs: std::env::var("CONSENSUS_SESSION_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(60)
+            .max(10),
+    };
+
     let system_handler = {
         let mut h = SystemHandler::new(
             registry_arc.clone(),
@@ -563,6 +582,7 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
         h.set_probe_cache(probe_cache.clone());
         h.set_usage_store(last_usage_store.clone());
         h.set_session_manager(session_manager.clone());
+        h.set_consensus_config(consensus_config);
         Arc::new(h)
     };
 
@@ -677,24 +697,6 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
     // Wire up kernel event bus to MCP manager (for PermissionRequested emission)
     mcp_manager.set_kernel_event_tx(event_tx.clone()).await;
 
-    // 6. Consensus Orchestrator (kernel-level, replaces core.moderator plugin)
-    let consensus_config = consensus::ConsensusConfig {
-        synthesizer_engine: std::env::var("CONSENSUS_SYNTHESIZER").unwrap_or_default(),
-        synthetic_agent_id: std::env::var("CONSENSUS_AGENT_ID")
-            .unwrap_or_else(|_| consensus::DEFAULT_CONSENSUS_AGENT_ID.to_string()),
-        min_proposals: std::env::var("CONSENSUS_MIN_PROPOSALS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(2)
-            .max(2),
-        session_timeout_secs: std::env::var("CONSENSUS_SESSION_TIMEOUT_SECS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(60)
-            .max(10),
-    };
-    let consensus_orchestrator = consensus::ConsensusOrchestrator::new(consensus_config);
-
     // 6a. Event Loop
     let processor = Arc::new(EventProcessor::new(
         registry_arc.clone(),
@@ -705,7 +707,6 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
         metrics,
         config.event_history_size,
         config.event_retention_hours,
-        Some(consensus_orchestrator),
         system_handler,
         config.max_event_history,
         config.hal_rate_limit_per_sec,

--- a/crates/core/tests/consensus_test.rs
+++ b/crates/core/tests/consensus_test.rs
@@ -1,0 +1,156 @@
+//! Integration tests for the in-kernel consensus orchestration (Goal #138).
+//!
+//! The happy path (real engines produce proposals → synthesis → unified
+//! answer) depends on live MCP engines and is verified against the running app
+//! — there is no Rust `ReasoningEngine` in the codebase to mock (every engine
+//! is an MCP server). These tests instead pin the structural guarantees that
+//! the redesign must hold regardless of engines:
+//!
+//!   1. A consensus request always terminates with **exactly one**
+//!      `ThoughtResponse`, stamped with the synthetic agent id — never a silent
+//!      timeout (fail-safe).
+//!   2. The consensus path no longer emits the retired `ConsensusRequested` /
+//!      `ThoughtRequested` events (the dead event contract is gone).
+//!
+//! See docs/CONSENSUS_REVIVAL_DESIGN.md.
+
+use cloto_core::handlers::system::SystemHandler;
+use cloto_core::managers::{AgentManager, PluginRegistry};
+use cloto_shared::{ClotoEventData, ClotoMessage, MessageSource};
+use sqlx::SqlitePool;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+const SYNTHETIC_AGENT_ID: &str = "system.consensus";
+
+async fn build_handler(
+    engines: Vec<String>,
+) -> (SystemHandler, mpsc::Receiver<cloto_core::EnvelopedEvent>) {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
+        .await
+        .unwrap();
+
+    let agent_id = "agent.test";
+    sqlx::query("INSERT INTO agents (id, name, description, status, default_engine_id, required_capabilities, metadata, enabled) VALUES (?, 'Test Agent', 'Desc', 'online', 'engine.test', '[\"Reasoning\"]', '{}', 1)")
+        .bind(agent_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let registry = Arc::new(PluginRegistry::new(5, 10, 50));
+    let agent_manager = AgentManager::new(pool.clone(), 90_000);
+    let (event_tx, event_rx) = mpsc::channel(64);
+    let metrics = Arc::new(cloto_core::managers::SystemMetrics::new());
+
+    let handler = SystemHandler::new(
+        registry,
+        agent_manager,
+        agent_id.to_string(),
+        event_tx,
+        10, // memory_context_limit
+        metrics,
+        engines,
+        "consensus:".to_string(),
+        16, // max_agentic_iterations
+        30, // tool_execution_timeout_secs
+        Arc::new(dashmap::DashMap::new()),
+        Arc::new(dashmap::DashMap::new()),
+        pool,
+        Arc::new(dashmap::DashMap::new()),
+        5,     // memory_timeout_secs
+        false, // mcp_streaming_enabled
+    );
+
+    (handler, event_rx)
+}
+
+fn drain(rx: &mut mpsc::Receiver<cloto_core::EnvelopedEvent>) -> Vec<ClotoEventData> {
+    let mut out = Vec::new();
+    while let Ok(env) = rx.try_recv() {
+        out.push(env.event.data.clone());
+    }
+    out
+}
+
+fn consensus_msg() -> ClotoMessage {
+    ClotoMessage::new(
+        MessageSource::User {
+            id: "user1".into(),
+            name: "User".into(),
+        },
+        "consensus: what is the best approach?".into(),
+    )
+}
+
+/// Assert the common invariants every consensus run must satisfy: exactly one
+/// terminal `ThoughtResponse` stamped with the synthetic agent id, and no
+/// retired `ConsensusRequested` / `ThoughtRequested` events on the bus.
+fn assert_single_synthetic_response(events: &[ClotoEventData]) -> String {
+    let mut responses = events.iter().filter_map(|e| match e {
+        ClotoEventData::ThoughtResponse {
+            agent_id,
+            engine_id,
+            content,
+            ..
+        } => Some((agent_id.clone(), engine_id.clone(), content.clone())),
+        _ => None,
+    });
+
+    let (agent_id, engine_id, content) = responses
+        .next()
+        .expect("consensus must emit exactly one ThoughtResponse, got none");
+    assert!(
+        responses.next().is_none(),
+        "consensus must emit exactly one ThoughtResponse, got more than one"
+    );
+    assert_eq!(
+        agent_id, SYNTHETIC_AGENT_ID,
+        "terminal response must be stamped with the synthetic agent id"
+    );
+    assert_eq!(engine_id, "consensus", "engine_id must be 'consensus'");
+
+    assert!(
+        !events.iter().any(|e| matches!(
+            e,
+            ClotoEventData::ConsensusRequested { .. } | ClotoEventData::ThoughtRequested { .. }
+        )),
+        "the retired ConsensusRequested / ThoughtRequested events must not be emitted"
+    );
+
+    content
+}
+
+/// Fewer engines configured than `min_proposals` (default 2) → immediate
+/// fail-safe response, no engine ever runs.
+#[tokio::test]
+async fn consensus_too_few_engines_emits_single_synthetic_failsafe() {
+    let (handler, mut rx) = build_handler(vec!["mind.alpha".to_string()]).await;
+
+    handler.handle_message(consensus_msg()).await.unwrap();
+
+    let events = drain(&mut rx);
+    let content = assert_single_synthetic_response(&events);
+    assert!(
+        content.contains("[Consensus unavailable]"),
+        "expected the too-few-engines fail-safe message, got: {content}"
+    );
+}
+
+/// Enough engines configured but none are registered/resolvable → every
+/// proposal loop errors → quorum is not reached → fail-safe response. Proves
+/// the kernel never hangs waiting on proposals that will never arrive.
+#[tokio::test]
+async fn consensus_all_engines_unavailable_quorum_failsafe_no_legacy_events() {
+    let (handler, mut rx) =
+        build_handler(vec!["mind.alpha".to_string(), "mind.beta".to_string()]).await;
+
+    handler.handle_message(consensus_msg()).await.unwrap();
+
+    let events = drain(&mut rx);
+    let content = assert_single_synthetic_response(&events);
+    assert!(
+        content.contains("[Consensus failed]"),
+        "expected the quorum-not-reached fail-safe message, got: {content}"
+    );
+}

--- a/crates/core/tests/event_cascading_test.rs
+++ b/crates/core/tests/event_cascading_test.rs
@@ -135,7 +135,6 @@ async fn test_event_cascading_protection() {
         metrics,
         1000, // max_history_size
         24,   // event_retention_hours
-        None, // consensus
         sys_handler,
         10_000, // max_event_history
         10,     // hal_rate_limit_per_sec

--- a/crates/core/tests/event_memory_management_test.rs
+++ b/crates/core/tests/event_memory_management_test.rs
@@ -51,8 +51,7 @@ async fn create_test_processor(
         event_history.clone(),
         metrics,
         max_history_size,
-        24,   // event_retention_hours
-        None, // consensus
+        24, // event_retention_hours
         sys_handler,
         10_000, // max_event_history
         10,     // hal_rate_limit_per_sec

--- a/crates/core/tests/permission_elevation_test.rs
+++ b/crates/core/tests/permission_elevation_test.rs
@@ -130,7 +130,6 @@ async fn test_dynamic_permission_elevation_flow() {
         metrics,
         1000, // max_history_size
         24,   // event_retention_hours
-        None, // consensus
         sys_handler,
         10_000, // max_event_history
         10,     // hal_rate_limit_per_sec

--- a/crates/core/tests/security_forging_test.rs
+++ b/crates/core/tests/security_forging_test.rs
@@ -179,7 +179,6 @@ async fn test_vulnerability_event_forging() {
         metrics,
         1000, // max_history_size
         24,   // event_retention_hours
-        None, // consensus
         sys_handler,
         10_000, // max_event_history
         10,     // hal_rate_limit_per_sec

--- a/docs/CONSENSUS_REVIVAL_DESIGN.md
+++ b/docs/CONSENSUS_REVIVAL_DESIGN.md
@@ -1,0 +1,249 @@
+# Consensus Revival — In-Kernel Proposal Generation (Design)
+
+Status: **Accepted** (2026-06-30). Scope #12 / Goal #138 / Task #111.
+Supersedes the reverted standalone bug-408 patch (`481279c`).
+
+Ratified decisions (see §9): **(a) Option A** — kernel-driven synchronous
+orchestration. **(b)** `ConsensusRequested` / `ThoughtRequested` enum variants
+are **kept** in `ClotoEventData` (protocol stability) but no longer
+produced/consumed on the consensus path. **(c)** proposal `agent_id` stamping
+per §5.1 (`agent_id = agent.id`, distinguished by `engine_id`).
+
+## 1. Motivation
+
+Consensus is a multi-engine deliberation mode: a single user task is sent to N
+LLM engines, each returns an independent *proposal*, and a designated
+*synthesizer* engine merges them into one answer. It is a flagship "multiple
+LLMs deliberating" capability and a marketing asset. Today it is **dormant** —
+a consensus request collects nothing and silently times out.
+
+This document specifies how to make consensus functional again by generating
+proposals **in-kernel**, and shows why that redesign subsumes bug-408
+(consensus aggregation race) as a correct-by-construction property rather than a
+patch.
+
+## 2. Current (dormant) architecture and the exact gap
+
+### 2.1 What fires today
+
+When an inbound message starts with the consensus prefix (default `consensus:`),
+`handlers/system.rs` (`handle_message`, the consensus branch ~L758) emits:
+
+1. one `ConsensusRequested { task, engine_ids }` envelope (depth 0), and
+2. one `ThoughtRequested { agent, engine_id, message, context }` envelope per
+   configured engine (depth 1, `correlation_id = trace_id`).
+
+In `events.rs` the event loop then:
+
+- routes `ConsensusRequested` → `ConsensusOrchestrator::handle_event` →
+  `on_consensus_requested`, which inserts a `Collecting` session and returns
+  `None`;
+- routes each `ThoughtRequested` → `registry.dispatch_event` (MCP plugins only,
+  empty set) → `consensus.handle_event` (its `match` has no `ThoughtRequested`
+  arm → `None`) → the post-processing `match` in `events.rs` (no
+  `ThoughtRequested` arm).
+
+### 2.2 The gap
+
+**Nothing consumes `ThoughtRequested`.** No component runs the engine for a
+`ThoughtRequested` event and emits a matching `ThoughtResponse`. Historically
+`plugins/moderator` (a Rust plugin) listened for `ThoughtRequested` in its
+`on_event` and called the engine; that plugin layer was removed:
+
+- `742ee61` — state machine absorbed into the kernel (`consensus.rs`),
+- `dcc6820` — plugin layer + consensus dashboard UI trimmed,
+- `207b39e` — consensus dropped from the advertised use cases.
+
+The engine-running half of the contract was never re-homed. Consequently:
+
+- proposals are never produced → `ConsensusOrchestrator`'s `on_thought_response`
+  never fires → the `Collecting` session reaches `min_proposals` never →
+- the background cleanup task evicts the session after
+  `session_timeout_secs` (default 60s). The user sees nothing.
+
+Note the asymmetry with the **normal** message path: a non-consensus message is
+handled *synchronously inside* `handle_message`, which calls
+`run_agentic_loop(...) -> anyhow::Result<String>` and then emits the
+`ThoughtResponse` directly (system.rs ~L1254). The normal path never relies on
+an external `ThoughtRequested` consumer. **Consensus is the only path that emits
+work-request events expecting an external worker that no longer exists.**
+
+## 3. Design goals and constraints
+
+- **G1 — Functional consensus**: a `consensus:` message must collect proposals
+  from ≥2 real engines, synthesize, and return one unified `ThoughtResponse`.
+- **G2 — Reuse, don't fork**: proposals and synthesis must run through the same
+  `run_agentic_loop` the normal path uses (same engine resolution, MCP/plugin
+  fallback, tool access, error semantics). No second engine-invocation codepath.
+- **G3 — Correct identity (subsumes bug-408)**: the kernel must stamp the
+  `agent_id` on every proposal and on the synthesis, so identity is never
+  inferred from event ordering.
+- **G4 — Fail-safe**: an engine erroring, fewer than `min_proposals`
+  succeeding, or the synthesizer failing/timing out must surface a definite
+  result (error `ThoughtResponse`), never a silent 60s timeout.
+- **G5 — No reference cycle**: `EventProcessor` already owns both the
+  `SystemHandler` and the `ConsensusOrchestrator`; the design must not require
+  the orchestrator to call back into the handler.
+- **G6 — Additive default**: with `CONSENSUS_ENGINES` empty (current default),
+  behavior is unchanged. Nothing turns on until a deployment configures engines.
+
+## 4. Options considered
+
+### Option A — Kernel-driven, synchronous orchestration (RECOMMENDED)
+
+Move *all* engine execution into the `system.rs` consensus branch. The branch
+becomes a self-contained async routine:
+
+1. Resolve `consensus_engines`; if `< min_proposals` are configured, emit an
+   error `ThoughtResponse` immediately (G4).
+2. Run the N engines **concurrently** via `run_agentic_loop`, one task per
+   engine, each bounded by a per-engine timeout (`tokio::select!` over the
+   existing `session_timeout_secs`/a dedicated proposal timeout). Collect the
+   `Ok(String)` proposals; log and drop `Err`/timed-out engines.
+3. If `collected.len() < min_proposals` → error `ThoughtResponse` (G4).
+4. Build the combined-views prompt and run the **synthesizer engine** in-kernel
+   via the same `run_agentic_loop`, bounded by a synthesis timeout.
+5. Emit exactly one final `ThoughtResponse` with `agent_id =
+   synthetic_agent_id`, `engine_id = "consensus"`.
+
+`ConsensusOrchestrator` (consensus.rs) is **retired as an event handler**. Its
+value — the prompt-combination logic, `ConsensusConfig` (min_proposals,
+synthesizer_engine, timeout, synthetic_agent_id) — is kept, either as a small
+synchronous helper module or folded into the consensus branch. The
+`ConsensusRequested` event and the per-engine `ThoughtRequested` emissions are
+**deleted** (they have no consumer and no other producer).
+
+- **bug-408 disposition**: the race ("a late proposal `ThoughtResponse` is
+  mistaken for the synthesis result") **cannot occur** — collection and
+  synthesis are sequential awaits in one task, not events matched by arrival
+  order. The reverted guard (`481279c`, `synthesizer_agent_id` matching) is
+  unnecessary; correctness is structural (G3).
+- **Concurrency** (G2): `tokio::task::JoinSet` or `futures::join_all` over
+  per-engine `run_agentic_loop` futures, each wrapped in `tokio::time::timeout`.
+- **Trace/session** (Task #111c): one `trace_id` for the whole consensus
+  session; each proposal loop uses a per-engine derived `session_key` so engines
+  don't share conversational state, while the synthesis loop uses its own.
+- **Pros**: simplest data flow; no event-bus round trips; no reference cycle
+  (G5); kernel stamps every `agent_id` (G3); fail-safe is plain `Result`
+  handling (G4); deletes dead code.
+- **Cons**: retires the event-driven `ConsensusOrchestrator`. (It is currently
+  dead, so this removes liability rather than function.) Consensus no longer
+  emits intermediate per-proposal events on the bus — if the dashboard wants to
+  visualize each engine's proposal live (Task #113), the branch must emit
+  explicit progress events for that purpose (see §7).
+
+### Option B — Event-driven, add an in-kernel `ThoughtRequested` runner
+
+Keep `ConsensusRequested` and the orchestrator. Add a kernel handler that
+consumes `ThoughtRequested` events generally: run `run_agentic_loop`, emit a
+`ThoughtResponse`. Now both the per-engine proposal requests (from system.rs)
+and the synthesizer request (from the orchestrator's `NeedsSynthesis`) get
+executed. The orchestrator stays event-driven; bug-408's `synthesizer_agent_id`
+guard remains load-bearing.
+
+- **Pros**: minimal change to consensus.rs; preserves the event-driven model; a
+  general `ThoughtRequested → engine → ThoughtResponse` mechanism could be
+  reused by other features.
+- **Cons**: more moving parts and bus round trips; requires loop-guards so a
+  proposal's `ThoughtResponse` is not re-dispatched as new work; bug-408 race is
+  **real and must be guarded** (identity matching by `synthesizer_agent_id`)
+  rather than eliminated; identity is split across two stampers (proposal runner
+  vs orchestrator). Higher surface for the same outcome.
+
+### Decision
+
+**Option A.** It matches the direction recorded at goal creation (kernel
+generates proposals and stamps `ThoughtResponse.agent_id` directly), eliminates
+bug-408 instead of guarding it, avoids the reference cycle, and removes dead
+code. Option B's only unique upside — a general `ThoughtRequested` worker — is
+speculative (YAGNI); no other feature needs it today.
+
+## 5. Recommended design in detail (Option A)
+
+### 5.1 Agent-id stamping convention (Task #111b)
+
+- **Proposal**: stamped with the proposing engine's identity. Use the inbound
+  `agent` as the base and tag the engine, so each proposal is attributable
+  (e.g. `agent_id = agent.id`, distinguished by `engine_id`). The kernel sets
+  this; engines never self-declare it (consistent with the anti-spoofing rule at
+  system.rs ~L819).
+- **Synthesis / final answer**: `agent_id = config.synthetic_agent_id` (default
+  `system.consensus`), `engine_id = "consensus"`. This is the only
+  `ThoughtResponse` delivered to the user/chat.
+
+### 5.2 Fail-safe matrix (Task #111d, G4)
+
+| Condition                              | Behavior                                             |
+| -------------------------------------- | ---------------------------------------------------- |
+| `consensus_engines.len() < min`        | Immediate error `ThoughtResponse`, no engine run.    |
+| An engine returns `Err` / times out    | Log, drop that engine, continue with the rest.       |
+| Collected `< min_proposals`            | Error `ThoughtResponse` ("not enough proposals").    |
+| Synthesizer `Err` / times out          | Error `ThoughtResponse` ("synthesis failed"); MAY    |
+|                                        | fall back to returning the proposals concatenated.   |
+| All good                               | One synthesized `ThoughtResponse`.                   |
+
+Every terminal branch emits exactly one `ThoughtResponse` (success or error) so
+the user never waits on a silent timeout. The background cleanup task in
+consensus.rs is removed along with the session map (no long-lived sessions
+remain).
+
+### 5.3 Reuse boundary (Task #111e)
+
+Reused unchanged: `run_agentic_loop` (engine resolution, `mind.` prefix
+fallback, MCP/plugin dispatch, tool grants, retriable-error fallback). New code
+is limited to: the concurrent fan-out, per-engine timeout wrapping, the
+combined-views prompt builder (lifted from `consensus.rs` `on_thought_response`),
+and the fail-safe branching. No new engine-call primitive is introduced (G2).
+
+### 5.4 What is deleted vs kept
+
+- **Deleted**: `ConsensusRequested` event emission and its `events.rs` routing;
+  the per-engine `ThoughtRequested` fan-out in system.rs; `ConsensusOrchestrator`
+  event handling, the `sessions` map, and the cleanup task.
+- **Kept**: `ConsensusConfig` and its env wiring (`CONSENSUS_ENGINES`,
+  `CONSENSUS_PREFIX`, `CONSENSUS_SYNTHESIZER`, `CONSENSUS_MIN_PROPOSALS`,
+  `CONSENSUS_SESSION_TIMEOUT_SECS`, `CONSENSUS_AGENT_ID`); the combined-views
+  prompt; the synthesizer prompt template.
+- **Open sub-decision for ratification**: whether `ConsensusRequested` /
+  `ThoughtRequested` variants stay in the `ClotoEventData` enum (kept for
+  protocol stability / future Option-B reuse) or are removed. Default
+  recommendation: **keep the enum variants** (cheap, avoids a breaking protocol
+  change) but stop producing/consuming them in the consensus path.
+
+## 6. Config and defaults
+
+No new config keys. Defaults already additive: `CONSENSUS_ENGINES` empty →
+consensus never triggers (G6). Documentation of the keys and a recommended
+multi-engine example belongs to Task #114 (distribution/docs).
+
+## 7. Dashboard visibility hook (forward note for Task #113)
+
+Because Option A no longer puts per-proposal events on the bus, live
+visualization (each engine's proposal, Collecting/Synthesizing state) needs the
+consensus branch to emit explicit progress events (e.g. a `ConsensusProgress`
+SSE payload) at: session start, each proposal collected, synthesis start, and
+completion. This is out of scope for the implementation task (#112) but the
+branch should be structured so these emit points are trivial to add.
+
+## 8. Test plan (for the implementation task #112)
+
+- **Unit**: combined-views builder formatting; fail-safe branches
+  (`< min` engines configured; an engine erroring; `< min` collected; synthesizer
+  erroring/timing out) each yield the expected single `ThoughtResponse`.
+- **Integration (mock engines)**: a `consensus:` message with 2+ mock engines →
+  proposals collected concurrently → synthesis → one unified `ThoughtResponse`
+  with `synthetic_agent_id`. Assert no `ConsensusRequested`/`ThoughtRequested`
+  is emitted. Assert a slow/late engine past the timeout is dropped, not merged.
+- **Regression**: with `CONSENSUS_ENGINES` empty, a `consensus:`-prefixed
+  message is treated as a normal message (or a defined no-op) — confirm the
+  additive default.
+- **Registry**: flip bug-408 `open → fixed` with the rationale "eliminated by
+  in-kernel synchronous orchestration"; run `scripts/verify-issues.sh` → expect
+  `[FIXED]`.
+
+## 9. Done criteria for this design task (#111)
+
+This doc lands (Tier A — PR + review) and is ratified by the maintainer. The
+ratification points are: (a) Option A vs B, (b) the §5.4 enum-variants
+sub-decision, (c) the proposal `agent_id` stamping convention in §5.1.
+Implementation (#112) does not start until these are confirmed.

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -3204,9 +3204,9 @@
       "version": "0.6.8-beta.1",
       "file": "crates/core/src/consensus.rs",
       "pattern": "Synthesis complete via",
-      "expected": "present",
-      "status": "open",
-      "notes": "Fix: record the expected synthesizer identity (agent_id or a freshly minted synthesis request id) in SessionState::Synthesizing and only accept the matching response as Complete; ignore/aggregate non-matching late proposals. DEFERRED (2026-06-30): an attempted fix (commit 481279c, matching agent_id == 'agent.synthesizer') was reverted. It depends on an out-of-repo contract — that the external MGP/SSE mind-bridge echoes the dispatched AgentMetadata.id ('agent.synthesizer') verbatim into ThoughtResponse.agent_id. ThoughtRequested has no in-repo consumer (the Rust Plugin SDK was removed in 85e36cb), so the contract is unverifiable here; if the bridge stamps a different id the match never completes and consensus breaks entirely (worse than this bug). Re-attempt only with an e2e test against the real mind-bridge asserting the synthesis ThoughtResponse.agent_id, plus a fail-safe so a never-matching response cannot hang a session past the cleanup timeout.",
+      "expected": "absent",
+      "status": "fixed",
+      "notes": "FIXED (2026-06-30, Goal #138): eliminated by the in-kernel consensus redesign rather than guarded. The event-driven ConsensusOrchestrator.on_thought_response (whose 'Synthesis complete via' branch accepted the first arriving ThoughtResponse for the trace_id as the synthesis — the race) was removed entirely; consensus.rs is now config + prompt helpers only. Consensus is orchestrated synchronously in SystemHandler::run_consensus: it collects all proposals, then runs the synthesizer in-kernel and stamps the synthetic agent id on the single terminal ThoughtResponse. Because collection and synthesis are sequential awaits in one task — not events matched by arrival order — a late proposal can never be mistaken for the synthesis result, and the out-of-repo agent_id-echo contract the reverted guard (481279c) needed is gone. Per-phase timeouts give the fail-safe (never a hung session). See docs/CONSENSUS_REVIVAL_DESIGN.md. HISTORY: an earlier standalone guard (commit 481279c, matching agent_id == 'agent.synthesizer') was reverted because it depended on the external MGP/SSE mind-bridge echoing AgentMetadata.id verbatim, which is unverifiable in-repo.",
       "github_issue": 218
     },
     {


### PR DESCRIPTION
## Summary

Revives the dormant **consensus** mode (multi-engine deliberation) by re-homing proposal generation **in-kernel**, and eliminates **bug-408** (consensus aggregation race) as a structural property rather than a patch. Implements Goal #138 (design doc + implementation), Option A as ratified.

Design: `docs/CONSENSUS_REVIVAL_DESIGN.md`.

## The problem (why consensus was dormant)

The consensus branch emitted `ConsensusRequested` + a per-engine `ThoughtRequested` for each engine, expecting an external worker to run the engine and emit a `ThoughtResponse`. That worker — the old `plugins/moderator` — was removed (`742ee61` → `dcc6820` → `207b39e`). Nothing consumed `ThoughtRequested`, so **no proposals were ever generated** and every consensus session silently timed out after 60s. The normal message path, by contrast, runs the engine synchronously in `handle_message` via `run_agentic_loop` — consensus was the only path relying on a worker that no longer exists.

## The change (Option A — in-kernel orchestration)

`SystemHandler::run_consensus`:
- runs every configured engine **concurrently** through the same `run_agentic_loop` the normal path uses (`futures::join_all`, per-engine timeout, throwaway per-engine session keys so proposals don't pollute the user's T1 transcript);
- collects the proposals, runs the **synthesizer in-kernel** over the combined views, and emits **exactly one** terminal `ThoughtResponse` stamped with the synthetic agent id;
- every fail-safe branch (too few engines, quorum not reached, synthesizer error/timeout) emits a definite response — **never a silent timeout**.

`consensus.rs` is reduced to `ConsensusConfig` + prompt builders; the event-driven `ConsensusOrchestrator` (sessions map, cleanup task, `on_thought_response` matching) is retired. `events.rs` drops the orchestrator hook; `lib.rs` builds `ConsensusConfig` before `SystemHandler` and injects it via `set_consensus_config`. The `ConsensusRequested` / `ThoughtRequested` enum variants are kept for protocol stability but no longer produced/consumed on the consensus path.

## bug-408 (consensus aggregation race) — eliminated, not guarded

Collection and synthesis are now sequential `await`s in one task, not events matched by arrival order, so a late proposal can never be mistaken for the synthesis result. The reverted standalone guard (`481279c`) and its unverifiable out-of-repo `agent_id`-echo contract are gone. Registry `bug-408 → fixed`, `verify-issues.sh` green. Closes #218.

## Tests

- **Unit** (`consensus.rs`): `combine_views`, `synthesis_prompt`, config default.
- **Integration** (`consensus_test.rs`): fail-safe branches + the invariant that exactly one synthetic-stamped `ThoughtResponse` is emitted and the retired `ConsensusRequested`/`ThoughtRequested` events are never produced.
- 342 lib + all integration tests green; CI-exact clippy + `cargo fmt` clean.

**Not covered in CI** — the happy path (real engines → proposals → synthesis → unified answer) depends on live MCP engines; there is no Rust `ReasoningEngine` to mock (every engine is an MCP server). This needs **live-app verification** (tauri dev + real engines), consistent with how engine-dependent paths are verified in this project.

## Follow-ups (separate tasks)

- **#113** dashboard consensus UI — in-kernel orchestration no longer puts per-proposal events on the bus, so live visualization needs explicit progress events (design doc §7).
- **#114** config defaults / docs / marketing material.

## Merge note

This is a **behavior change** (consensus goes dormant → functional), not behavior-preserving, so it is **not** self-mergeable under the green-light rule — maintainer merge required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
