### PR TITLE
fix(dashboard): passwordless agent deletion returns 400 Bad Request

### DIFF
--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -85,7 +85,14 @@ async function mutate(
 ): Promise<Response> {
   const res = await fetch(`${API_BASE}${path}`, {
     method,
-    headers: { 'Content-Type': 'application/json', ...extraHeaders },
+    // Only advertise a JSON body when one is actually sent. axum's
+    // `Option<Json<..>>` extractor treats the body as present whenever the
+    // Content-Type header is `application/json`, so pairing it with an empty
+    // body makes optional-body handlers reject with 400 (see deleteAgent).
+    headers: {
+      ...(body !== undefined && { 'Content-Type': 'application/json' }),
+      ...extraHeaders,
+    },
     signal: signal ?? AbortSignal.timeout(API_TIMEOUT_MS),
     ...(body !== undefined && { body: JSON.stringify(body) }),
   });
@@ -241,9 +248,17 @@ export const api = {
       { 'X-API-Key': apiKey },
     ).then(() => {}),
   async deleteAgent(agentId: string, apiKey: string, password?: string): Promise<void> {
+    // Only send a JSON body (and its Content-Type) when a password is supplied.
+    // The backend handler extracts `Option<Json<..>>`, but axum only treats the
+    // body as absent when the Content-Type header is missing entirely — sending
+    // `application/json` with an empty body makes it try (and fail) to parse the
+    // body, rejecting passwordless deletes with 400 before the handler runs.
     const res = await fetch(`${API_BASE}/agents/${agentId}`, {
       method: 'DELETE',
-      headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
+      headers: {
+        'X-API-Key': apiKey,
+        ...(password ? { 'Content-Type': 'application/json' } : {}),
+      },
       ...(password ? { body: JSON.stringify({ password }) } : {}),
     });
     await throwIfNotOk(res, 'delete agent');


### PR DESCRIPTION
## Problem

Deleting an agent that has no power password fails with `Failed to delete agent: Bad Request` (HTTP 400). This affects **every** passwordless agent — the agent id (incl. multibyte names like `agent.マイク`) is irrelevant.

## Root cause

`deleteAgent` always sent `Content-Type: application/json` but only attached a body when a password was supplied:

```ts
headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
...(password ? { body: JSON.stringify({ password }) } : {}),
```

The handler extracts `body: Option<Json<Value>>`. But axum 0.8's `OptionalFromRequest for Json` only yields `None` when the **Content-Type header is absent entirely** — if it's `application/json`, it tries to parse the (empty) body and rejects:

```rust
if headers.get(CONTENT_TYPE).is_some() {
    if json_content_type(headers) {
        let bytes = Bytes::from_request(req, state).await?;
        Ok(Some(Self::from_bytes(&bytes)?))   // empty body -> parse error -> 400
    } ...
} else { Ok(None) }
```

So a passwordless delete = JSON content-type + empty body → 400 before the handler runs. (`axum-0.8.9/src/json.rs`.)

## Fix

Attach `Content-Type` + body only when a password is actually sent, so axum sees no Content-Type and yields `None`. The same guard is applied to the shared `mutate` helper, preventing the class of bug for any other optional-body endpoint invoked without a body. Body-carrying calls are unchanged.

## Verification

- `npx biome check` clean
- `npm run build` (tsc + vite) green
- Root cause confirmed against the axum 0.8.9 `OptionalFromRequest` impl; the target agent (`agent.マイク`) confirmed passwordless in the dev DB (`power_password_hash` NULL), so the delete path now reaches the handler and succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)