### PR TITLE
fix(dashboard): show de-prefixed catalog engines/memory in agent dropdowns

### DIFF
--- a/dashboard/src/components/AgentPluginWorkspace.tsx
+++ b/dashboard/src/components/AgentPluginWorkspace.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useApi } from '../hooks/useApi';
 import { useMcpServers } from '../hooks/useMcpServers';
 import { AgentIcon, agentColor } from '../lib/agentIdentity';
+import { isEngineServer, isMemoryServer } from '../lib/serverCategory';
 import { extractVrmThumbnail } from '../lib/vrmThumbnail';
 import type { AgentMetadata } from '../types';
 import { AvatarSection } from './AvatarSection';
@@ -143,8 +144,12 @@ export function AgentPluginWorkspace({ agent, onBack }: Props) {
 
   const applyPreset = (presetServerIds: string[]) => {
     setGrantedIds((prev) => {
-      // Keep existing mind.* engines, replace everything else with preset
-      const engines = [...prev].filter((id) => id.startsWith('mind.'));
+      // Keep existing engines (legacy mind.* or de-prefixed catalog engines),
+      // replace everything else with preset.
+      const engines = [...prev].filter((id) => {
+        const server = servers.find((s) => s.id === id);
+        return server ? isEngineServer(server) : id.startsWith('mind.');
+      });
       return new Set([...engines, ...presetServerIds]);
     });
   };
@@ -162,8 +167,8 @@ export function AgentPluginWorkspace({ agent, onBack }: Props) {
 
       // Derive default_engine_id and preferred_memory from granted servers
       const grantedServers = servers.filter((s) => grantedIds.has(s.id));
-      const engineServer = grantedServers.find((s) => s.id.startsWith('mind.'));
-      const memoryServer = grantedServers.find((s) => s.id.startsWith('memory.'));
+      const engineServer = grantedServers.find(isEngineServer);
+      const memoryServer = grantedServers.find(isMemoryServer);
 
       const metadata: Record<string, string> = { ...agent.metadata };
       // Remove fields managed by dedicated APIs (avatar, VRM, password).

--- a/dashboard/src/components/AgentTerminal.tsx
+++ b/dashboard/src/components/AgentTerminal.tsx
@@ -20,6 +20,7 @@ import { useEventStream } from '../hooks/useEventStream';
 import { useMcpServers } from '../hooks/useMcpServers';
 import { agentColor } from '../lib/agentIdentity';
 import { displayServerId } from '../lib/format';
+import { isEngineServer, isMemoryServer } from '../lib/serverCategory';
 import { EVENTS_URL } from '../services/api';
 import type { AccessControlEntry, AgentMetadata } from '../types';
 import { AgentConsole } from './AgentConsole';
@@ -65,8 +66,8 @@ export function AgentTerminal({ agents, selectedAgent, onSelectAgent, onRefresh,
   // MCP-based engine/memory discovery (mind.* = reasoning engines, memory.* = memory backends)
   // Must be called before any conditional returns to satisfy React's Rules of Hooks
   const { servers: mcpServers } = useMcpServers();
-  const mcpEngines = mcpServers.filter((s) => s.id.startsWith('mind.') && s.status === 'Connected');
-  const mcpMemories = mcpServers.filter((s) => s.id.startsWith('memory.') && s.status === 'Connected');
+  const mcpEngines = mcpServers.filter((s) => isEngineServer(s) && s.status === 'Connected');
+  const mcpMemories = mcpServers.filter((s) => isMemoryServer(s) && s.status === 'Connected');
 
   const DEFAULT_AGENT_ID = 'agent.cloto_default';
 

--- a/dashboard/src/components/CronJobs.tsx
+++ b/dashboard/src/components/CronJobs.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useUserIdentity } from '../contexts/UserIdentityContext';
 import { useApi } from '../hooks/useApi';
 import { useMcpServers } from '../hooks/useMcpServers';
+import { isEngineServer } from '../lib/serverCategory';
 import type { AgentMetadata, CronJob } from '../types';
 import { ConfirmDialog } from './ui/ConfirmDialog';
 
@@ -32,7 +33,7 @@ export const CronJobs = memo(function CronJobs() {
   const [jobs, setJobs] = useState<CronJob[]>([]);
   const [agents, setAgents] = useState<AgentMetadata[]>([]);
   const { servers: mcpServers } = useMcpServers();
-  const mcpEngines = mcpServers.filter((s) => s.id.startsWith('mind.') && s.status === 'Connected');
+  const mcpEngines = mcpServers.filter((s) => isEngineServer(s) && s.status === 'Connected');
   const [showForm, setShowForm] = useState(false);
   const [notification, setNotification] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [confirmDialog, setConfirmDialog] = useState<{ message: string; onConfirm: () => void } | null>(null);

--- a/dashboard/src/components/EngineSelector.tsx
+++ b/dashboard/src/components/EngineSelector.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, Zap } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { displayServerId } from '../lib/format';
+import { isEngineServer } from '../lib/serverCategory';
 import type { McpServerInfo } from '../types';
 
 interface EngineSelectorProps {
@@ -23,7 +24,7 @@ export function EngineSelector({ servers, selectedEngine, onSelect, disabled }: 
   const menuRef = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState<{ left: number; bottom: number; maxHeight: number } | null>(null);
 
-  const mindServers = servers.filter((s) => s.id.startsWith('mind.'));
+  const mindServers = servers.filter(isEngineServer);
   const selected = selectedEngine ? mindServers.find((s) => s.id === selectedEngine) : null;
 
   const pillLabel = selected ? resolveDisplayName(selected) : 'Auto';

--- a/dashboard/src/lib/__tests__/serverCategory.test.ts
+++ b/dashboard/src/lib/__tests__/serverCategory.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { McpServerInfo } from '../../types';
+import { isEngineServer, isMemoryServer } from '../serverCategory';
+
+function server(id: string, tools: string[] = []): McpServerInfo {
+  return {
+    id,
+    command: 'python',
+    args: [],
+    status: 'Connected',
+    tools,
+    is_cloto_sdk: true,
+  };
+}
+
+describe('isEngineServer', () => {
+  it('matches the legacy mind.* prefix', () => {
+    expect(isEngineServer(server('mind.local'))).toBe(true);
+  });
+
+  it('matches de-prefixed catalog engines by the think tool surface', () => {
+    // bug-388/396: ClotoHub registers `deepseek`, not `mind.deepseek`.
+    expect(isEngineServer(server('deepseek', ['think', 'think_with_tools']))).toBe(true);
+  });
+
+  it('rejects non-engine servers', () => {
+    expect(isEngineServer(server('cscheduler', ['create_task', 'list_goals']))).toBe(false);
+    expect(isEngineServer(server('cpersona', ['store', 'recall']))).toBe(false);
+  });
+});
+
+describe('isMemoryServer', () => {
+  it('matches the legacy memory.* prefix', () => {
+    expect(isMemoryServer(server('memory.cpersona'))).toBe(true);
+  });
+
+  it('matches de-prefixed catalog memory backends by the memory tool surface', () => {
+    expect(isMemoryServer(server('cpersona', ['store', 'recall', 'list_memories']))).toBe(true);
+  });
+
+  it('rejects non-memory servers', () => {
+    expect(isMemoryServer(server('mind.local', ['think']))).toBe(false);
+    expect(isMemoryServer(server('websearch', ['search']))).toBe(false);
+  });
+});

--- a/dashboard/src/lib/serverCategory.ts
+++ b/dashboard/src/lib/serverCategory.ts
@@ -1,0 +1,42 @@
+import type { McpServerInfo } from '../types';
+
+// Capability classification for connected MCP servers, mirroring the kernel's
+// `classify_tool` (crates/core/src/managers/capability_dispatcher.rs).
+//
+// Servers installed via the ClotoHub catalog carry de-prefixed ids (e.g.
+// `deepseek`, `cpersona`) instead of the legacy `mind.` / `memory.` namespace
+// (bug-388 / bug-396). Prefix-only matching therefore misses every catalog
+// connector and only catches built-ins like `mind.local`. Fall back to the
+// same tool surface the kernel keys on so de-prefixed engines and memory
+// backends are categorised correctly.
+
+const REASONING_TOOLS = ['think', 'think_with_tools'];
+
+const MEMORY_TOOLS = new Set([
+  'store',
+  'recall',
+  'list_memories',
+  'delete_memory',
+  'list_episodes',
+  'delete_episode',
+  'archive_episode',
+  'delete_agent_data',
+  'update_profile',
+  'update_memory',
+  'lock_memory',
+  'unlock_memory',
+  'set_recall_precision',
+  'get_recall_precision',
+]);
+
+/** True when the server is a reasoning engine (legacy `mind.` prefix or a
+ *  de-prefixed catalog engine exposing the `think` tool surface). */
+export function isEngineServer(s: McpServerInfo): boolean {
+  return s.id.startsWith('mind.') || s.tools.some((t) => REASONING_TOOLS.includes(t));
+}
+
+/** True when the server is a memory backend (legacy `memory.` prefix or a
+ *  de-prefixed catalog backend exposing the memory tool surface). */
+export function isMemoryServer(s: McpServerInfo): boolean {
+  return s.id.startsWith('memory.') || s.tools.some((t) => MEMORY_TOOLS.has(t));
+}


### PR DESCRIPTION
## Problem

In the agent-creation form, the **LLM engine** dropdown showed only `local` and the **memory** dropdown was empty (`なし` only), despite multiple MCP servers being installed and connected.

## Root cause

The dashboard classified engine/memory servers by **id prefix only** (`s.id.startsWith('mind.')` / `'memory.'`). But connectors installed via the ClotoHub catalog are registered with **de-prefixed ids** (`deepseek` not `mind.deepseek`, `cpersona` not `memory.cpersona`; bug-388/396). Only the built-in `mind.local` carries the legacy prefix, so it was the sole engine shown, and no memory backend matched.

The kernel's `capability_dispatcher::classify_tool` already handles this (prefix **OR** tool-name fallback), but the dashboard never followed suit.

## Fix

New `dashboard/src/lib/serverCategory.ts` mirrors the kernel's classification:
- `isEngineServer` — `mind.*` prefix **or** exposes `think` / `think_with_tools`
- `isMemoryServer` — `memory.*` prefix **or** exposes the memory tool surface (`store` / `recall` / …)

Applied to the 5 consumers that classify `McpServerInfo`:
- `AgentTerminal` (creation form engine + memory + routing dropdowns)
- `EngineSelector` (chat engine picker)
- `AgentPluginWorkspace` (grant → `default_engine_id` / `preferred_memory` derivation — a real functional bug, plus preset-keep)
- `CronJobs` (cron engine dropdown)

Additive / behavior-preserving: the legacy prefix still matches; this only **adds** detection of de-prefixed connectors.

Out of scope (separate, string-only / display layer): `lib/presets.ts` (preset definitions hardcode `mind.cerebras`), `AgentConsole` event filters.

## Verification

- `npx biome check` clean
- `npm run build` (tsc + vite) green
- New `serverCategory.test.ts` — 6 cases; full suite 45/45 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)