### PR TITLE
fix(consensus): deliver answer to chat + dedicated Consensus tab + MGP errors (bug-417)

### DIFF
--- a/crates/core/src/handlers/system.rs
+++ b/crates/core/src/handlers/system.rs
@@ -1564,9 +1564,10 @@ impl SystemHandler {
                 engines.len()
             );
             warn!(trace_id = %trace_id, "{detail}");
-            self.emit_consensus_response(
+            self.deliver_consensus_result(
+                agent,
+                msg,
                 format!("[Consensus unavailable] {detail}"),
-                &msg.id,
                 trace_id,
             )
             .await;
@@ -1576,6 +1577,8 @@ impl SystemHandler {
         // 1. Collect proposals — run every engine concurrently, in-kernel. Each
         //    engine gets a throwaway per-engine session key so the proposals
         //    never pollute the user's real T1 transcript or each other's.
+        //    Per-engine ConsensusProgress events feed the dashboard's Consensus
+        //    tab (pending → success/error); MGP-server failures carry a §14 code.
         let proposal_keys: Vec<_> = engines
             .iter()
             .map(|e| {
@@ -1585,6 +1588,20 @@ impl SystemHandler {
                 )
             })
             .collect();
+        for engine in engines {
+            self.emit_consensus_progress(
+                trace_id,
+                agent,
+                &msg.content,
+                "proposal",
+                engine,
+                None,
+                "pending",
+                None,
+                None,
+            )
+            .await;
+        }
         let proposal_futs = engines.iter().zip(&proposal_keys).map(|(engine, key)| {
             let ctx = context.clone();
             async move {
@@ -1601,6 +1618,53 @@ impl SystemHandler {
                     ),
                 )
                 .await;
+                // Emit the per-engine completion as soon as this engine finishes
+                // so the Consensus tab updates live (not after the slowest).
+                match &r {
+                    Ok(Ok(text)) => {
+                        self.emit_consensus_progress(
+                            trace_id,
+                            agent,
+                            &msg.content,
+                            "proposal",
+                            engine,
+                            Some(text.clone()),
+                            "success",
+                            None,
+                            None,
+                        )
+                        .await;
+                    }
+                    Ok(Err(e)) => {
+                        let (code, retryable, message) = Self::classify_engine_error(e);
+                        self.emit_consensus_progress(
+                            trace_id,
+                            agent,
+                            &msg.content,
+                            "proposal",
+                            engine,
+                            Some(message),
+                            "error",
+                            code,
+                            retryable,
+                        )
+                        .await;
+                    }
+                    Err(_) => {
+                        self.emit_consensus_progress(
+                            trace_id,
+                            agent,
+                            &msg.content,
+                            "proposal",
+                            engine,
+                            Some("Engine timed out".to_string()),
+                            "error",
+                            Some(crate::managers::mcp_mgp::MGP_ERR_TIMEOUT),
+                            Some(true),
+                        )
+                        .await;
+                    }
+                }
                 (engine.clone(), r)
             }
         });
@@ -1629,8 +1693,13 @@ impl SystemHandler {
                 proposals.len()
             );
             warn!(trace_id = %trace_id, "{detail}");
-            self.emit_consensus_response(format!("[Consensus failed] {detail}"), &msg.id, trace_id)
-                .await;
+            self.deliver_consensus_result(
+                agent,
+                msg,
+                format!("[Consensus failed] {detail}"),
+                trace_id,
+            )
+            .await;
             return;
         }
 
@@ -1669,6 +1738,18 @@ impl SystemHandler {
             proposals = proposals.len(),
             "⚗️ Consensus synthesis started"
         );
+        self.emit_consensus_progress(
+            trace_id,
+            agent,
+            &msg.content,
+            "synthesis",
+            &synthesizer_engine,
+            None,
+            "pending",
+            None,
+            None,
+        )
+        .await;
 
         let synth_result = tokio::time::timeout(
             phase_timeout,
@@ -1687,39 +1768,168 @@ impl SystemHandler {
         let content = match synth_result {
             Ok(Ok(text)) => {
                 info!(trace_id = %trace_id, "🏁 Consensus synthesis complete");
+                self.emit_consensus_progress(
+                    trace_id,
+                    agent,
+                    &msg.content,
+                    "synthesis",
+                    &synthesizer_engine,
+                    Some(text.clone()),
+                    "success",
+                    None,
+                    None,
+                )
+                .await;
                 text
             }
             Ok(Err(e)) => {
                 error!(trace_id = %trace_id, error = %e, "❌ Consensus synthesis failed — returning raw proposals");
+                let (code, retryable, message) = Self::classify_engine_error(&e);
+                self.emit_consensus_progress(
+                    trace_id,
+                    agent,
+                    &msg.content,
+                    "synthesis",
+                    &synthesizer_engine,
+                    Some(message),
+                    "error",
+                    code,
+                    retryable,
+                )
+                .await;
                 format!(
                     "[Consensus synthesis failed: {e}. Individual proposals below.]\n\n{combined}"
                 )
             }
             Err(_) => {
                 error!(trace_id = %trace_id, "⏱️ Consensus synthesis timed out — returning raw proposals");
+                self.emit_consensus_progress(
+                    trace_id,
+                    agent,
+                    &msg.content,
+                    "synthesis",
+                    &synthesizer_engine,
+                    Some("Synthesis timed out".to_string()),
+                    "error",
+                    Some(crate::managers::mcp_mgp::MGP_ERR_TIMEOUT),
+                    Some(true),
+                )
+                .await;
                 format!(
                     "[Consensus synthesis timed out. Individual proposals below.]\n\n{combined}"
                 )
             }
         };
-        self.emit_consensus_response(content, &msg.id, trace_id)
+        self.deliver_consensus_result(agent, msg, content, trace_id)
             .await;
     }
 
-    /// Emit the single terminal consensus `ThoughtResponse`, stamped with the
-    /// configured synthetic agent id. Mirrors the normal path's emission so
-    /// downstream (`events.rs`) treats it like any other agent response.
-    async fn emit_consensus_response(
+    /// Map an engine error to MGP §14 fields for the Consensus tab. When the
+    /// underlying error is a typed [`MgpError`](crate::managers::mcp_mgp::MgpError)
+    /// (e.g. an unresolved engine server → `SERVER_NOT_READY`), surface its
+    /// spec-defined code + retryable hint and a `MGP-<code>: <message>` string;
+    /// otherwise fall back to a plain message with no code.
+    fn classify_engine_error(e: &anyhow::Error) -> (Option<i64>, Option<bool>, String) {
+        if let Some(mgp) = e.downcast_ref::<crate::managers::mcp_mgp::MgpError>() {
+            let retryable = mgp.recovery.as_ref().map(|r| r.retryable);
+            (
+                Some(mgp.code),
+                retryable,
+                format!("MGP-{}: {}", mgp.code, mgp.message),
+            )
+        } else {
+            (None, None, e.to_string())
+        }
+    }
+
+    /// Emit one `ConsensusProgress` step (per-engine proposal or synthesis) for
+    /// the dashboard's dedicated Consensus actions tab. Display-only; the final
+    /// answer is delivered separately via [`Self::deliver_consensus_result`].
+    #[allow(clippy::too_many_arguments)]
+    async fn emit_consensus_progress(
         &self,
+        consensus_id: ClotoId,
+        agent: &AgentMetadata,
+        prompt: &str,
+        phase: &str,
+        engine_id: &str,
+        response: Option<String>,
+        status: &str,
+        mgp_error_code: Option<i64>,
+        retryable: Option<bool>,
+    ) {
+        let data = ClotoEventData::ConsensusProgress {
+            consensus_id: consensus_id.to_string(),
+            agent_id: agent.id.clone(),
+            agent_name: agent.name.clone(),
+            prompt: prompt.to_string(),
+            phase: phase.to_string(),
+            engine_id: engine_id.to_string(),
+            response,
+            status: status.to_string(),
+            mgp_error_code,
+            retryable,
+        };
+        let envelope = crate::EnvelopedEvent {
+            event: Arc::new(ClotoEvent::with_trace(consensus_id, data)),
+            issuer: None,
+            correlation_id: None,
+            depth: 0,
+        };
+        if let Err(e) = self.sender.send(envelope).await {
+            warn!(error = %e, "Failed to send ConsensusProgress event");
+        }
+    }
+
+    /// Deliver the terminal consensus result to the ORIGINATING agent's chat:
+    /// persist it under `agent.id` (so it appears where the user asked and
+    /// survives reload) AND emit a `ThoughtResponse` stamped with `agent.id` so
+    /// the live chat unblocks. `engine_id = "consensus"` + metadata mark it for
+    /// the UI. Fixes bug-417: the previous synthetic-agent-id stamping (and the
+    /// missing persistence) made every consensus answer/error invisible, leaving
+    /// the chat hung on "thinking…". Mirrors the normal path's persist-then-emit.
+    async fn deliver_consensus_result(
+        &self,
+        agent: &AgentMetadata,
+        msg: &ClotoMessage,
         content: String,
-        source_message_id: &str,
         trace_id: ClotoId,
     ) {
+        let resp_id = format!("{}-resp", msg.id);
+        let response_parent = msg
+            .metadata
+            .get("parent_id")
+            .cloned()
+            .unwrap_or_else(|| msg.id.clone());
+        let resp_branch = crate::db::get_next_branch_index(&self.pool, &response_parent)
+            .await
+            .unwrap_or(0);
+        let chat_msg = crate::db::ChatMessageRow {
+            id: resp_id,
+            agent_id: agent.id.clone(),
+            user_id: Self::extract_user_id(msg).to_string(),
+            source: "agent".to_string(),
+            content: serde_json::to_string(
+                &serde_json::json!([{"type": "text", "text": &content}]),
+            )
+            .unwrap_or_default(),
+            metadata: serde_json::to_string(&serde_json::json!({
+                "consensus": true,
+                "synthetic_agent_id": self.consensus_config.synthetic_agent_id,
+            }))
+            .ok(),
+            created_at: chrono::Utc::now().timestamp_millis(),
+            parent_id: Some(response_parent),
+            branch_index: resp_branch,
+        };
+        if let Err(e) = crate::db::save_chat_message_reliable(&self.pool, &chat_msg).await {
+            error!(trace_id = %trace_id, error = %e, "Consensus chat persist DROPPED");
+        }
         let response = ClotoEventData::ThoughtResponse {
-            agent_id: self.consensus_config.synthetic_agent_id.clone(),
+            agent_id: agent.id.clone(),
             engine_id: "consensus".to_string(),
             content,
-            source_message_id: source_message_id.to_string(),
+            source_message_id: msg.id.clone(),
             auto_spoken: false,
         };
         let envelope = crate::EnvelopedEvent {
@@ -1774,7 +1984,15 @@ impl SystemHandler {
             };
 
         if engine_plugin.is_none() && mcp_engine.is_none() {
-            return Err(anyhow::anyhow!("Engine '{}' not found", engine_id));
+            // MGP §14: an unresolved engine is a lifecycle condition — the engine
+            // server is not registered/connected. Surface it as a typed MgpError
+            // (SERVER_NOT_READY, retryable) so MGP-server failures carry a
+            // spec-defined code/recovery instead of an opaque string.
+            return Err(anyhow::Error::new(
+                crate::managers::mcp_mgp::MgpError::server_not_ready(format!(
+                    "Engine '{engine_id}' is not a registered/connected engine server"
+                )),
+            ));
         }
 
         // Determine tool support
@@ -2326,7 +2544,11 @@ impl SystemHandler {
             return Self::extract_mcp_think_content(&result);
         }
 
-        Err(anyhow::anyhow!("Engine '{}' not found", engine_id))
+        Err(anyhow::Error::new(
+            crate::managers::mcp_mgp::MgpError::server_not_ready(format!(
+                "Engine '{engine_id}' is not a registered/connected engine server"
+            )),
+        ))
     }
 
     /// Call engine's think_with_tools() — routes to either Rust plugin or MCP server.
@@ -2402,7 +2624,11 @@ impl SystemHandler {
             return Self::parse_mcp_think_result(&result);
         }
 
-        Err(anyhow::anyhow!("Engine '{}' not found", engine_id))
+        Err(anyhow::Error::new(
+            crate::managers::mcp_mgp::MgpError::server_not_ready(format!(
+                "Engine '{engine_id}' is not a registered/connected engine server"
+            )),
+        ))
     }
 
     /// Drive a streaming `think_with_tools` call (Phase C).

--- a/crates/core/tests/consensus_test.rs
+++ b/crates/core/tests/consensus_test.rs
@@ -7,31 +7,45 @@
 //! the redesign must hold regardless of engines:
 //!
 //!   1. A consensus request always terminates with **exactly one**
-//!      `ThoughtResponse`, stamped with the synthetic agent id — never a silent
-//!      timeout (fail-safe).
-//!   2. The consensus path no longer emits the retired `ConsensusRequested` /
+//!      `ThoughtResponse`, stamped with the **originating agent id** (bug-417:
+//!      previously the synthetic id made the answer invisible to the user's
+//!      chat) — never a silent timeout (fail-safe).
+//!   2. The terminal answer is **persisted** to the originating agent's chat
+//!      history (bug-417: it must survive reload and appear where the user
+//!      asked).
+//!   3. Per-step `ConsensusProgress` events are emitted for the dashboard's
+//!      Consensus tab, and engine failures carry an MGP §14 error code.
+//!   4. The consensus path no longer emits the retired `ConsensusRequested` /
 //!      `ThoughtRequested` events (the dead event contract is gone).
 //!
 //! See docs/CONSENSUS_REVIVAL_DESIGN.md.
 
 use cloto_core::handlers::system::SystemHandler;
+use cloto_core::managers::mcp_mgp::MGP_ERR_SERVER_NOT_READY;
 use cloto_core::managers::{AgentManager, PluginRegistry};
 use cloto_shared::{ClotoEventData, ClotoMessage, MessageSource};
 use sqlx::SqlitePool;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
-const SYNTHETIC_AGENT_ID: &str = "system.consensus";
+/// The consensus answer is now delivered as the originating agent's own
+/// response (so it lands in the chat where the user asked), not under a
+/// detached synthetic id.
+const ORIGINATING_AGENT_ID: &str = "agent.test";
 
 async fn build_handler(
     engines: Vec<String>,
-) -> (SystemHandler, mpsc::Receiver<cloto_core::EnvelopedEvent>) {
+) -> (
+    SystemHandler,
+    mpsc::Receiver<cloto_core::EnvelopedEvent>,
+    SqlitePool,
+) {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
     cloto_core::db::init_db(&pool, "sqlite::memory:", None)
         .await
         .unwrap();
 
-    let agent_id = "agent.test";
+    let agent_id = ORIGINATING_AGENT_ID;
     sqlx::query("INSERT INTO agents (id, name, description, status, default_engine_id, required_capabilities, metadata, enabled) VALUES (?, 'Test Agent', 'Desc', 'online', 'engine.test', '[\"Reasoning\"]', '{}', 1)")
         .bind(agent_id)
         .execute(&pool)
@@ -56,13 +70,13 @@ async fn build_handler(
         30, // tool_execution_timeout_secs
         Arc::new(dashmap::DashMap::new()),
         Arc::new(dashmap::DashMap::new()),
-        pool,
+        pool.clone(),
         Arc::new(dashmap::DashMap::new()),
         5,     // memory_timeout_secs
         false, // mcp_streaming_enabled
     );
 
-    (handler, event_rx)
+    (handler, event_rx, pool)
 }
 
 fn drain(rx: &mut mpsc::Receiver<cloto_core::EnvelopedEvent>) -> Vec<ClotoEventData> {
@@ -84,9 +98,10 @@ fn consensus_msg() -> ClotoMessage {
 }
 
 /// Assert the common invariants every consensus run must satisfy: exactly one
-/// terminal `ThoughtResponse` stamped with the synthetic agent id, and no
-/// retired `ConsensusRequested` / `ThoughtRequested` events on the bus.
-fn assert_single_synthetic_response(events: &[ClotoEventData]) -> String {
+/// terminal `ThoughtResponse` stamped with the **originating** agent id (so the
+/// user's chat unblocks), engine_id "consensus", and no retired
+/// `ConsensusRequested` / `ThoughtRequested` events on the bus.
+fn assert_single_terminal_response(events: &[ClotoEventData]) -> String {
     let mut responses = events.iter().filter_map(|e| match e {
         ClotoEventData::ThoughtResponse {
             agent_id,
@@ -105,8 +120,8 @@ fn assert_single_synthetic_response(events: &[ClotoEventData]) -> String {
         "consensus must emit exactly one ThoughtResponse, got more than one"
     );
     assert_eq!(
-        agent_id, SYNTHETIC_AGENT_ID,
-        "terminal response must be stamped with the synthetic agent id"
+        agent_id, ORIGINATING_AGENT_ID,
+        "terminal response must be stamped with the originating agent id (bug-417)"
     );
     assert_eq!(engine_id, "consensus", "engine_id must be 'consensus'");
 
@@ -121,36 +136,114 @@ fn assert_single_synthetic_response(events: &[ClotoEventData]) -> String {
     content
 }
 
+/// The terminal consensus answer/error MUST be persisted to the originating
+/// agent's chat history (bug-417) so it appears where the user asked and
+/// survives a reload.
+async fn assert_response_persisted(pool: &SqlitePool, expected_substring: &str) {
+    let rows: Vec<String> =
+        sqlx::query_scalar("SELECT content FROM chat_messages WHERE agent_id = ? AND source = ?")
+            .bind(ORIGINATING_AGENT_ID)
+            .bind("agent")
+            .fetch_all(pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "exactly one consensus agent response must be persisted, got {}",
+        rows.len()
+    );
+    assert!(
+        rows[0].contains(expected_substring),
+        "persisted consensus response should contain {expected_substring:?}, got: {}",
+        rows[0]
+    );
+}
+
 /// Fewer engines configured than `min_proposals` (default 2) → immediate
-/// fail-safe response, no engine ever runs.
+/// fail-safe response, no engine ever runs, no ConsensusProgress steps.
 #[tokio::test]
-async fn consensus_too_few_engines_emits_single_synthetic_failsafe() {
-    let (handler, mut rx) = build_handler(vec!["mind.alpha".to_string()]).await;
+async fn consensus_too_few_engines_emits_single_failsafe_persisted() {
+    let (handler, mut rx, pool) = build_handler(vec!["mind.alpha".to_string()]).await;
 
     handler.handle_message(consensus_msg()).await.unwrap();
 
     let events = drain(&mut rx);
-    let content = assert_single_synthetic_response(&events);
+    let content = assert_single_terminal_response(&events);
     assert!(
         content.contains("[Consensus unavailable]"),
         "expected the too-few-engines fail-safe message, got: {content}"
     );
+    // No engines run before the quorum-precheck early return.
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, ClotoEventData::ConsensusProgress { .. })),
+        "no ConsensusProgress steps should be emitted when fewer than min engines are configured"
+    );
+    assert_response_persisted(&pool, "[Consensus unavailable]").await;
 }
 
 /// Enough engines configured but none are registered/resolvable → every
 /// proposal loop errors → quorum is not reached → fail-safe response. Proves
-/// the kernel never hangs waiting on proposals that will never arrive.
+/// the kernel never hangs, each engine surfaces a ConsensusProgress step with an
+/// MGP §14 error code (SERVER_NOT_READY), and the error is delivered to chat.
 #[tokio::test]
-async fn consensus_all_engines_unavailable_quorum_failsafe_no_legacy_events() {
-    let (handler, mut rx) =
+async fn consensus_all_engines_unavailable_quorum_failsafe_mgp_errors() {
+    let (handler, mut rx, pool) =
         build_handler(vec!["mind.alpha".to_string(), "mind.beta".to_string()]).await;
 
     handler.handle_message(consensus_msg()).await.unwrap();
 
     let events = drain(&mut rx);
-    let content = assert_single_synthetic_response(&events);
+    let content = assert_single_terminal_response(&events);
     assert!(
         content.contains("[Consensus failed]"),
         "expected the quorum-not-reached fail-safe message, got: {content}"
     );
+
+    // Each configured engine gets a pending step and an error step.
+    let progress: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            ClotoEventData::ConsensusProgress {
+                phase,
+                engine_id,
+                status,
+                mgp_error_code,
+                ..
+            } => Some((
+                phase.clone(),
+                engine_id.clone(),
+                status.clone(),
+                *mgp_error_code,
+            )),
+            _ => None,
+        })
+        .collect();
+
+    let pending = progress
+        .iter()
+        .filter(|(_, _, s, _)| s == "pending")
+        .count();
+    assert_eq!(
+        pending, 2,
+        "both engines should emit a pending proposal step"
+    );
+
+    let errors: Vec<_> = progress
+        .iter()
+        .filter(|(_, _, s, _)| s == "error")
+        .collect();
+    assert_eq!(errors.len(), 2, "both engines should fail to resolve");
+    for (phase, engine, _, code) in &errors {
+        assert_eq!(phase, "proposal");
+        assert_eq!(
+            *code,
+            Some(MGP_ERR_SERVER_NOT_READY),
+            "unresolved MGP engine '{engine}' must surface SERVER_NOT_READY"
+        );
+    }
+
+    assert_response_persisted(&pool, "[Consensus failed]").await;
 }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -733,6 +733,39 @@ pub enum ClotoEventData {
         /// "pending", "success", "error"
         status: String,
     },
+    /// Consensus deliberation progress: one entry per engine proposal and one
+    /// for the synthesis, emitted by `SystemHandler::run_consensus` so the
+    /// dashboard's dedicated "Consensus" actions tab can show the multi-engine
+    /// deliberation live. Emitted at dispatch (`response = None`, status
+    /// "pending") and at completion (status "success"/"error"). The final
+    /// synthesized answer is ALSO delivered to the originating agent's chat as a
+    /// normal `ThoughtResponse`; this event is the per-step visualization only.
+    ConsensusProgress {
+        /// Groups every step of one consensus session (= the request trace id).
+        consensus_id: String,
+        /// Originating agent the `consensus:` message was sent to.
+        agent_id: String,
+        agent_name: String,
+        /// The user's question (without the consensus prefix is acceptable; the
+        /// raw prompt is fine — the tab shows it once per session).
+        prompt: String,
+        /// "proposal" (one engine's contribution) or "synthesis" (the merge).
+        phase: String,
+        /// The engine producing this step (e.g. "mind.deepseek").
+        engine_id: String,
+        /// None while pending; Some(text) on success, Some(error message) on error.
+        response: Option<String>,
+        /// "pending", "success", "error".
+        status: String,
+        /// MGP §14 error code when `status = "error"` and the failing engine is
+        /// an MGP server (e.g. 2000 SERVER_NOT_READY, 3003 TIMEOUT, 5000
+        /// UPSTREAM_ERROR). None for non-MGP/internal failures.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mgp_error_code: Option<i64>,
+        /// Whether the MGP error is retryable (from the error's recovery hints).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        retryable: Option<bool>,
+    },
 }
 
 impl ClotoEvent {

--- a/dashboard/src/compiled-tailwind.css
+++ b/dashboard/src/compiled-tailwind.css
@@ -630,6 +630,40 @@ video {
   --canvas-text: rgba(226, 232, 240, 0.8);
 }
 
+.container {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+
 /* A-group: solid semi-transparent card surface for primary content
    * (agent cards, memory cards, marketplace cards, chat header controls).
    * Callers add their own border color, padding, rounded-*, and hover color. */
@@ -2034,6 +2068,10 @@ video {
   background-color: rgb(var(--brand-primary) / 0.1);
 }
 
+.bg-brand\/15 {
+  background-color: rgb(var(--brand-primary) / 0.15);
+}
+
 .bg-brand\/20 {
   background-color: rgb(var(--brand-primary) / 0.2);
 }
@@ -2438,6 +2476,10 @@ video {
 
 .text-right {
   text-align: right;
+}
+
+.align-middle {
+  vertical-align: middle;
 }
 
 .align-text-bottom {

--- a/dashboard/src/components/ActionsPanel.tsx
+++ b/dashboard/src/components/ActionsPanel.tsx
@@ -1,7 +1,8 @@
 import { ChevronLeft, PanelRightClose } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import type { ActionCategory, Artifact, DialogueTab, ExternalActionTab } from '../hooks/useActions';
+import type { ActionCategory, Artifact, ConsensusRoundTab, DialogueTab, ExternalActionTab } from '../hooks/useActions';
 import { CodeBlock } from './CodeBlock';
+import { ConsensusCard } from './ConsensusCard';
 import { DialogueCard } from './DialogueCard';
 import { ExternalActionCard } from './ExternalActionCard';
 
@@ -13,13 +14,16 @@ interface ActionsPanelProps {
   onCategoryChange: (cat: ActionCategory) => void;
   hasDialogues: boolean;
   hasExternalActions: boolean;
+  hasConsensus: boolean;
   artifacts: Artifact[];
   activeArtifactIndex: number;
   onArtifactTabChange: (index: number) => void;
   dialogues: DialogueTab[];
   externalActions: ExternalActionTab[];
+  consensusRounds: ConsensusRoundTab[];
   unreadDialogueCount: number;
   unreadExternalCount: number;
+  unreadConsensusCount: number;
   totalCount: number;
 }
 
@@ -39,21 +43,24 @@ export function ActionsPanel({
   onCategoryChange,
   hasDialogues,
   hasExternalActions,
+  hasConsensus,
   artifacts,
   activeArtifactIndex,
   onArtifactTabChange,
   dialogues,
   externalActions,
+  consensusRounds,
   unreadDialogueCount,
   unreadExternalCount,
+  unreadConsensusCount,
   totalCount,
 }: ActionsPanelProps) {
   const { t } = useTranslation('actions');
   if (totalCount === 0) return null;
 
   const active = artifacts[activeArtifactIndex] || artifacts[0];
-  const showCategoryBar = hasDialogues || hasExternalActions;
-  const totalUnread = unreadDialogueCount + unreadExternalCount;
+  const showCategoryBar = hasDialogues || hasExternalActions || hasConsensus;
+  const totalUnread = unreadDialogueCount + unreadExternalCount + unreadConsensusCount;
 
   // Collapsed state
   if (!isOpen) {
@@ -141,6 +148,22 @@ export function ActionsPanel({
               )}
             </button>
           )}
+          {hasConsensus && (
+            <button
+              onClick={() => onCategoryChange('consensus')}
+              className={`flex-1 px-3 py-2 text-[10px] font-bold uppercase tracking-wider transition-all border-b-2 relative ${
+                activeCategory === 'consensus'
+                  ? 'border-brand text-content-primary'
+                  : 'border-transparent text-content-tertiary hover:text-content-secondary'
+              }`}
+            >
+              {t('tabs.consensus')}
+              <span className="ml-1.5 text-[9px] font-mono opacity-60">{consensusRounds.length}</span>
+              {unreadConsensusCount > 0 && activeCategory !== 'consensus' && (
+                <span className="absolute top-1.5 right-2 w-1.5 h-1.5 rounded-full bg-brand animate-pulse" />
+              )}
+            </button>
+          )}
         </div>
       )}
 
@@ -197,6 +220,15 @@ export function ActionsPanel({
         <div className="flex-1 overflow-y-auto no-scrollbar p-3 space-y-3">
           {[...externalActions].reverse().map((tab) => (
             <ExternalActionCard key={tab.action.action_id} action={tab.action} />
+          ))}
+        </div>
+      )}
+
+      {/* Content: Consensus — one card per deliberation, newest first */}
+      {activeCategory === 'consensus' && consensusRounds.length > 0 && (
+        <div className="flex-1 overflow-y-auto no-scrollbar p-3 space-y-3">
+          {[...consensusRounds].reverse().map((tab) => (
+            <ConsensusCard key={tab.round.consensus_id} round={tab.round} />
           ))}
         </div>
       )}

--- a/dashboard/src/components/AgentConsole.tsx
+++ b/dashboard/src/components/AgentConsole.tsx
@@ -1074,13 +1074,16 @@ export function AgentConsole({ agent, onBack }: { agent: AgentMetadata; onBack: 
           onCategoryChange={actions.setActiveCategory}
           hasDialogues={actions.hasDialogues}
           hasExternalActions={actions.hasExternalActions}
+          hasConsensus={actions.hasConsensus}
           artifacts={actions.artifacts}
           activeArtifactIndex={actions.activeArtifactIndex}
           onArtifactTabChange={actions.setActiveArtifactIndex}
           dialogues={actions.dialogues}
           externalActions={actions.externalActions}
+          consensusRounds={actions.consensusRounds}
           unreadDialogueCount={actions.unreadDialogueCount}
           unreadExternalCount={actions.unreadExternalCount}
+          unreadConsensusCount={actions.unreadConsensusCount}
           totalCount={actions.totalCount}
         />
       </div>

--- a/dashboard/src/components/ConsensusCard.tsx
+++ b/dashboard/src/components/ConsensusCard.tsx
@@ -1,0 +1,137 @@
+import { CheckCircle2, ChevronDown, ChevronRight, Loader2, Sparkles, XCircle } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ConsensusRound, ConsensusStep } from '../types';
+
+interface ConsensusCardProps {
+  round: ConsensusRound;
+}
+
+function truncate(text: string, lines: number): { truncated: string; isTruncated: boolean } {
+  const parts = text.split('\n');
+  if (parts.length <= lines) return { truncated: text, isTruncated: false };
+  return { truncated: parts.slice(0, lines).join('\n'), isTruncated: true };
+}
+
+function StatusIcon({ status }: { status: ConsensusStep['status'] }) {
+  if (status === 'pending') return <Loader2 size={11} className="text-brand animate-spin shrink-0" />;
+  if (status === 'error') return <XCircle size={11} className="text-red-400 shrink-0" />;
+  return <CheckCircle2 size={11} className="text-emerald-400 shrink-0" />;
+}
+
+function StepRow({ step, defaultLines }: { step: ConsensusStep; defaultLines: number }) {
+  const [expanded, setExpanded] = useState(false);
+  const { t } = useTranslation('actions');
+  const isError = step.status === 'error';
+  const isPending = step.status === 'pending';
+  const body = step.response ? truncate(step.response, expanded ? 999 : defaultLines) : null;
+
+  return (
+    <div
+      className={`rounded-md border p-2 ${isError ? 'border-red-500/40 bg-red-500/5' : 'border-edge bg-glass-strong'}`}
+    >
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <div className="flex items-center gap-1.5 min-w-0">
+          <StatusIcon status={step.status} />
+          <span className="text-[10px] font-mono font-bold uppercase tracking-wider text-content-secondary truncate">
+            {step.engine_id.replace('mind.', '')}
+          </span>
+        </div>
+        {isError && step.mgp_error_code != null && (
+          <span className="text-[9px] font-mono text-red-400 bg-red-500/10 px-1.5 py-0.5 rounded shrink-0">
+            MGP-{step.mgp_error_code}
+            {step.retryable ? ` · ${t('consensusCard.retryable')}` : ''}
+          </span>
+        )}
+      </div>
+
+      {isPending ? (
+        <span className="text-[10px] text-content-tertiary animate-pulse">{t('consensusCard.thinking')}</span>
+      ) : (
+        body && (
+          <div
+            className={`text-[11px] whitespace-pre-wrap break-words leading-relaxed ${
+              isError ? 'text-red-400' : 'text-content-primary'
+            }`}
+          >
+            {body.truncated}
+            {!expanded && body.isTruncated && <span className="text-content-tertiary">...</span>}
+            {body.isTruncated && (
+              <button
+                type="button"
+                onClick={() => setExpanded(!expanded)}
+                className="ml-1 inline-flex items-center gap-0.5 text-[9px] font-bold uppercase tracking-wider text-content-tertiary hover:text-content-secondary transition-colors align-middle"
+              >
+                {expanded ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
+                {expanded ? t('consensusCard.collapse') : t('consensusCard.expand')}
+              </button>
+            )}
+          </div>
+        )
+      )}
+    </div>
+  );
+}
+
+export function ConsensusCard({ round }: ConsensusCardProps) {
+  const { t } = useTranslation('actions');
+  const proposals = round.steps.filter((s) => s.phase === 'proposal');
+  const synthesis = round.steps.find((s) => s.phase === 'synthesis');
+  const prompt = truncate(round.prompt, 2);
+
+  return (
+    <div className="rounded-lg border border-edge bg-glass-subtle p-3">
+      {/* Header: consensus badge → agent */}
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <div className="flex items-center gap-1.5 min-w-0">
+          <span className="inline-flex items-center gap-1 text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded shrink-0 bg-brand/15 text-brand">
+            <Sparkles size={10} />
+            {t('tabs.consensus')}
+          </span>
+          <span className="text-[10px] font-mono font-bold uppercase tracking-wider text-content-secondary truncate">
+            {round.agent_name}
+          </span>
+        </div>
+        <span className="text-[9px] font-mono text-content-tertiary bg-surface-secondary px-1.5 py-0.5 rounded shrink-0">
+          {proposals.length} {t('consensusCard.engines')}
+        </span>
+      </div>
+
+      {/* Prompt */}
+      <div className="text-[11px] text-content-primary whitespace-pre-wrap break-words leading-relaxed mb-2">
+        {prompt.truncated}
+        {prompt.isTruncated && <span className="text-content-tertiary">...</span>}
+      </div>
+
+      {/* Proposals */}
+      {proposals.length > 0 && (
+        <>
+          <div className="text-[9px] font-bold uppercase tracking-wider text-content-tertiary mb-1">
+            {t('consensusCard.proposals')}
+          </div>
+          <div className="space-y-1.5 mb-2">
+            {proposals.map((s) => (
+              <StepRow key={`proposal-${s.engine_id}`} step={s} defaultLines={3} />
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Synthesis */}
+      {synthesis && (
+        <>
+          <div className="text-[9px] font-bold uppercase tracking-wider text-brand/80 mb-1">
+            {t('consensusCard.synthesis')}
+          </div>
+          <StepRow key="synthesis" step={synthesis} defaultLines={8} />
+        </>
+      )}
+
+      <div className="mt-2 flex justify-end">
+        <span className="text-[10px] font-mono text-content-tertiary">
+          {new Date(round.timestamp).toLocaleTimeString()}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/contexts/ActionsContext.tsx
+++ b/dashboard/src/contexts/ActionsContext.tsx
@@ -62,8 +62,27 @@ export function ActionsProvider({ children }: { children: ReactNode }) {
           timestamp: Date.now(),
         });
       }
+
+      if (event.type === 'ConsensusProgress') {
+        const d = event.data as {
+          consensus_id: string;
+          agent_id: string;
+          agent_name: string;
+          prompt: string;
+          phase: string;
+          engine_id: string;
+          response: string | null;
+          status: string;
+          mgp_error_code?: number;
+          retryable?: boolean;
+        };
+        actions.addOrUpdateConsensus({
+          ...d,
+          status: d.status as 'pending' | 'success' | 'error',
+        });
+      }
     },
-    [actions.addOrUpdateDialogue, actions.addOrUpdateExternalAction],
+    [actions.addOrUpdateDialogue, actions.addOrUpdateExternalAction, actions.addOrUpdateConsensus],
   );
 
   useEventStream(EVENTS_URL, handleEvent, apiKey);

--- a/dashboard/src/hooks/useActions.ts
+++ b/dashboard/src/hooks/useActions.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import type { AgentDialogue, ExternalAction } from '../types';
+import type { AgentDialogue, ConsensusProgressEvent, ConsensusRound, ExternalAction } from '../types';
 
 // ── Storage Keys ──
 
@@ -7,6 +7,7 @@ const ARTIFACTS_KEY = 'cloto-actions';
 const OPEN_KEY = 'cloto-actions-open';
 const DIALOGUES_KEY = 'cloto-dialogues';
 const EXTERNAL_ACTIONS_KEY = 'cloto-external-actions';
+const CONSENSUS_KEY = 'cloto-consensus-rounds';
 
 // Legacy migration
 const LEGACY_ARTIFACTS_KEY = 'cloto-artifacts';
@@ -14,7 +15,7 @@ const LEGACY_OPEN_KEY = 'cloto-artifacts-open';
 
 // ── Types ──
 
-export type ActionCategory = 'code' | 'dialogues' | 'external';
+export type ActionCategory = 'code' | 'dialogues' | 'external' | 'consensus';
 
 export interface Artifact {
   id: string;
@@ -33,6 +34,11 @@ export interface ExternalActionTab {
   unread: boolean;
 }
 
+export interface ConsensusRoundTab {
+  round: ConsensusRound;
+  unread: boolean;
+}
+
 export interface UseActionsResult {
   // Panel state
   isOpen: boolean;
@@ -44,6 +50,7 @@ export interface UseActionsResult {
   setActiveCategory: (cat: ActionCategory) => void;
   hasDialogues: boolean;
   hasExternalActions: boolean;
+  hasConsensus: boolean;
 
   // Artifacts (code)
   artifacts: Artifact[];
@@ -65,10 +72,17 @@ export interface UseActionsResult {
   externalActions: ExternalActionTab[];
   addOrUpdateExternalAction: (action: ExternalAction) => void;
 
+  // Consensus
+  consensusRounds: ConsensusRoundTab[];
+  activeConsensusIndex: number;
+  setActiveConsensusIndex: (index: number) => void;
+  addOrUpdateConsensus: (ev: ConsensusProgressEvent) => void;
+
   // Counts
   totalCount: number;
   unreadDialogueCount: number;
   unreadExternalCount: number;
+  unreadConsensusCount: number;
 }
 
 // ── Persistence Helpers ──
@@ -167,12 +181,43 @@ function saveExternalActions(actions: ExternalActionTab[]) {
   }
 }
 
+// ── Consensus Rounds Persistence ──
+
+function loadConsensusRounds(): ConsensusRoundTab[] {
+  try {
+    const raw = localStorage.getItem(CONSENSUS_KEY);
+    if (!raw) return [];
+    const parsed: ConsensusRoundTab[] = JSON.parse(raw);
+    const cutoff = Date.now() - MAX_DIALOGUE_AGE_MS;
+    const fresh = parsed.filter((r) => r.round.timestamp >= cutoff);
+    const pruned = fresh.length > MAX_DIALOGUES ? fresh.slice(-MAX_DIALOGUES) : fresh;
+    if (pruned.length !== parsed.length) saveConsensusRounds(pruned);
+    return pruned;
+  } catch {
+    return [];
+  }
+}
+
+function saveConsensusRounds(rounds: ConsensusRoundTab[]) {
+  try {
+    if (rounds.length === 0) {
+      localStorage.removeItem(CONSENSUS_KEY);
+    } else {
+      localStorage.setItem(CONSENSUS_KEY, JSON.stringify(rounds));
+    }
+  } catch {
+    /* localStorage full — ignore */
+  }
+}
+
 // ── Hook ──
 
 export function useActions(): UseActionsResult {
   const [artifacts, setArtifacts] = useState<Artifact[]>(loadArtifacts);
   const [dialogues, setDialogues] = useState<DialogueTab[]>(loadDialogues);
   const [externalActions, setExternalActions] = useState<ExternalActionTab[]>(loadExternalActions);
+  const [consensusRounds, setConsensusRounds] = useState<ConsensusRoundTab[]>(loadConsensusRounds);
+  const [activeConsensusIndex, setActiveConsensusIndex] = useState(0);
   const [isOpen, setIsOpen] = useState(() => {
     const saved = loadArtifacts();
     return saved.length > 0 && sessionStorage.getItem(OPEN_KEY) !== 'closed';
@@ -231,6 +276,9 @@ export function useActions(): UseActionsResult {
     saveDialogues([]);
     setExternalActions([]);
     saveExternalActions([]);
+    setConsensusRounds([]);
+    setActiveConsensusIndex(0);
+    saveConsensusRounds([]);
     setActiveCategory('code');
     setIsOpen(false);
     sessionStorage.setItem(OPEN_KEY, 'closed');
@@ -290,6 +338,64 @@ export function useActions(): UseActionsResult {
     sessionStorage.removeItem(OPEN_KEY);
   }, []);
 
+  // ── Consensus ──
+
+  const addOrUpdateConsensus = useCallback((ev: ConsensusProgressEvent) => {
+    setConsensusRounds((prev) => {
+      const step = {
+        phase: ev.phase,
+        engine_id: ev.engine_id,
+        response: ev.response,
+        status: ev.status,
+        mgp_error_code: ev.mgp_error_code,
+        retryable: ev.retryable,
+      };
+      const roundIndex = prev.findIndex((r) => r.round.consensus_id === ev.consensus_id);
+      if (roundIndex >= 0) {
+        // Existing round — update the matching step (same phase + engine) in place,
+        // or append it if this is the step's first event.
+        const round = prev[roundIndex].round;
+        const stepIndex = round.steps.findIndex((s) => s.phase === ev.phase && s.engine_id === ev.engine_id);
+        const steps = stepIndex >= 0 ? round.steps.map((s, i) => (i === stepIndex ? step : s)) : [...round.steps, step];
+        const next = [...prev];
+        next[roundIndex] = { round: { ...round, steps }, unread: true };
+        saveConsensusRounds(next);
+        return next;
+      }
+      // First event of a new consensus round → auto-select the Consensus category.
+      if (prev.length === 0) setActiveCategory('consensus');
+      const next = [
+        ...prev,
+        {
+          round: {
+            consensus_id: ev.consensus_id,
+            agent_id: ev.agent_id,
+            agent_name: ev.agent_name,
+            prompt: ev.prompt,
+            steps: [step],
+            timestamp: Date.now(),
+          },
+          unread: true,
+        },
+      ];
+      saveConsensusRounds(next);
+      return next;
+    });
+    setIsOpen(true);
+    sessionStorage.removeItem(OPEN_KEY);
+  }, []);
+
+  const handleConsensusTabChange = useCallback((index: number) => {
+    setActiveConsensusIndex(index);
+    setConsensusRounds((prev) => {
+      if (!prev[index]?.unread) return prev;
+      const next = [...prev];
+      next[index] = { ...next[index], unread: false };
+      saveConsensusRounds(next);
+      return next;
+    });
+  }, []);
+
   const handleDialogueTabChange = useCallback(
     (index: number) => {
       setActiveDialogueIndex(index);
@@ -318,9 +424,11 @@ export function useActions(): UseActionsResult {
 
   const hasDialogues = dialogues.length > 0;
   const hasExternalActions = externalActions.length > 0;
+  const hasConsensus = consensusRounds.length > 0;
   const unreadDialogueCount = dialogues.filter((d) => d.unread).length;
   const unreadExternalCount = externalActions.filter((e) => e.unread).length;
-  const totalCount = artifacts.length + dialogues.length + externalActions.length;
+  const unreadConsensusCount = consensusRounds.filter((r) => r.unread).length;
+  const totalCount = artifacts.length + dialogues.length + externalActions.length + consensusRounds.length;
 
   return {
     isOpen,
@@ -330,6 +438,7 @@ export function useActions(): UseActionsResult {
     setActiveCategory,
     hasDialogues,
     hasExternalActions,
+    hasConsensus,
     artifacts,
     activeArtifactIndex,
     addArtifact,
@@ -343,8 +452,13 @@ export function useActions(): UseActionsResult {
     markDialogueRead,
     externalActions,
     addOrUpdateExternalAction,
+    consensusRounds,
+    activeConsensusIndex,
+    setActiveConsensusIndex: handleConsensusTabChange,
+    addOrUpdateConsensus,
     totalCount,
     unreadDialogueCount,
     unreadExternalCount,
+    unreadConsensusCount,
   };
 }

--- a/dashboard/src/locales/en/actions.json
+++ b/dashboard/src/locales/en/actions.json
@@ -6,6 +6,16 @@
   "tabs": {
     "code": "Code",
     "dialogues": "Dialogues",
-    "external": "External"
+    "external": "External",
+    "consensus": "Consensus"
+  },
+  "consensusCard": {
+    "engines": "engines",
+    "proposals": "Proposals",
+    "synthesis": "Synthesis",
+    "thinking": "Thinking…",
+    "retryable": "retryable",
+    "expand": "Expand",
+    "collapse": "Collapse"
   }
 }

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -367,3 +367,40 @@ export interface ExternalAction {
   callback_id: string;
   timestamp: number;
 }
+
+/** A single step (one engine's proposal, or the synthesis) of a consensus round.
+ * Emitted by the kernel as a `ConsensusProgress` event. */
+export interface ConsensusProgressEvent {
+  consensus_id: string;
+  agent_id: string;
+  agent_name: string;
+  prompt: string;
+  /** 'proposal' (one engine's contribution) or 'synthesis' (the merge). */
+  phase: string;
+  engine_id: string;
+  response: string | null;
+  status: 'pending' | 'success' | 'error';
+  /** MGP §14 error code when status='error' and the engine is an MGP server. */
+  mgp_error_code?: number;
+  retryable?: boolean;
+}
+
+export interface ConsensusStep {
+  phase: string;
+  engine_id: string;
+  response: string | null;
+  status: 'pending' | 'success' | 'error';
+  mgp_error_code?: number;
+  retryable?: boolean;
+}
+
+/** One consensus deliberation, aggregating every per-engine proposal step and
+ * the synthesis step under a single `consensus_id`. */
+export interface ConsensusRound {
+  consensus_id: string;
+  agent_id: string;
+  agent_name: string;
+  prompt: string;
+  steps: ConsensusStep[];
+  timestamp: number;
+}

--- a/docs/CONSENSUS_REVIVAL_DESIGN.md
+++ b/docs/CONSENSUS_REVIVAL_DESIGN.md
@@ -162,14 +162,33 @@ speculative (YAGNI); no other feature needs it today.
 
 ### 5.1 Agent-id stamping convention (Task #111b)
 
-- **Proposal**: stamped with the proposing engine's identity. Use the inbound
-  `agent` as the base and tag the engine, so each proposal is attributable
-  (e.g. `agent_id = agent.id`, distinguished by `engine_id`). The kernel sets
-  this; engines never self-declare it (consistent with the anti-spoofing rule at
+> **Revised 2026-06-30 (bug-417).** The original convention stamped the final
+> answer with `config.synthetic_agent_id` (`system.consensus`) and never
+> persisted it. In the running app that routed the answer to a detached
+> identity the user's chat does not subscribe to, **and** skipped chat
+> persistence entirely — so a `consensus:` message hung on "thinking…" forever
+> (every fail-safe branch was equally invisible, violating §5.2's "no silent
+> timeout" guarantee). The convention below is the shipped behavior.
+
+- **Per-engine proposals & synthesis progress** are NOT delivered as chat
+  `ThoughtResponse`s. They are emitted as `ConsensusProgress` events
+  (`consensus_id`, `phase` ∈ {`proposal`,`synthesis`}, `engine_id`, `status` ∈
+  {`pending`,`success`,`error`}, optional `mgp_error_code`) for the dashboard's
+  dedicated **Consensus** actions tab (see §7). The kernel sets every field;
+  engines never self-declare them (consistent with the anti-spoofing rule at
   system.rs ~L819).
-- **Synthesis / final answer**: `agent_id = config.synthetic_agent_id` (default
-  `system.consensus`), `engine_id = "consensus"`. This is the only
-  `ThoughtResponse` delivered to the user/chat.
+- **Final answer (and every fail-safe error message)**: delivered via
+  `deliver_consensus_result`, which (1) **persists** the text to the
+  **originating** agent's chat history (`agent_id = agent.id`, `source =
+  "agent"`, mirroring the normal path's `parent_id`/`branch_index` threading)
+  and (2) emits one `ThoughtResponse` stamped `agent_id = agent.id`,
+  `engine_id = "consensus"`. So it lands in the chat where the user asked and
+  survives reload. `config.synthetic_agent_id` is retained only as a display
+  label in the persisted message metadata (`{"consensus": true,
+  "synthetic_agent_id": …}`), not as the routing key.
+- **bug-408 stays fixed**: the in-kernel synchronous orchestration stamps the
+  response deterministically regardless of which `agent_id` value is chosen, so
+  using the originating id does not reintroduce the synthesis-identity race.
 
 ### 5.2 Fail-safe matrix (Task #111d, G4)
 
@@ -216,14 +235,27 @@ No new config keys. Defaults already additive: `CONSENSUS_ENGINES` empty →
 consensus never triggers (G6). Documentation of the keys and a recommended
 multi-engine example belongs to Task #114 (distribution/docs).
 
-## 7. Dashboard visibility hook (forward note for Task #113)
+## 7. Dashboard visibility — Consensus tab (implemented 2026-06-30)
 
-Because Option A no longer puts per-proposal events on the bus, live
-visualization (each engine's proposal, Collecting/Synthesizing state) needs the
-consensus branch to emit explicit progress events (e.g. a `ConsensusProgress`
-SSE payload) at: session start, each proposal collected, synthesis start, and
-completion. This is out of scope for the implementation task (#112) but the
-branch should be structured so these emit points are trivial to add.
+Live visualization of the deliberation is delivered through a dedicated
+**Consensus** tab in the Actions panel (alongside Code / Dialogues / External),
+not by overloading the External (I/O-bridge) semantics. `run_consensus` emits a
+`ConsensusProgress` event at each step:
+
+- **pending** for every engine before the concurrent fan-out, and for the
+  synthesizer before synthesis;
+- **success** with the proposal/synthesis text as each step completes;
+- **error** with an MGP §14 `mgp_error_code` (+ `retryable`) when an engine
+  fails to resolve / errors / times out.
+
+All steps of one deliberation share a `consensus_id` so the dashboard
+(`useActions` → `ActionsContext` → `ActionsPanel` → `ConsensusCard`) aggregates
+them into a single card showing each engine's proposal and the final synthesis.
+The events are display-only; the final answer is delivered to chat separately
+(§5.1). MGP-server engine errors carry a spec-defined code: an unresolved engine
+surfaces `SERVER_NOT_READY` (2000); a timeout surfaces `TIMEOUT` (3003). The
+kernel's `MgpError` codes are a faithful port of `mgp-spec` §14.3 (the `mgp-py`
+SDK provides the matching `ErrorData{code, message, data._mgp}` envelope).
 
 ## 8. Test plan (for the implementation task #112)
 

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -3308,6 +3308,32 @@
       "fix_note": "agentTabs now removes the empty-string id (ids.delete('')), so no '' tab is offered; global-pool ('') rows are shown under 'All' (which maps to agent_id='' at the backend anyway). fetchData also treats both null and '' as the unscoped view (scope = selectedAgent || undefined), so a concrete agent id is the only thing that scopes the fetch. Cross-ref bug-413.",
       "notes": "The backend can't separate '' from 'all' without an API change; excluding the '' tab is the minimal correct fix since '' rows are already visible under 'All'. A backend distinction (e.g. a sentinel for global-pool-only) was considered out of scope for a LOW edge.",
       "github_issue": 229
+    },
+    {
+      "id": "bug-417",
+      "summary": "HIGH: Consensus terminal response is never delivered to the originating chat — silent hang. SystemHandler::run_consensus produces the synthesized (or fail-safe error) text and calls emit_consensus_response, which ONLY sends a ThoughtResponse event stamped agent_id=consensus_config.synthetic_agent_id ('system.consensus') and never calls save_chat_message_reliable. The normal agentic path (system.rs ~1119-1137) persists the agent response under agent_id=agent.id with parent_id/branch threading before emitting; the consensus path has no persistence at all. Consequence: a 'consensus:'-prefixed message to agent.cloto_default leaves the user's chat with the user message and no response (GET /api/chat/agent.cloto_default/messages returns only the user turn; /api/chat/system.consensus/messages is empty), so the dashboard sits on thinking forever. This holds for BOTH the happy path AND every fail-safe branch ('[Consensus unavailable]', '[Consensus failed] N/min proposals', synthesis timeout), so the design guarantee in section 5.2 'the user never waits on a silent timeout' is violated — it merely becomes a silent error. Unit/integration tests only assert the ThoughtResponse event is emitted, never end-to-end chat visibility, so they pass while consensus is unusable in the chat UI. Live-reproduced 2026-06-30 (trace f98b7db4) on dev kernel :8081.",
+      "severity": "HIGH",
+      "discovered": "2026-06-30T00:00:00Z",
+      "version": "0.6.8-beta.1",
+      "file": "crates/core/src/handlers/system.rs",
+      "pattern": "synthetic_agent_id\\.clone\\(\\)",
+      "expected": "absent",
+      "status": "fixed",
+      "fixed_in": "0.6.8-beta.1",
+      "fix_note": "run_consensus now delivers the terminal answer (and every fail-safe error) via deliver_consensus_result: it persists the response under the ORIGINATING agent.id with save_chat_message_reliable (mirroring the normal path's parent_id/branch_index threading) and emits the ThoughtResponse stamped agent_id=agent.id (engine_id='consensus', metadata.consensus=true) — so it lands in the chat where the user asked and survives reload. The old emit_consensus_response (which stamped synthetic_agent_id and never persisted) is removed; the synthetic id is retained only as a metadata label, so the 'synthetic_agent_id.clone()' stamping pattern is gone. Per-step ConsensusProgress events feed the new dashboard Consensus tab. Covered by consensus_test.rs (terminal response under originating id + chat persistence + ConsensusProgress + MGP error code). bug-408 stays fixed (in-kernel synchronous orchestration stamps deterministically regardless of the chosen agent_id).",
+      "notes": "Carried in by the consensus revival (PR #230, Goal #138); root-caused via live verification (trace f98b7db4). The synthetic_agent_id ('system.consensus') is now a display label in chat metadata, not the routing key. Cross-ref docs/CONSENSUS_REVIVAL_DESIGN.md sections 5.1/5.2."
+    },
+    {
+      "id": "bug-418",
+      "summary": "LOW: The shipped CONSENSUS_ENGINES example references an engine that is not auto-registered, so consensus fails out of the box. installer.rs writes a commented '# CONSENSUS_ENGINES=mind.deepseek,mind.cerebras' example, but only providers wired as a runtime mind.* engine server resolve in run_agentic_loop (engine_resolver: get_engine OR mcp.has_server(id) OR has_server(strip 'mind.')). On the dev kernel only 'deepseek' (an active agent's default engine) and 'mind.local' are registered engine servers; 'cerebras' exists in the llm_providers table but is not registered, so 'mind.cerebras' resolves to Err('Engine not found'), the engine is dropped, and a 2-engine config collects only 1 of min 2 proposals → quorum fail. The example thus produces a guaranteed failure for a user who copies it. Live-reproduced 2026-06-30 (trace f98b7db4: deepseek ok, mind.cerebras 'not found').",
+      "severity": "LOW",
+      "discovered": "2026-06-30T00:00:00Z",
+      "version": "0.6.8-beta.1",
+      "file": "crates/core/src/installer.rs",
+      "pattern": "CONSENSUS_ENGINES=mind\\.deepseek,mind\\.cerebras",
+      "expected": "present",
+      "status": "open",
+      "notes": "Belongs with Task #114 (config defaults/docs/marketing). Fix options: (a) change the example to two reliably-registered engines, (b) document that CONSENSUS_ENGINES entries must be registered mind.* engine servers and how to register a provider as one, and/or (c) emit a clearer boot/runtime warning when a CONSENSUS_ENGINES id has no resolvable engine server. Surfacing the dropped-engine reason to the user also depends on bug-417 (right now even the '[Consensus failed] 1/2' message is invisible)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Live verification of the consensus revival (#230) exposed **bug-417 (HIGH)**: the synthesized answer (and every fail-safe error) was emitted under `agent_id = synthetic_agent_id` (`system.consensus`) and **never persisted**, so it never reached the originating agent's chat — the dashboard hung on "thinking…" forever. This violated the design's §5.2 "no silent timeout" guarantee (it became a silent *error* instead). Unit/integration tests only asserted the event was emitted, never end-to-end visibility, so they passed while consensus was unusable in the chat UI.

## Changes

- **bug-417 fix** — `run_consensus` now delivers the terminal result via `deliver_consensus_result`: persists the response under the **originating** `agent.id` (`save_chat_message_reliable`, mirroring the normal path's `parent_id`/`branch_index` threading) and emits a `ThoughtResponse` stamped `agent_id = agent.id`, `engine_id = "consensus"`. So it lands in the chat where the user asked and survives reload. The synthetic id is retained only as a chat-metadata label. **bug-408 stays fixed** (in-kernel synchronous orchestration stamps deterministically regardless of the chosen `agent_id`).
- **Dedicated Consensus tab** — new `ClotoEventData::ConsensusProgress` event (per-engine proposal + synthesis, `pending → success/error`, grouped by `consensus_id`) feeds a new **Consensus** tab in the Actions panel (`useActions` / `ActionsContext` / `ActionsPanel` / new `ConsensusCard`), following the existing Dialogues/External category pattern.
- **MGP-spec errors** — unresolved engine servers surface a typed `MgpError` (`SERVER_NOT_READY` 2000, retryable) instead of an opaque string; engine failures map to MGP §14 codes (timeout → `TIMEOUT` 3003) so the tab shows `MGP-<code>`. The kernel's `MgpError` codes are a faithful port of `mgp-spec` §14.3 (the `mgp-py` SDK provides the matching `ErrorData{code,message,data._mgp}` envelope).

## Tests / verification

- `consensus_test.rs`: terminal response lands under the originating agent id, is persisted to chat, emits `ConsensusProgress` steps, and carries `SERVER_NOT_READY` on unresolved engines.
- `verify-issues.sh` flips **bug-417 → FIXED**. bug-418 (installer `CONSENSUS_ENGINES` example references an unregistered engine) registered LOW, deferred.
- fmt + clippy (CI-exact) + full kernel test; dashboard tsc + biome lint + build + vitest (39) all green.
- **Live-verified** in the running app: `consensus:` message now shows the synthesized answer in chat and the full deliberation in the Consensus tab.

Additive default: `CONSENSUS_ENGINES` empty → consensus never triggers, so normal users are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)