### PR TITLE
feat(consensus): engine-reuse fallback to reach quorum (CONSENSUS_ENGINE_REUSE)

### DIFF
--- a/crates/core/src/consensus.rs
+++ b/crates/core/src/consensus.rs
@@ -38,6 +38,11 @@ pub struct ConsensusConfig {
     /// Configurable so a deployment can rename it instead of the kernel
     /// hard-coding the literal. Defaults to `DEFAULT_CONSENSUS_AGENT_ID`.
     pub synthetic_agent_id: String,
+    /// Fallback for when fewer distinct engines succeed than `min_proposals`
+    /// (e.g. only one of two configured engines is registered): re-sample a
+    /// working engine in an isolated session, through a varied framing, to reach
+    /// quorum instead of hard-failing. Default on. (`CONSENSUS_ENGINE_REUSE`)
+    pub engine_reuse: bool,
 }
 
 impl Default for ConsensusConfig {
@@ -47,8 +52,32 @@ impl Default for ConsensusConfig {
             min_proposals: 2,
             session_timeout_secs: 60,
             synthetic_agent_id: DEFAULT_CONSENSUS_AGENT_ID.to_string(),
+            engine_reuse: true,
         }
     }
+}
+
+/// Answer-neutral reasoning lenses used to re-frame a re-sampled proposal so the
+/// same engine explores a different reasoning path instead of collapsing to an
+/// identical answer (which low-temperature sampling would otherwise produce).
+const REUSE_FRAMINGS: &[&str] = &[
+    "Reason from first principles, then answer:",
+    "Carefully weigh edge cases and caveats, then answer:",
+    "Consider alternative viewpoints, then answer:",
+    "Be precise and direct, then answer:",
+];
+
+/// Build the prompt for the `sample_index`-th sample of an engine. Sample 1 is
+/// the original, un-framed proposal. Samples >= 2 are reuse fallbacks: the same
+/// question re-asked through a rotating reasoning lens so re-sampled proposals
+/// diverge instead of duplicating. The lenses are answer-neutral — they change
+/// the reasoning path, not the requested answer.
+pub(crate) fn framed_prompt(content: &str, sample_index: u32) -> String {
+    if sample_index <= 1 {
+        return content.to_string();
+    }
+    let lens = REUSE_FRAMINGS[(sample_index as usize - 2) % REUSE_FRAMINGS.len()];
+    format!("{lens}\n\n{content}")
 }
 
 // ============================================================
@@ -102,5 +131,32 @@ mod tests {
         let p = synthesis_prompt("## Opinion 1:\nx");
         assert!(p.contains("wise moderator"));
         assert!(p.ends_with("## Opinion 1:\nx"));
+    }
+
+    #[test]
+    fn framed_prompt_first_sample_is_unframed() {
+        assert_eq!(framed_prompt("what is X?", 1), "what is X?");
+        assert_eq!(framed_prompt("what is X?", 0), "what is X?");
+    }
+
+    #[test]
+    fn framed_prompt_reuse_samples_diverge_but_keep_question() {
+        let s2 = framed_prompt("what is X?", 2);
+        let s3 = framed_prompt("what is X?", 3);
+        // Both still carry the original question…
+        assert!(s2.ends_with("what is X?"));
+        assert!(s3.ends_with("what is X?"));
+        // …but through different lenses, so re-samples don't duplicate.
+        assert_ne!(s2, s3);
+        assert_ne!(s2, "what is X?");
+    }
+
+    #[test]
+    fn framed_prompt_lenses_rotate() {
+        // 4 lenses → sample 2 and sample 6 reuse the same lens (wrap-around).
+        assert_eq!(
+            framed_prompt("q", 2),
+            framed_prompt("q", 2 + REUSE_FRAMINGS.len() as u32)
+        );
     }
 }

--- a/crates/core/src/handlers/system.rs
+++ b/crates/core/src/handlers/system.rs
@@ -1595,6 +1595,7 @@ impl SystemHandler {
                 &msg.content,
                 "proposal",
                 engine,
+                1,
                 None,
                 "pending",
                 None,
@@ -1628,6 +1629,7 @@ impl SystemHandler {
                             &msg.content,
                             "proposal",
                             engine,
+                            1,
                             Some(text.clone()),
                             "success",
                             None,
@@ -1643,6 +1645,7 @@ impl SystemHandler {
                             &msg.content,
                             "proposal",
                             engine,
+                            1,
                             Some(message),
                             "error",
                             code,
@@ -1657,6 +1660,7 @@ impl SystemHandler {
                             &msg.content,
                             "proposal",
                             engine,
+                            1,
                             Some("Engine timed out".to_string()),
                             "error",
                             Some(crate::managers::mcp_mgp::MGP_ERR_TIMEOUT),
@@ -1671,11 +1675,13 @@ impl SystemHandler {
         let results = futures::future::join_all(proposal_futs).await;
 
         let mut proposals: Vec<String> = Vec::new();
+        let mut success_engines: Vec<String> = Vec::new();
         for (engine, r) in results {
             match r {
                 Ok(Ok(text)) => {
                     info!(trace_id = %trace_id, engine = %engine, "📥 Consensus proposal collected");
                     proposals.push(text);
+                    success_engines.push(engine);
                 }
                 Ok(Err(e)) => {
                     warn!(trace_id = %trace_id, engine = %engine, error = %e, "⚠️ Consensus engine errored — dropping its proposal");
@@ -1686,7 +1692,120 @@ impl SystemHandler {
             }
         }
 
-        // Fail-safe: quorum not reached after errors / timeouts.
+        // Fallback (CONSENSUS_ENGINE_REUSE, default on): too few *distinct*
+        // engines succeeded to reach quorum, but at least one works → re-sample
+        // the working engine(s) in fresh isolated sessions, each through a
+        // different reasoning lens (so the samples diverge instead of
+        // duplicating), until we reach `min_proposals`. Graceful degradation
+        // (e.g. only one of two configured engines is registered) instead of a
+        // hard fail. Only engines that succeeded in pass 1 are re-sampled; failed
+        // (unregistered/broken) engines are not retried. A safety cap bounds the
+        // total reuse attempts so a flaky engine can't loop forever.
+        if cfg.engine_reuse && proposals.len() < min_proposals && !success_engines.is_empty() {
+            let mut sample_counts: std::collections::HashMap<String, u32> =
+                success_engines.iter().map(|e| (e.clone(), 1u32)).collect();
+            let max_reuse_attempts = min_proposals.saturating_mul(3);
+            let mut attempts = 0usize;
+            let mut rr = 0usize;
+            while proposals.len() < min_proposals && attempts < max_reuse_attempts {
+                attempts += 1;
+                let engine = success_engines[rr % success_engines.len()].clone();
+                rr += 1;
+                let sample = {
+                    let c = sample_counts.entry(engine.clone()).or_insert(1);
+                    *c += 1;
+                    *c
+                };
+                let key = crate::managers::session_manager::SessionKey::new(
+                    &agent.id,
+                    format!("consensus:{trace_id}:{engine}#{sample}"),
+                );
+                let framed = ClotoMessage::new(
+                    msg.source.clone(),
+                    crate::consensus::framed_prompt(&msg.content, sample),
+                );
+                self.emit_consensus_progress(
+                    trace_id,
+                    agent,
+                    &msg.content,
+                    "proposal",
+                    &engine,
+                    sample,
+                    None,
+                    "pending",
+                    None,
+                    None,
+                )
+                .await;
+                let r = tokio::time::timeout(
+                    phase_timeout,
+                    self.run_agentic_loop(
+                        agent,
+                        &engine,
+                        &framed,
+                        context.clone(),
+                        granted_server_ids,
+                        trace_id,
+                        &key,
+                    ),
+                )
+                .await;
+                match r {
+                    Ok(Ok(text)) => {
+                        info!(trace_id = %trace_id, engine = %engine, sample, "📥 Consensus reuse proposal collected");
+                        self.emit_consensus_progress(
+                            trace_id,
+                            agent,
+                            &msg.content,
+                            "proposal",
+                            &engine,
+                            sample,
+                            Some(text.clone()),
+                            "success",
+                            None,
+                            None,
+                        )
+                        .await;
+                        proposals.push(text);
+                    }
+                    Ok(Err(e)) => {
+                        let (code, retryable, message) = Self::classify_engine_error(&e);
+                        warn!(trace_id = %trace_id, engine = %engine, error = %e, "⚠️ Consensus reuse sample errored");
+                        self.emit_consensus_progress(
+                            trace_id,
+                            agent,
+                            &msg.content,
+                            "proposal",
+                            &engine,
+                            sample,
+                            Some(message),
+                            "error",
+                            code,
+                            retryable,
+                        )
+                        .await;
+                    }
+                    Err(_) => {
+                        warn!(trace_id = %trace_id, engine = %engine, "⏱️ Consensus reuse sample timed out");
+                        self.emit_consensus_progress(
+                            trace_id,
+                            agent,
+                            &msg.content,
+                            "proposal",
+                            &engine,
+                            sample,
+                            Some("Engine timed out".to_string()),
+                            "error",
+                            Some(crate::managers::mcp_mgp::MGP_ERR_TIMEOUT),
+                            Some(true),
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+
+        // Fail-safe: quorum not reached after errors / timeouts (and reuse).
         if proposals.len() < min_proposals {
             let detail = format!(
                 "Consensus collected only {}/{min_proposals} proposals (engines errored or timed out).",
@@ -1706,10 +1825,16 @@ impl SystemHandler {
         // 2. Synthesize — run the synthesizer engine in-kernel over the combined
         //    views. A pure text merge → no tools (empty grant list → plain think).
         let combined = crate::consensus::combine_views(&proposals);
-        let synthesizer_engine = if cfg.synthesizer_engine.is_empty() {
-            engines[0].clone()
-        } else {
+        // Pick the synthesizer: an explicit config wins; otherwise prefer a
+        // proven-working engine from this run (so the synthesis doesn't fail just
+        // because the first *configured* engine was the unregistered one), then
+        // fall back to the first configured engine.
+        let synthesizer_engine = if !cfg.synthesizer_engine.is_empty() {
             cfg.synthesizer_engine.clone()
+        } else if let Some(first_ok) = success_engines.first() {
+            first_ok.clone()
+        } else {
+            engines[0].clone()
         };
         let synth_agent = AgentMetadata {
             id: "agent.synthesizer".to_string(),
@@ -1744,6 +1869,7 @@ impl SystemHandler {
             &msg.content,
             "synthesis",
             &synthesizer_engine,
+            1,
             None,
             "pending",
             None,
@@ -1774,6 +1900,7 @@ impl SystemHandler {
                     &msg.content,
                     "synthesis",
                     &synthesizer_engine,
+                    1,
                     Some(text.clone()),
                     "success",
                     None,
@@ -1791,6 +1918,7 @@ impl SystemHandler {
                     &msg.content,
                     "synthesis",
                     &synthesizer_engine,
+                    1,
                     Some(message),
                     "error",
                     code,
@@ -1809,6 +1937,7 @@ impl SystemHandler {
                     &msg.content,
                     "synthesis",
                     &synthesizer_engine,
+                    1,
                     Some("Synthesis timed out".to_string()),
                     "error",
                     Some(crate::managers::mcp_mgp::MGP_ERR_TIMEOUT),
@@ -1853,6 +1982,7 @@ impl SystemHandler {
         prompt: &str,
         phase: &str,
         engine_id: &str,
+        sample_index: u32,
         response: Option<String>,
         status: &str,
         mgp_error_code: Option<i64>,
@@ -1865,6 +1995,7 @@ impl SystemHandler {
             prompt: prompt.to_string(),
             phase: phase.to_string(),
             engine_id: engine_id.to_string(),
+            sample_index,
             response,
             status: status.to_string(),
             mgp_error_code,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -558,6 +558,15 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
             .and_then(|v| v.parse().ok())
             .unwrap_or(60)
             .max(10),
+        // Default on: re-sample a working engine to reach quorum when too few
+        // distinct engines are available, rather than hard-failing.
+        engine_reuse: match std::env::var("CONSENSUS_ENGINE_REUSE") {
+            Ok(v) => !matches!(
+                v.trim().to_lowercase().as_str(),
+                "0" | "false" | "off" | "no"
+            ),
+            Err(_) => true,
+        },
     };
 
     let system_handler = {

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -753,6 +753,12 @@ pub enum ClotoEventData {
         phase: String,
         /// The engine producing this step (e.g. "mind.deepseek").
         engine_id: String,
+        /// Which sample of this engine produced the step. 1 = the first (primary)
+        /// proposal; >= 2 = a reuse fallback re-sampling the same engine (through a
+        /// varied framing) to reach quorum when too few distinct engines are
+        /// available. Always 1 for synthesis.
+        #[serde(default = "default_sample_index")]
+        sample_index: u32,
         /// None while pending; Some(text) on success, Some(error message) on error.
         response: Option<String>,
         /// "pending", "success", "error".
@@ -806,6 +812,10 @@ pub struct AgentMetadata {
 
 fn default_agent_type() -> String {
     "agent".to_string()
+}
+
+fn default_sample_index() -> u32 {
+    1
 }
 
 impl AgentMetadata {

--- a/dashboard/src/components/ConsensusCard.tsx
+++ b/dashboard/src/components/ConsensusCard.tsx
@@ -36,6 +36,11 @@ function StepRow({ step, defaultLines }: { step: ConsensusStep; defaultLines: nu
           <span className="text-[10px] font-mono font-bold uppercase tracking-wider text-content-secondary truncate">
             {step.engine_id.replace('mind.', '')}
           </span>
+          {step.sample_index > 1 && (
+            <span className="text-[9px] font-mono text-content-tertiary shrink-0">
+              · {t('consensusCard.sample')} {step.sample_index}
+            </span>
+          )}
         </div>
         {isError && step.mgp_error_code != null && (
           <span className="text-[9px] font-mono text-red-400 bg-red-500/10 px-1.5 py-0.5 rounded shrink-0">
@@ -93,7 +98,7 @@ export function ConsensusCard({ round }: ConsensusCardProps) {
           </span>
         </div>
         <span className="text-[9px] font-mono text-content-tertiary bg-surface-secondary px-1.5 py-0.5 rounded shrink-0">
-          {proposals.length} {t('consensusCard.engines')}
+          {new Set(proposals.map((s) => s.engine_id)).size} {t('consensusCard.engines')}
         </span>
       </div>
 
@@ -111,7 +116,7 @@ export function ConsensusCard({ round }: ConsensusCardProps) {
           </div>
           <div className="space-y-1.5 mb-2">
             {proposals.map((s) => (
-              <StepRow key={`proposal-${s.engine_id}`} step={s} defaultLines={3} />
+              <StepRow key={`proposal-${s.engine_id}-${s.sample_index}`} step={s} defaultLines={3} />
             ))}
           </div>
         </>

--- a/dashboard/src/contexts/ActionsContext.tsx
+++ b/dashboard/src/contexts/ActionsContext.tsx
@@ -71,6 +71,7 @@ export function ActionsProvider({ children }: { children: ReactNode }) {
           prompt: string;
           phase: string;
           engine_id: string;
+          sample_index: number;
           response: string | null;
           status: string;
           mgp_error_code?: number;

--- a/dashboard/src/hooks/useActions.ts
+++ b/dashboard/src/hooks/useActions.ts
@@ -342,9 +342,11 @@ export function useActions(): UseActionsResult {
 
   const addOrUpdateConsensus = useCallback((ev: ConsensusProgressEvent) => {
     setConsensusRounds((prev) => {
+      const sampleIndex = ev.sample_index ?? 1;
       const step = {
         phase: ev.phase,
         engine_id: ev.engine_id,
+        sample_index: sampleIndex,
         response: ev.response,
         status: ev.status,
         mgp_error_code: ev.mgp_error_code,
@@ -352,10 +354,13 @@ export function useActions(): UseActionsResult {
       };
       const roundIndex = prev.findIndex((r) => r.round.consensus_id === ev.consensus_id);
       if (roundIndex >= 0) {
-        // Existing round — update the matching step (same phase + engine) in place,
-        // or append it if this is the step's first event.
+        // Existing round — update the matching step (same phase + engine + sample)
+        // in place, or append it. The sample index keeps reuse re-samples of the
+        // same engine as distinct steps.
         const round = prev[roundIndex].round;
-        const stepIndex = round.steps.findIndex((s) => s.phase === ev.phase && s.engine_id === ev.engine_id);
+        const stepIndex = round.steps.findIndex(
+          (s) => s.phase === ev.phase && s.engine_id === ev.engine_id && s.sample_index === sampleIndex,
+        );
         const steps = stepIndex >= 0 ? round.steps.map((s, i) => (i === stepIndex ? step : s)) : [...round.steps, step];
         const next = [...prev];
         next[roundIndex] = { round: { ...round, steps }, unread: true };

--- a/dashboard/src/locales/en/actions.json
+++ b/dashboard/src/locales/en/actions.json
@@ -15,6 +15,7 @@
     "synthesis": "Synthesis",
     "thinking": "Thinking…",
     "retryable": "retryable",
+    "sample": "sample",
     "expand": "Expand",
     "collapse": "Collapse"
   }

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -378,6 +378,9 @@ export interface ConsensusProgressEvent {
   /** 'proposal' (one engine's contribution) or 'synthesis' (the merge). */
   phase: string;
   engine_id: string;
+  /** Which sample of this engine: 1 = primary; >= 2 = reuse fallback re-sampling
+   * the same engine through a varied framing to reach quorum. */
+  sample_index: number;
   response: string | null;
   status: 'pending' | 'success' | 'error';
   /** MGP §14 error code when status='error' and the engine is an MGP server. */
@@ -388,6 +391,7 @@ export interface ConsensusProgressEvent {
 export interface ConsensusStep {
   phase: string;
   engine_id: string;
+  sample_index: number;
   response: string | null;
   status: 'pending' | 'success' | 'error';
   mgp_error_code?: number;

--- a/docs/CONSENSUS_REVIVAL_DESIGN.md
+++ b/docs/CONSENSUS_REVIVAL_DESIGN.md
@@ -231,9 +231,31 @@ and the fail-safe branching. No new engine-call primitive is introduced (G2).
 
 ## 6. Config and defaults
 
-No new config keys. Defaults already additive: `CONSENSUS_ENGINES` empty →
-consensus never triggers (G6). Documentation of the keys and a recommended
-multi-engine example belongs to Task #114 (distribution/docs).
+`CONSENSUS_ENGINES` empty → consensus never triggers (G6, additive default).
+Documentation of all keys and a recommended multi-engine example belongs to
+Task #114 (distribution/docs).
+
+### 6.1 Engine-reuse fallback (`CONSENSUS_ENGINE_REUSE`, default on)
+
+When fewer **distinct** engines succeed than `min_proposals` (e.g. only one of
+two configured engines is registered), consensus does not hard-fail: it
+re-samples the working engine(s) in fresh isolated sessions to reach quorum.
+Each re-sample (`sample_index >= 2`) re-asks the same question through a
+rotating, answer-neutral reasoning lens (`consensus::framed_prompt`) so the
+proposals diverge instead of collapsing to an identical answer (which
+low-temperature sampling would otherwise produce — the fallback is
+self-consistency sampling, not true cross-engine diversity, and its value
+depends on the engine's sampling variance). Only engines that succeeded in
+pass 1 are re-sampled; failed (unregistered/broken) engines are not retried. A
+safety cap (`min_proposals * 3` attempts) bounds the work so a flaky engine
+cannot loop forever. The Consensus tab labels re-samples as
+"<engine> · sample N" so the reuse is transparent, never silent. Set
+`CONSENSUS_ENGINE_REUSE=0|false|off|no` to require distinct engines and
+hard-fail instead.
+
+The §5.2 fail-safe matrix's "collected < min_proposals → error" row applies
+only **after** reuse has run (or when no engine succeeded at all / reuse is
+disabled).
 
 ## 7. Dashboard visibility — Consensus tab (implemented 2026-06-30)
 


### PR DESCRIPTION
## Summary

Follow-up to #231 (stacked on it). When fewer **distinct** engines succeed than `min_proposals` (e.g. only one of two configured engines is registered), consensus previously hard-failed with `[Consensus failed] 1/2 proposals`. It now degrades gracefully: re-sample the working engine(s) in fresh isolated sessions until quorum is reached.

> ⚠️ Stacked on #231 — review/merge that first. The base of this PR is `feat/consensus-ux-chat-delivery-bug417`; it will retarget to `master` once #231 merges.

## Changes

- Each re-sample (`sample_index >= 2`) re-asks the question through a rotating, **answer-neutral reasoning lens** (`consensus::framed_prompt`) so proposals diverge instead of collapsing to an identical answer under low-temperature sampling. (This fallback is self-consistency sampling, not true cross-engine diversity — its value depends on the engine's sampling variance; the framing mitigates the low-temp degenerate case.)
- Only engines that succeeded in pass 1 are re-sampled; failed (unregistered/broken) engines are not retried. A safety cap (`min_proposals * 3`) bounds the work.
- Default **on**; `CONSENSUS_ENGINE_REUSE=0|false|off|no` requires distinct engines (hard-fail).
- `ConsensusProgress` gains a `sample_index`; the Consensus tab labels re-samples as **`<engine> · sample N`** and counts distinct engines, so the reuse is transparent (never silent).
- The synthesizer now prefers a proven-working engine when `CONSENSUS_SYNTHESIZER` is unset, so synthesis doesn't fail just because the first *configured* engine was the unregistered one.

## Tests / verification

- `consensus::framed_prompt` unit tests (first sample unframed; re-samples diverge but keep the question; lenses rotate).
- The reuse orchestration's happy path needs a live engine (no Rust engine mock exists); the all-engines-unavailable integration test confirms reuse is a no-op with no working engine (no hang, still fail-safe).
- fmt + clippy (CI-exact) + full kernel test; dashboard tsc + biome lint + build + vitest (39) all green.
- **Live-verified**: with `CONSENSUS_ENGINES=mind.deepseek,mind.cerebras` (cerebras unregistered), deepseek is re-sampled as "sample 2" → quorum reached → synthesis → unified answer in chat.

Authority: `docs/CONSENSUS_REVIVAL_DESIGN.md` §6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)