### PR TITLE
fix: enforce per-agent access for consensus engines and tool_hint (bug-419, bug-420)

### DIFF
--- a/crates/core/src/handlers/system.rs
+++ b/crates/core/src/handlers/system.rs
@@ -811,27 +811,48 @@ impl SystemHandler {
             );
 
             if let Some(ref mcp) = self.registry.mcp_manager {
-                let result = match tokio::time::timeout(
-                    Duration::from_secs(self.tool_execution_timeout_secs),
-                    mcp.execute_tool_internal(&tool_name, final_args),
-                )
-                .await
-                {
-                    Ok(Ok(val)) => {
-                        info!(agent_id = %agent.id, tool = %tool_name, "✅ Direct tool completed");
-                        match val {
-                            serde_json::Value::String(s) => s,
-                            other => serde_json::to_string_pretty(&other).unwrap_or_default(),
+                // 🔐 Per-agent access control. `tool_hint` is supplied by an
+                // external I/O bridge, and `execute_tool_internal` resolves the
+                // tool via the global tool_index — so without this gate an agent
+                // could invoke a tool on any connected server, including ones it was
+                // never granted. Enforce the same mcp_access_control check the
+                // agentic loop applies (`execute_tool_for_agent` → check_tool_access):
+                // anything but an explicit Allow (Deny, or tool/server unknown) is
+                // refused before execution.
+                let access_allowed = matches!(
+                    mcp.check_tool_access(&agent.id, &tool_name).await,
+                    Ok(crate::db::mcp::PermissionLevel::Allow)
+                );
+                let result = if access_allowed {
+                    match tokio::time::timeout(
+                        Duration::from_secs(self.tool_execution_timeout_secs),
+                        mcp.execute_tool_internal(&tool_name, final_args),
+                    )
+                    .await
+                    {
+                        Ok(Ok(val)) => {
+                            info!(agent_id = %agent.id, tool = %tool_name, "✅ Direct tool completed");
+                            match val {
+                                serde_json::Value::String(s) => s,
+                                other => serde_json::to_string_pretty(&other).unwrap_or_default(),
+                            }
+                        }
+                        Ok(Err(e)) => {
+                            error!(agent_id = %agent.id, tool = %tool_name, error = %e, "❌ Direct tool failed");
+                            format!("Error: {e}")
+                        }
+                        Err(_) => {
+                            error!(agent_id = %agent.id, tool = %tool_name, "⏱️ Direct tool timed out");
+                            "Error: Tool execution timed out".into()
                         }
                     }
-                    Ok(Err(e)) => {
-                        error!(agent_id = %agent.id, tool = %tool_name, error = %e, "❌ Direct tool failed");
-                        format!("Error: {e}")
-                    }
-                    Err(_) => {
-                        error!(agent_id = %agent.id, tool = %tool_name, "⏱️ Direct tool timed out");
-                        "Error: Tool execution timed out".into()
-                    }
+                } else {
+                    warn!(
+                        agent_id = %agent.id,
+                        tool = %tool_name,
+                        "🚫 Direct tool denied: agent is not granted this tool's server"
+                    );
+                    format!("Error: tool '{tool_name}' is not available to this agent")
                 };
 
                 // Route result back via callback if this is an external action

--- a/crates/core/src/handlers/system.rs
+++ b/crates/core/src/handlers/system.rs
@@ -1522,6 +1522,58 @@ impl SystemHandler {
 
     // ── Consensus (in-kernel orchestration, Goal #138) ──
 
+    /// The engine servers this agent is actually assigned — i.e. its granted MCP
+    /// servers that are reasoning engines. This mirrors the dashboard's per-agent
+    /// engine model: `SetupWizard` always adds the chosen engine to the agent's
+    /// server grants, `AgentPluginWorkspace` derives `default_engine_id` from the
+    /// granted engine servers, and `AgentConsole` lists an agent's engines as its
+    /// granted engine servers. Classification matches `serverCategory.ts`
+    /// `isEngineServer` (#234): an engine is a Rust engine plugin, a legacy
+    /// `mind.*` server, or any server exposing the `think` / `think_with_tools`
+    /// tool surface.
+    async fn agent_engine_servers(&self, granted_server_ids: &[String]) -> Vec<String> {
+        let mut engines = Vec::new();
+        for id in granted_server_ids {
+            if self.is_engine_server(id).await {
+                engines.push(id.clone());
+            }
+        }
+        engines
+    }
+
+    /// True when `id` is a reasoning engine (see [`Self::agent_engine_servers`]).
+    async fn is_engine_server(&self, id: &str) -> bool {
+        if id.starts_with("mind.") || self.registry.get_engine(id).await.is_some() {
+            return true;
+        }
+        if let Some(ref mcp) = self.registry.mcp_manager {
+            return mcp
+                .has_kind_at(id, &crate::managers::ToolKind::ThinkWithTools)
+                .await
+                || mcp.has_kind_at(id, &crate::managers::ToolKind::Think).await;
+        }
+        false
+    }
+
+    /// Apply the global `CONSENSUS_ENGINES` list as a *filter* over the agent's
+    /// own engines. Empty list → pass through unchanged (consensus uses all of
+    /// the agent's engines). Non-empty → keep only agent engines whose id (modulo
+    /// the legacy `mind.` prefix, so `mind.deepseek` and `deepseek` match) appears
+    /// in the list. It can only ever *narrow* the agent's engine set — it never
+    /// adds an engine the agent was not assigned, which is what stops consensus
+    /// from running engines configured globally but not on the agent.
+    fn filter_consensus_engines(agent_engines: Vec<String>, global: &[String]) -> Vec<String> {
+        if global.is_empty() {
+            return agent_engines;
+        }
+        let norm = |s: &str| s.strip_prefix("mind.").unwrap_or(s).to_string();
+        let allow: std::collections::HashSet<String> = global.iter().map(|s| norm(s)).collect();
+        agent_engines
+            .into_iter()
+            .filter(|id| allow.contains(&norm(id)))
+            .collect()
+    }
+
     /// Run a consensus session entirely in-kernel.
     ///
     /// Every configured engine runs concurrently through the same
@@ -1546,7 +1598,14 @@ impl SystemHandler {
         trace_id: ClotoId,
     ) {
         let cfg = &self.consensus_config;
-        let engines = &self.consensus_engines;
+        // Engines are sourced from *this agent's* assigned engine servers, not the
+        // global `CONSENSUS_ENGINES` env. The global list, when set, only filters
+        // that per-agent set down (see `filter_consensus_engines`). Previously the
+        // global list ran on every agent regardless of its configuration, so
+        // consensus could run engines the agent was never assigned.
+        let agent_engines = self.agent_engine_servers(granted_server_ids).await;
+        let engines_owned = Self::filter_consensus_engines(agent_engines, &self.consensus_engines);
+        let engines = &engines_owned;
         let min_proposals = cfg.min_proposals;
         let phase_timeout = Duration::from_secs(cfg.session_timeout_secs);
 
@@ -1560,7 +1619,7 @@ impl SystemHandler {
         // Fail-safe: not enough engines configured to ever reach quorum.
         if engines.len() < min_proposals {
             let detail = format!(
-                "Consensus needs at least {min_proposals} proposals but only {} engine(s) are configured (CONSENSUS_ENGINES).",
+                "Consensus needs at least {min_proposals} engines assigned to this agent but only {} is/are available (grant more engine servers, or widen the CONSENSUS_ENGINES filter).",
                 engines.len()
             );
             warn!(trace_id = %trace_id, "{detail}");
@@ -3822,6 +3881,66 @@ impl SystemHandler {
         if let Err(e) = self.sender.send(envelope).await {
             warn!("⚠️ Failed to emit observability event: {}", e);
         }
+    }
+}
+
+#[cfg(test)]
+mod consensus_engine_filter_tests {
+    //! Unit tests for the global `CONSENSUS_ENGINES` filter over an agent's own
+    //! engine set. The agent-engine *discovery* (`agent_engine_servers` /
+    //! `is_engine_server`) depends on the live registry / MCP manager and is
+    //! exercised end-to-end in `tests/consensus_test.rs`; here we pin the pure
+    //! filtering / normalization logic.
+    use super::*;
+
+    fn ids(xs: &[&str]) -> Vec<String> {
+        xs.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn empty_global_passes_agent_engines_through() {
+        let agent = ids(&["deepseek", "mind.local"]);
+        assert_eq!(
+            SystemHandler::filter_consensus_engines(agent.clone(), &[]),
+            agent,
+            "an empty CONSENSUS_ENGINES means: use all of the agent's engines"
+        );
+    }
+
+    #[test]
+    fn global_intersects_and_drops_non_agent_engines() {
+        // Agent is assigned deepseek + mind.local; the global list also names an
+        // engine the agent is NOT assigned (cerebras) — it must be dropped, not
+        // run. This is the core of the fix.
+        let agent = ids(&["deepseek", "mind.local"]);
+        let global = ids(&["mind.deepseek", "mind.cerebras"]);
+        assert_eq!(
+            SystemHandler::filter_consensus_engines(agent, &global),
+            ids(&["deepseek"]),
+            "only the agent's own engines that also appear in the global list survive"
+        );
+    }
+
+    #[test]
+    fn normalizes_mind_prefix_on_both_sides() {
+        // `mind.deepseek` (global) ↔ `deepseek` (granted) and `mind.local` ↔
+        // `mind.local` must both match.
+        let agent = ids(&["deepseek", "mind.local"]);
+        let global = ids(&["mind.deepseek", "mind.local"]);
+        assert_eq!(
+            SystemHandler::filter_consensus_engines(agent.clone(), &global),
+            agent
+        );
+    }
+
+    #[test]
+    fn global_with_no_overlap_yields_empty() {
+        let agent = ids(&["deepseek"]);
+        let global = ids(&["mind.cerebras"]);
+        assert!(
+            SystemHandler::filter_consensus_engines(agent, &global).is_empty(),
+            "a global filter that names none of the agent's engines selects nothing"
+        );
     }
 }
 

--- a/crates/core/tests/consensus_test.rs
+++ b/crates/core/tests/consensus_test.rs
@@ -33,8 +33,16 @@ use tokio::sync::mpsc;
 /// detached synthetic id.
 const ORIGINATING_AGENT_ID: &str = "agent.test";
 
+/// Build a consensus handler whose engine set is driven by **the agent's own
+/// grants**, the way production resolves it. `granted_engines` are engine server
+/// ids granted to the originating agent (each becomes a `server_grant` row, so
+/// `run_consensus` discovers them via `get_granted_server_ids` and classifies
+/// them as engines — `mind.*` ids qualify by prefix without a live MCP server).
+/// `global_filter` is the `CONSENSUS_ENGINES` env value, now only a *filter* over
+/// that per-agent set (empty = no filter).
 async fn build_handler(
-    engines: Vec<String>,
+    granted_engines: Vec<String>,
+    global_filter: Vec<String>,
 ) -> (
     SystemHandler,
     mpsc::Receiver<cloto_core::EnvelopedEvent>,
@@ -52,6 +60,26 @@ async fn build_handler(
         .await
         .unwrap();
 
+    // Grant the requested engine servers to the agent (the per-agent engine
+    // assignment consensus now sources from). The server row must exist first —
+    // `mcp_access_control.server_id` is a FK onto `mcp_servers(name)`.
+    for engine in &granted_engines {
+        sqlx::query("INSERT INTO mcp_servers (name, command, created_at) VALUES (?, 'noop', 0)")
+            .bind(engine)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO mcp_access_control (entry_type, agent_id, server_id, permission, granted_at) \
+             VALUES ('server_grant', ?, ?, 'allow', 't0')",
+        )
+        .bind(agent_id)
+        .bind(engine)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
     let registry = Arc::new(PluginRegistry::new(5, 10, 50));
     let agent_manager = AgentManager::new(pool.clone(), 90_000);
     let (event_tx, event_rx) = mpsc::channel(64);
@@ -64,7 +92,7 @@ async fn build_handler(
         event_tx,
         10, // memory_context_limit
         metrics,
-        engines,
+        global_filter,
         "consensus:".to_string(),
         16, // max_agentic_iterations
         30, // tool_execution_timeout_secs
@@ -160,11 +188,11 @@ async fn assert_response_persisted(pool: &SqlitePool, expected_substring: &str) 
     );
 }
 
-/// Fewer engines configured than `min_proposals` (default 2) → immediate
-/// fail-safe response, no engine ever runs, no ConsensusProgress steps.
+/// The agent is assigned fewer engines than `min_proposals` (default 2) →
+/// immediate fail-safe response, no engine ever runs, no ConsensusProgress steps.
 #[tokio::test]
 async fn consensus_too_few_engines_emits_single_failsafe_persisted() {
-    let (handler, mut rx, pool) = build_handler(vec!["mind.alpha".to_string()]).await;
+    let (handler, mut rx, pool) = build_handler(vec!["mind.alpha".to_string()], vec![]).await;
 
     handler.handle_message(consensus_msg()).await.unwrap();
 
@@ -184,14 +212,18 @@ async fn consensus_too_few_engines_emits_single_failsafe_persisted() {
     assert_response_persisted(&pool, "[Consensus unavailable]").await;
 }
 
-/// Enough engines configured but none are registered/resolvable → every
-/// proposal loop errors → quorum is not reached → fail-safe response. Proves
-/// the kernel never hangs, each engine surfaces a ConsensusProgress step with an
-/// MGP §14 error code (SERVER_NOT_READY), and the error is delivered to chat.
+/// The agent is assigned enough engines but none are registered/resolvable →
+/// every proposal loop errors → quorum is not reached → fail-safe response.
+/// Proves the kernel never hangs, each engine surfaces a ConsensusProgress step
+/// with an MGP §14 error code (SERVER_NOT_READY), and the error is delivered to
+/// chat.
 #[tokio::test]
 async fn consensus_all_engines_unavailable_quorum_failsafe_mgp_errors() {
-    let (handler, mut rx, pool) =
-        build_handler(vec!["mind.alpha".to_string(), "mind.beta".to_string()]).await;
+    let (handler, mut rx, pool) = build_handler(
+        vec!["mind.alpha".to_string(), "mind.beta".to_string()],
+        vec![],
+    )
+    .await;
 
     handler.handle_message(consensus_msg()).await.unwrap();
 
@@ -246,4 +278,38 @@ async fn consensus_all_engines_unavailable_quorum_failsafe_mgp_errors() {
     }
 
     assert_response_persisted(&pool, "[Consensus failed]").await;
+}
+
+/// Regression (the fix): a non-empty global `CONSENSUS_ENGINES` whose engines the
+/// agent is **not** granted must NOT run. Previously the global list ran on every
+/// agent regardless of its configuration; now engines are sourced from the
+/// agent's own grants, with the global list acting only as a filter. With no
+/// engine grants the agent has zero consensus engines → immediate
+/// `[Consensus unavailable]`, and crucially **no engine ever runs** (no
+/// ConsensusProgress steps), proving the global list alone can no longer drive a
+/// proposal under an agent that was never assigned those engines.
+#[tokio::test]
+async fn consensus_ignores_global_engines_not_granted_to_agent() {
+    let (handler, mut rx, pool) = build_handler(
+        vec![],                                                  // agent is granted no engines
+        vec!["mind.alpha".to_string(), "mind.beta".to_string()], // but the global env lists two
+    )
+    .await;
+
+    handler.handle_message(consensus_msg()).await.unwrap();
+
+    let events = drain(&mut rx);
+    let content = assert_single_terminal_response(&events);
+    assert!(
+        content.contains("[Consensus unavailable]"),
+        "an agent with no engine grants must get the unavailable fail-safe even when \
+         CONSENSUS_ENGINES is set, got: {content}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, ClotoEventData::ConsensusProgress { .. })),
+        "no engine may run for an agent that was not granted any consensus engine"
+    );
+    assert_response_persisted(&pool, "[Consensus unavailable]").await;
 }

--- a/crates/core/tests/tool_hint_access_test.rs
+++ b/crates/core/tests/tool_hint_access_test.rs
@@ -1,0 +1,118 @@
+//! Regression test for the `tool_hint` direct-execution access-control gate
+//! (bug-420).
+//!
+//! `tool_hint` is supplied by an external I/O bridge (e.g. a Discord backtick
+//! command) and lets the kernel run a tool without going through the agentic
+//! loop. `execute_tool_internal` resolves the tool via the GLOBAL tool index, so
+//! without a per-agent check an agent could invoke a tool on any connected
+//! server — including one it was never granted. The fix gates the path with the
+//! same `check_tool_access` the agentic loop uses (`execute_tool_for_agent`):
+//! anything but an explicit Allow is refused *before* execution.
+//!
+//! Here we assert the denial: an agent that is not granted a tool gets the
+//! "not available to this agent" refusal (which only the access gate emits —
+//! before the fix the path would have reached execute_tool_internal and
+//! returned a generic "tool not found"). The granted/allowed path runs the tool
+//! and is exercised end-to-end against the live app (it needs a connected MCP
+//! server) and by the agentic loop's existing permission tests.
+
+use cloto_core::handlers::system::SystemHandler;
+use cloto_core::managers::{AgentManager, McpClientManager, PluginRegistry};
+use cloto_shared::{ClotoEventData, ClotoMessage, MessageSource};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+const AGENT_ID: &str = "agent.test";
+
+async fn build_handler() -> (SystemHandler, mpsc::Receiver<cloto_core::EnvelopedEvent>) {
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO agents (id, name, description, status, default_engine_id, required_capabilities, metadata, enabled) VALUES (?, 'Test Agent', 'Desc', 'online', 'engine.test', '[]', '{}', 1)")
+        .bind(AGENT_ID)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // A real (in-process) MCP manager so the tool_hint branch is taken and
+    // check_tool_access runs. yolo off so the default opt-in policy denies an
+    // ungranted tool.
+    let mcp = Arc::new(McpClientManager::new(pool.clone(), false, 120, 30));
+    let mut registry = PluginRegistry::new(5, 10, 50);
+    registry.set_mcp_manager(mcp);
+    let registry = Arc::new(registry);
+
+    let agent_manager = AgentManager::new(pool.clone(), 90_000);
+    let (event_tx, event_rx) = mpsc::channel(64);
+    let metrics = Arc::new(cloto_core::managers::SystemMetrics::new());
+
+    let handler = SystemHandler::new(
+        registry,
+        agent_manager,
+        AGENT_ID.to_string(),
+        event_tx,
+        10,
+        metrics,
+        vec![],
+        "consensus:".to_string(),
+        16,
+        30,
+        Arc::new(dashmap::DashMap::new()),
+        Arc::new(dashmap::DashMap::new()),
+        pool.clone(),
+        Arc::new(dashmap::DashMap::new()),
+        5,
+        false,
+    );
+    (handler, event_rx)
+}
+
+fn tool_hint_msg(tool: &str) -> ClotoMessage {
+    let mut metadata = HashMap::new();
+    metadata.insert("tool_hint".to_string(), tool.to_string());
+    // A callback so the result is surfaced as an ExternalAction event we can read.
+    metadata.insert("external_callback_id".to_string(), "cb1".to_string());
+    metadata.insert("external_action_id".to_string(), "a1".to_string());
+    metadata.insert("external_source".to_string(), "discord".to_string());
+    ClotoMessage {
+        id: cloto_shared::ClotoId::new().to_string(),
+        source: MessageSource::User {
+            id: "discord:u1".into(),
+            name: "User".into(),
+        },
+        target_agent: Some(AGENT_ID.to_string()),
+        content: "`secret_tool`".to_string(),
+        timestamp: chrono::Utc::now(),
+        metadata,
+    }
+}
+
+/// An agent that is not granted a tool's server must be refused by the
+/// access gate before execution — even via the tool_hint bypass.
+#[tokio::test]
+async fn tool_hint_denies_ungranted_tool() {
+    let (handler, mut rx) = build_handler().await;
+
+    handler
+        .handle_message(tool_hint_msg("secret_tool"))
+        .await
+        .unwrap();
+
+    let response = {
+        let mut found = None;
+        while let Ok(env) = rx.try_recv() {
+            if let ClotoEventData::ExternalAction { response, .. } = &env.event.data {
+                found = response.clone();
+                break;
+            }
+        }
+        found.expect("tool_hint execution must surface an ExternalAction result")
+    };
+
+    assert!(
+        response.contains("not available to this agent"),
+        "an ungranted tool_hint must be refused by the access gate before execution, got: {response}"
+    );
+}

--- a/docs/MCP_CAPABILITY_GATE_DESIGN.md
+++ b/docs/MCP_CAPABILITY_GATE_DESIGN.md
@@ -1,0 +1,203 @@
+# MCP Capability Gate — Unified Per-Agent Access Enforcement
+
+Status: **Proposed** (design only; not yet implemented)
+Scope: ClotoCore kernel access control (`crates/core`)
+Related bugs: bug-419 (consensus engines), bug-420 (tool_hint bypass), engine-not-gated (LM Studio repro)
+
+## 1. Problem
+
+Per-agent access control in ClotoCore is enforced at **several scattered
+execution sites with inconsistent logic** — some gated, some not. The
+permission *data model* is already unified (`mcp_access_control` +
+`resolve_tool_access`), but *enforcement* is fragmented, which makes the
+effective policy **non-deterministic** (whether an agent may use a server
+depends on which code path reaches the server) and **redundant** (the same
+"can agent A use server S?" decision is re-implemented per call site).
+
+Observed consequences:
+
+- **Engine is never access-checked.** An agent's reasoning engine
+  (`default_engine_id`, a `mind.*` MCP server) is resolved globally via
+  `get_engine` / `has_server` with no grant check, so an agent with **zero
+  grants still runs its engine and responds** (LM Studio repro). Engines are
+  MCP servers but are treated as outside access control.
+- **tool_hint bypass** (bug-420, point-fixed): the bridge-supplied direct-tool
+  path called `execute_tool_internal` without a grant check.
+- **Consensus** (bug-419, point-fixed): ran a global engine list under every
+  agent regardless of the agent's granted engines.
+- **Delegation** (`run_mgp_agent_ask_loop`): executes engine-requested tools via
+  `call_server_tool` with no per-agent check.
+- **Empty-grant branch**: the agentic loop falls back to the ungated
+  `registry.execute_tool` when `agent_plugin_ids` is empty.
+
+### Current enforcement sites (the fragmentation)
+
+| Path | Current check | State |
+| --- | --- | --- |
+| Agentic loop — tool presentation | `collect_tool_schemas_for_agent` per-tool `resolve_tool_access` | gate (presentation) |
+| Agentic loop — membership | `tool_names.contains` | gate (depends on presented set) |
+| Agentic loop — execution | `execute_tool_for_agent` → `check_tool_access` | gate |
+| Agentic loop — empty-grant branch | `registry.execute_tool` | **ungated** |
+| tool_hint direct execution | (bug-420) `check_tool_access` added | bolt-on gate |
+| Delegation (`run_mgp_agent_ask_loop`) | `call_server_tool` direct | **ungated** |
+| Engine think / think_with_tools | `get_engine` / `has_server` (global) | **ungated** |
+| `/api/mcp/call` | auth only | separate axis |
+
+## 2. Key insight: the data model is already unified
+
+- All capabilities — reasoning **engines** (`mind.*`), **tools**, **memory**
+  servers — are MCP servers registered in `mcp_servers` and grantable through
+  `mcp_access_control` (`server_grant` / `tool_grant`) with a per-server
+  `default_policy`.
+- `resolve_tool_access(agent_id, server_id, tool_name)` already resolves the
+  full 3-level precedence (`tool_grant > server_grant > default_policy`) **by
+  `server_id`** — so it works uniformly for engines, tools, and memory. (Note:
+  `check_tool_access` resolves the server *via the global tool_index*, which
+  does **not** index `mind.*` engine-internal tools; `resolve_tool_access` takes
+  `server_id` directly and therefore covers engines too.)
+
+So unification requires **no new permission concept**. "Engine config" is not a
+separate permission system; an engine is just an MCP server that today is not
+enforced. The fix is to route **all** execution through one gate that consults
+the existing `resolve_tool_access`.
+
+## 3. Design: a single deterministic chokepoint
+
+All execution — tools, engine `think` / `think_with_tools`, delegation,
+tool_hint, `/api/mcp/call` — ultimately flows through
+`McpClientManager::call_server_tool` (and its streaming sibling
+`call_server_tool_streaming`). These are the **single lowest chokepoint** and,
+critically, they already hold the resolved `server_id` — the exact key
+`resolve_tool_access` needs.
+
+### 3.1 Caller identity
+
+Thread a caller identity into the chokepoint:
+
+```rust
+enum Caller {
+    /// Subject to per-agent access control.
+    Agent(String),         // agent_id
+    /// Trusted internal caller — bypasses the grant gate.
+    /// (kernel-native tools, the consensus synthesizer, coordinator /api callers)
+    System,
+}
+
+async fn call_server_tool(
+    &self,
+    caller: Caller,
+    server_id: &str,
+    tool_name: &str,
+    args: Value,
+) -> Result<Value, ToolFailure>;
+```
+
+Gate (the only enforcement of the **grant/access** axis):
+
+```
+match caller {
+    Caller::Agent(id) => match resolve_tool_access(id, server_id, tool_name) {
+        Allow   => proceed,
+        Deny    => Err(Rejection::access_denied),
+        Err(e)  => Err(Rejection::access_check_failed),
+    },
+    Caller::System => proceed,   // trusted internal
+}
+```
+
+Because the gate keys on `server_id`, **engines are covered for free**: engine
+execution is routed with `Caller::Agent(agent.id)` and the agent's
+`default_engine_id` (a `mind.*` server) is checked via `server_grant` /
+`default_policy` exactly like any other server. An agent with no engine grant
+no longer responds.
+
+### 3.2 Orthogonal axes stay distinct (policy vs data)
+
+The grant/access axis is **data** (DB rows). The MCP permission model has other,
+**orthogonal** axes that must be *composed* at the chokepoint as distinct
+ordered stages — **not flattened into the grant check** (mixing policy into the
+access-data resolution is the same anti-pattern as baking routing into a data
+layer):
+
+| Axis | Question | Nature |
+| --- | --- | --- |
+| grant / access (`resolve_tool_access`) | May this agent use this server? | **data** — unified here |
+| YOLO / SafetyGate | Is this operation dangerous (agent-independent)? | policy |
+| Approval (`pending_approvals`) | Does a human need to confirm? | policy (human-in-loop) |
+| Delegation intersection | Effective caller = caller ∩ target | caller transform |
+
+The chokepoint becomes a single deterministic **ordered pipeline** with **one
+audit point** — but each stage remains a separate evaluator.
+
+### 3.3 What stays
+
+Presentation-layer filtering (`collect_tool_schemas_for_agent`) is **kept** for
+UX / token budget (which tools the LLM is shown), but it is **no longer the
+enforcement boundary** — "shown" and "allowed" are decoupled and enforcement is
+single-sourced.
+
+## 4. Redundancy removed
+
+Once the chokepoint enforces uniformly, these collapse:
+
+- `execute_tool_for_agent`'s inline `check_tool_access` branch → moves to the gate.
+- The agentic loop's `if agent_plugin_ids.is_empty() { execute_tool (ungated) } else { execute_tool_for_agent }` two-branch → single path.
+- The bolt-on `check_tool_access` in the tool_hint path (bug-420) → **removed** (subsumed by the central gate; the point-fix was interim).
+- `tool_names` membership used as *enforcement* → demoted to presentation only.
+- Delegation loop's unchecked execution → covered by the same gate.
+- Engine resolution's missing check → covered by the same gate.
+
+## 5. Caller threading & exemptions
+
+- **Agentic loop / normal message path / tool_hint / consensus engines**:
+  `Caller::Agent(agent.id)`.
+- **Consensus synthesizer** (`agent.synthesizer`, system agent): `Caller::System`
+  (it is a kernel-internal merge step, not a user agent).
+- **Kernel-native tools** (`mgp.*`, `gui.*`): keep the existing `server_id="kernel"`
+  RBAC (Deny-only) — represented as a `System`/kernel path or a dedicated kernel
+  gate; do not route through `resolve_tool_access` server grants.
+- **`/api/mcp/call` coordinator endpoint**: already auth-gated; map the
+  authenticated caller to `Caller::System` (or a coordinator agent id if one is
+  carried), preserving today's behavior.
+
+## 6. Open decision: `default_policy = opt-out`
+
+Migration `20260301000000_default_policy_opt_out.sql` set all servers'
+`default_policy` to `opt-out` (allow-all). With that default, **revoking a grant
+(deleting the `server_grant` row) falls back to allow** — so revoke does not
+actually deny. This is a **policy default**, separate from the enforcement
+unification. To make revoke effective, choose one:
+
+- (a) Engines / sensitive servers default to `opt-in` (deny-by-default), or
+- (b) "Reject" writes an explicit `Deny` entry rather than deleting the grant, or
+- (c) Both.
+
+This decision is independent of the chokepoint work and should be made
+deliberately (it changes existing deployments' effective access).
+
+## 7. Rollout / behavior change
+
+Enforcing the engine grant is a **behavior change**: an agent with no granted
+engine stops responding. Agents created through SetupWizard always grant their
+chosen engine, so well-formed agents are unaffected; agents created by other
+paths (tests, raw API) that set `default_engine_id` without a grant will need a
+grant. Consider a one-time backfill (grant each agent's current
+`default_engine_id` as a `server_grant`) and/or a clear "no engine assigned"
+error surfaced to chat.
+
+## 8. Test plan
+
+- Unit: the gate denies `Caller::Agent` for an ungranted server (engine, tool,
+  memory) and allows `Caller::System`.
+- Integration: a zero-grant agent cannot get an engine response (the LM Studio
+  repro), but the same agent with its engine granted responds.
+- Regression: bug-419 / bug-420 scenarios remain closed via the single gate.
+- Delegation: a delegated agent cannot execute tools on servers it is not granted.
+
+## 9. Relation to the point-fixes
+
+bug-419 (consensus engine sourcing) and bug-420 (tool_hint gate) are already
+fixed as targeted patches. This chokepoint **subsumes and simplifies** them: the
+tool_hint inline check is removed, and consensus engine filtering keeps using
+the agent's granted engine servers as its source. The point-fixes are safe
+interim measures; the chokepoint is the durable, deterministic design.

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -3349,6 +3349,20 @@
       "fixed_in": "0.6.8-beta.1",
       "fix_note": "run_consensus now sources engines from the agent's own granted engine servers via agent_engine_servers() (filtering get_granted_server_ids by is_engine_server — mind.* prefix OR get_engine OR think/think_with_tools tool surface, matching dashboard serverCategory.ts isEngineServer / #234). The global CONSENSUS_ENGINES is demoted to an optional filter (filter_consensus_engines): empty = use all of the agent's engines, non-empty = intersect (mind. prefix normalized), never adding an engine the agent is not assigned. The direct `let engines = &self.consensus_engines;` is removed. Covered by consensus_engine_filter_tests (unit: empty passthrough / intersection / mind-prefix normalization / no-overlap) and consensus_ignores_global_engines_not_granted_to_agent (integration regression: a global list with engines the agent is not granted runs nothing).",
       "notes": "User-reported 2026-06-30 ('consensus supports engines not configured on the agent'). Fix direction ratified by user: engines sourced from agent grants, CONSENSUS_ENGINES as filter (empty = all agent engines). Behavior note: with CONSENSUS_ENGINES empty, an agent granted >= min_proposals engine servers can now activate consensus on the 'consensus:' prefix (the prior additive-default G6 'empty = off' is intentionally relaxed). Cross-ref bug-417 (delivery) / bug-418 (unregistered-engine example) / docs/CONSENSUS_REVIVAL_DESIGN.md."
+    },
+    {
+      "id": "bug-420",
+      "summary": "HIGH: The tool_hint direct-execution path bypassed per-agent MCP access control — an agent could invoke a tool on any connected server, including ones it was never granted. An external I/O bridge (e.g. a Discord backtick command) supplies metadata.tool_hint; SystemHandler::handle_message ran it via mcp.execute_tool_internal(tool_name, args) WITHOUT a check_tool_access / resolve_tool_access gate. execute_tool_internal resolves the tool through the GLOBAL tool_index, so any connected server's tool is reachable by name regardless of the requesting agent's mcp_access_control grants. The agentic loop gates tool calls (tool_names membership + execute_tool_for_agent -> check_tool_access), but the tool_hint bypass did not — so an agent could use an ungranted MCP server via a bridge-supplied tool_hint.",
+      "severity": "HIGH",
+      "discovered": "2026-06-30T13:21:13Z",
+      "version": "0.6.8-beta.1",
+      "file": "crates/core/src/handlers/system.rs",
+      "pattern": "check_tool_access\\(&agent\\.id, &tool_name\\)",
+      "expected": "present",
+      "status": "fixed",
+      "fixed_in": "0.6.8-beta.1",
+      "fix_note": "The tool_hint path now calls mcp.check_tool_access(&agent.id, &tool_name) before execute_tool_internal and refuses anything but an explicit Allow (Deny, or tool/server unknown) with 'tool not available to this agent' — mirroring the agentic loop's execute_tool_for_agent -> check_tool_access gate. Covered by tests/tool_hint_access_test.rs (ungranted tool_hint denied before execution). Granted/allowed path is exercised against the live app and by the agentic loop's existing permission tests.",
+      "notes": "User-reported 2026-06-30 ('an agent can use an MCP server it is not registered/granted for'); confirmed path = tool_hint direct execution. Related: bug-419 (consensus engines), bug-173/174 (kernel-side tool validation / anti-spoofing). Follow-up (separate, not time-based): the mgp.agent.ask delegation loop (run_mgp_agent_ask_loop, mcp_kernel_tool.rs ~1824) executes engine tool calls via call_server_tool without a per-agent check_tool_access — tracked for a future hardening pass."
     }
   ]
 }

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -3335,6 +3335,20 @@
       "status": "open",
       "notes": "Belongs with Task #114 (config defaults/docs/marketing). Fix options: (a) change the example to two reliably-registered engines, (b) document that CONSENSUS_ENGINES entries must be registered mind.* engine servers and how to register a provider as one, and/or (c) emit a clearer boot/runtime warning when a CONSENSUS_ENGINES id has no resolvable engine server. Surfacing the dropped-engine reason to the user also depends on bug-417 (right now even the '[Consensus failed] 1/2' message is invisible).",
       "github_issue": 233
+    },
+    {
+      "id": "bug-419",
+      "summary": "MEDIUM: Consensus ran the global CONSENSUS_ENGINES list on every agent, ignoring per-agent engine configuration, so it executed engines the requesting agent was never assigned. SystemHandler::run_consensus took `let engines = &self.consensus_engines;` directly — a kernel-wide Vec<String> from the CONSENSUS_ENGINES env (config.rs) wired once in lib.rs — and ran each via run_agentic_loop under the originating agent, with engine resolution only checking global registration (get_engine / mcp.has_server), never whether the engine is one of the agent's granted engine servers. An agent assigned engines A+B would still have unrelated global engine C run under its identity, and the #232 engine-reuse fallback could mask a misconfigured/unregistered global engine. Decoupled from the dashboard's per-agent engine model (SetupWizard always grants the chosen engine; AgentConsole lists an agent's engines as its granted engine servers).",
+      "severity": "MEDIUM",
+      "discovered": "2026-06-30T13:00:41Z",
+      "version": "0.6.8-beta.1",
+      "file": "crates/core/src/handlers/system.rs",
+      "pattern": "let engines = &self\\.consensus_engines;",
+      "expected": "absent",
+      "status": "fixed",
+      "fixed_in": "0.6.8-beta.1",
+      "fix_note": "run_consensus now sources engines from the agent's own granted engine servers via agent_engine_servers() (filtering get_granted_server_ids by is_engine_server — mind.* prefix OR get_engine OR think/think_with_tools tool surface, matching dashboard serverCategory.ts isEngineServer / #234). The global CONSENSUS_ENGINES is demoted to an optional filter (filter_consensus_engines): empty = use all of the agent's engines, non-empty = intersect (mind. prefix normalized), never adding an engine the agent is not assigned. The direct `let engines = &self.consensus_engines;` is removed. Covered by consensus_engine_filter_tests (unit: empty passthrough / intersection / mind-prefix normalization / no-overlap) and consensus_ignores_global_engines_not_granted_to_agent (integration regression: a global list with engines the agent is not granted runs nothing).",
+      "notes": "User-reported 2026-06-30 ('consensus supports engines not configured on the agent'). Fix direction ratified by user: engines sourced from agent grants, CONSENSUS_ENGINES as filter (empty = all agent engines). Behavior note: with CONSENSUS_ENGINES empty, an agent granted >= min_proposals engine servers can now activate consensus on the 'consensus:' prefix (the prior additive-default G6 'empty = off' is intentionally relaxed). Cross-ref bug-417 (delivery) / bug-418 (unregistered-engine example) / docs/CONSENSUS_REVIVAL_DESIGN.md."
     }
   ]
 }


### PR DESCRIPTION
Per-agent access-control hardening: two targeted fixes plus the design doc for
the durable unification that subsumes them.

## bug-419 (MEDIUM) — consensus sourced engines from the global env, not the agent
`run_consensus` ran the kernel-wide `CONSENSUS_ENGINES` list under every agent,
ignoring per-agent engine configuration, so consensus could execute engines the
requesting agent was never assigned. Engines are now sourced from the agent's
own granted engine servers (`agent_engine_servers` / `is_engine_server`, matching
the dashboard's `serverCategory.ts` model), with `CONSENSUS_ENGINES` demoted to
an optional filter (empty = all of the agent's engines; non-empty = intersect).

## bug-420 (HIGH) — tool_hint direct-execution bypassed access control
The bridge-supplied `tool_hint` path ran tools via `execute_tool_internal`
(global tool_index) with no per-agent check, so an agent could invoke a tool on
any connected server it was never granted. It now goes through
`check_tool_access` before execution and refuses anything but an explicit Allow,
mirroring the agentic loop's gate.

## docs — MCP capability-gate design (Proposed)
`docs/MCP_CAPABILITY_GATE_DESIGN.md` describes collapsing the scattered
enforcement into a single deterministic chokepoint at `call_server_tool`,
consulting the existing `resolve_tool_access` uniformly for engines, tools, and
memory. It subsumes these point-fixes and closes the still-open engine-not-gated
hole (a zero-grant agent currently still runs its engine and responds). Tracked
by CScheduler Goal #140.

## Behavior change
With an empty `CONSENSUS_ENGINES`, an agent granted >= `min_proposals` engine
servers can now activate consensus on the prefix (the prior additive-default
"empty = off" is intentionally relaxed). Tool_hint denies ungranted tools.

## Tests
- `consensus_engine_filter_tests` (unit: passthrough / intersection / mind-prefix normalization / no-overlap)
- `consensus_ignores_global_engines_not_granted_to_agent` (integration regression)
- `tool_hint_access_test` (ungranted tool_hint refused before execution)
- Full suite green; fmt + CI-exact clippy clean; `verify-issues.sh` reports bug-419 [FIXED], bug-420 [VERIFIED].

🤖 Generated with [Claude Code](https://claude.com/claude-code)