### PR TITLE
fix(dashboard): tidy agent card footer + relocate agent id to console header

### DIFF
--- a/dashboard/src/compiled-tailwind.css
+++ b/dashboard/src/compiled-tailwind.css
@@ -1652,6 +1652,15 @@ video {
   gap: 2rem;
 }
 
+.gap-x-3 {
+  -moz-column-gap: 0.75rem;
+       column-gap: 0.75rem;
+}
+
+.gap-y-2 {
+  row-gap: 0.5rem;
+}
+
 .space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(0.125rem * calc(1 - var(--tw-space-y-reverse)));

--- a/dashboard/src/components/AgentConsole.tsx
+++ b/dashboard/src/components/AgentConsole.tsx
@@ -2,6 +2,7 @@ import {
   Activity,
   ArrowLeft,
   Box,
+  Lock,
   Pencil,
   RotateCcw as RetryIcon,
   RotateCcw,
@@ -792,8 +793,13 @@ export function AgentConsole({ agent, onBack }: { agent: AgentMetadata; onBack: 
             <h2 className="text-xl font-black text-content-primary tracking-tighter uppercase">{agent.name}</h2>
             <div className="flex items-center gap-2">
               <StatusDot status={agent.enabled ? 'online' : 'offline'} size="sm" />
-              <span className="text-[10px] font-mono text-content-tertiary uppercase tracking-[0.2em]">
+              <span className="text-[11px] font-mono text-content-tertiary uppercase tracking-[0.2em]">
                 {agent.enabled ? t('console.connected') : t('console.offline')}
+              </span>
+              <span className="text-[11px] text-content-tertiary">·</span>
+              <span className="flex items-center gap-1 text-[11px] font-mono text-content-tertiary tracking-wider">
+                {agent.metadata?.has_power_password === 'true' && <Lock size={9} />}
+                {agent.id}
               </span>
             </div>
           </div>

--- a/dashboard/src/components/AgentTerminal.tsx
+++ b/dashboard/src/components/AgentTerminal.tsx
@@ -384,7 +384,7 @@ export function AgentTerminal({ agents, selectedAgent, onSelectAgent, onRefresh,
               onClick={() => importRef.current?.click()}
               disabled={pendingImport !== null || isImporting}
               aria-label={t('import_config')}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold text-content-tertiary hover:text-brand hover:bg-brand/10 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold whitespace-nowrap shrink-0 text-content-tertiary hover:text-brand hover:bg-brand/10 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Upload size={14} /> {t('import_config')}
             </button>
@@ -515,14 +515,10 @@ export function AgentTerminal({ agents, selectedAgent, onSelectAgent, onRefresh,
                     </div>
 
                     {/* Divider + Actions */}
-                    <div className="mt-2 pt-2 border-t border-edge-subtle flex items-center justify-between">
-                      <span className="text-[9px] text-content-tertiary font-mono">
-                        {agent.metadata?.has_power_password === 'true' && <Lock size={8} className="inline mr-1" />}
-                        {agent.id}
-                      </span>
-                      <div className="flex items-center gap-2">
+                    <div className="mt-2 pt-2 border-t border-edge-subtle flex items-center gap-x-3 gap-y-2 flex-wrap">
+                      <div className="flex items-center gap-1 flex-wrap ml-auto justify-end">
                         <button
-                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold text-brand hover:bg-brand/10 transition-all"
+                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold whitespace-nowrap shrink-0 text-brand hover:bg-brand/10 transition-all"
                           aria-label={t('chat')}
                           onClick={(e) => {
                             e.stopPropagation();
@@ -533,7 +529,7 @@ export function AgentTerminal({ agents, selectedAgent, onSelectAgent, onRefresh,
                         </button>
                         {agent.id !== DEFAULT_AGENT_ID && (
                           <button
-                            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold text-content-tertiary hover:text-brand hover:bg-brand/10 transition-all"
+                            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold whitespace-nowrap shrink-0 text-content-tertiary hover:text-brand hover:bg-brand/10 transition-all"
                             aria-label={t('export_config')}
                             onClick={(e) => {
                               e.stopPropagation();
@@ -544,7 +540,7 @@ export function AgentTerminal({ agents, selectedAgent, onSelectAgent, onRefresh,
                           </button>
                         )}
                         <button
-                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold text-content-tertiary hover:text-brand hover:bg-brand/10 transition-all"
+                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold whitespace-nowrap shrink-0 text-content-tertiary hover:text-brand hover:bg-brand/10 transition-all"
                           aria-label={t('config')}
                           onClick={(e) => {
                             e.stopPropagation();
@@ -556,7 +552,7 @@ export function AgentTerminal({ agents, selectedAgent, onSelectAgent, onRefresh,
                         </button>
                         {agent.id !== DEFAULT_AGENT_ID && (
                           <button
-                            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold text-content-tertiary hover:text-red-500 hover:bg-red-500/10 transition-all"
+                            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold whitespace-nowrap shrink-0 text-content-tertiary hover:text-red-500 hover:bg-red-500/10 transition-all"
                             aria-label={tc('delete')}
                             onClick={(e) => {
                               e.stopPropagation();


### PR DESCRIPTION
## Summary

UI polish for the agent list cards and the agent console header (all CSS/markup only).

### 1. Action button labels no longer crush
The card footer buttons (チャット / エクスポート / 設定 / 🗑) wrapped their CJK labels **character-by-character** when the card narrowed, collapsing into unreadable vertical text. Each button is now `whitespace-nowrap shrink-0`, and the footer row `flex-wrap`s so **whole buttons** drop to a new line instead of the text crushing.

### 2. Buttons stay right-aligned
Replaced `justify-between` with `ml-auto` on the button group so it is pinned to the card's right edge **both** when it fits on one line and when it wraps (wrapped groups previously left-aligned, looking ragged across cards).

### 3. Agent id moved off the card
Removed the small `agent.<id>` line from each card (cleaner cards) and surfaced it on the **agent console header** status row instead: `● 接続済み · agent.<id>`. The power-password lock indicator moves with it. That status row is bumped 10px → 11px for legibility.

## Notes
- Regenerated `compiled-tailwind.css` (pre-compiled, not JIT) for the new `gap-x-3` / `gap-y-2` utilities.
- Min text size (`text-[9px]`) and min color (`text-content-tertiary`) rules respected.

## Verification
- `npx biome check` clean
- `npm run build` (tsc + vite) green
- `npx vitest run` — 45/45 green
- Verified live via Vite HMR across wide → narrow window widths (no crush, color intact, right-aligned, id relocated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)