### PR TITLE
fix(security): unify per-agent MCP access behind a single capability gate (bug-421)

### DIFF
--- a/crates/core/migrations/20260701000000_capability_gate_opt_in_backfill.sql
+++ b/crates/core/migrations/20260701000000_capability_gate_opt_in_backfill.sql
@@ -1,0 +1,65 @@
+-- Capability gate (bug-421): make per-agent MCP access deterministic.
+--
+-- Two coupled changes ship together with the code-level single capability gate
+-- (managers/mcp.rs enforce_caller_grant / enforce_kernel_rbac):
+--
+--   1. Flip every server back to opt-in (deny-by-default). Under the prior
+--      opt-out default, revoking a grant (deleting the row) fell back to allow,
+--      and an agent that was never granted an engine still ran it. opt-in makes
+--      both cases deny correctly: grant => allow, no grant => deny, revoke =
+--      delete => deny.
+--   2. Backfill each agent's reasoning engine as an explicit server_grant, so
+--      agents that relied on the implicit opt-out allow-all for their engine
+--      keep working — now with an explicit, auditable, revocable grant
+--      (implicit -> explicit). Agents with no engine and no grant (the bug being
+--      fixed) correctly lose access.
+
+-- 1. Global opt-in flip. Does NOT touch the 'kernel' row (already opt-in): its
+--    default is special-cased to Allow in code (Deny-only RBAC), so kernel-native
+--    tools are not turned into deny-by-default by this flip.
+UPDATE mcp_servers SET default_policy = 'opt-in' WHERE default_policy = 'opt-out';
+
+-- 2. Engine backfill — FK-safe, non-clobbering, and PREFIX-AWARE.
+--    The runtime engine resolver (handlers/system.rs, bug-396) strips a leading
+--    'mind.' from default_engine_id when only the de-prefixed MCP server is
+--    registered, and the capability gate then checks that de-prefixed server_id.
+--    So the grant must target the server name the runtime will ACTUALLY use:
+--    prefer default_engine_id when a server row matches it, else its de-prefixed
+--    ('mind.' stripped) form. The CASE only ever yields a name that EXISTS in
+--    mcp_servers (guaranteed by the WHERE clause), so the FK (foreign_keys=ON)
+--    is satisfied and the migration cannot abort; granted_at is NOT NULL and is
+--    supplied; the NOT EXISTS guard (matching the resolved name, allow OR deny)
+--    never clobbers an existing grant.
+INSERT INTO mcp_access_control (entry_type, agent_id, server_id, permission, granted_by, granted_at)
+SELECT
+    'server_grant',
+    a.id,
+    CASE
+        WHEN EXISTS (SELECT 1 FROM mcp_servers s WHERE s.name = a.default_engine_id)
+            THEN a.default_engine_id
+        ELSE substr(a.default_engine_id, 6)   -- strip leading 'mind.' (5 chars)
+    END,
+    'allow',
+    'migration:capability-gate',
+    datetime('now')
+FROM agents a
+WHERE a.default_engine_id IS NOT NULL
+  AND a.default_engine_id != ''
+  AND (
+        EXISTS (SELECT 1 FROM mcp_servers s WHERE s.name = a.default_engine_id)
+        OR (
+            a.default_engine_id LIKE 'mind.%'
+            AND EXISTS (SELECT 1 FROM mcp_servers s WHERE s.name = substr(a.default_engine_id, 6))
+        )
+      )
+  AND NOT EXISTS (
+        SELECT 1 FROM mcp_access_control ac
+        WHERE ac.agent_id = a.id
+          AND ac.server_id = CASE
+                WHEN EXISTS (SELECT 1 FROM mcp_servers s WHERE s.name = a.default_engine_id)
+                    THEN a.default_engine_id
+                ELSE substr(a.default_engine_id, 6)
+              END
+          AND ac.entry_type = 'server_grant'
+          AND ac.tool_name IS NULL
+      );

--- a/crates/core/src/db/mcp.rs
+++ b/crates/core/src/db/mcp.rs
@@ -510,12 +510,21 @@ pub async fn delete_access_entry(
 
 /// Resolve tool access for an agent.
 /// Priority: tool_grant > server_grant > default_policy
-pub async fn resolve_tool_access(
+/// Resolve only the **explicit** grant for `(agent, server, tool)` — the
+/// `tool_grant > server_grant` precedence — *without* falling back to the
+/// server's `default_policy`. Returns `None` when no explicit entry exists, so
+/// the caller decides the default.
+///
+/// Used by (a) [`resolve_tool_access`] for the data axis (which then applies
+/// `default_policy`), and (b) the kernel-native Deny-only RBAC, which must treat
+/// the *absence* of an explicit deny as Allow — never inheriting a server's
+/// opt-in `default_policy` as a deny (bug-421 kernel special-case).
+pub async fn resolve_explicit_permission(
     pool: &SqlitePool,
     agent_id: &str,
     server_id: &str,
     tool_name: &str,
-) -> anyhow::Result<PermissionLevel> {
+) -> anyhow::Result<Option<PermissionLevel>> {
     // 1. Check for explicit tool_grant
     let tool_grant = db_timeout(
         sqlx::query_scalar::<_, String>(
@@ -532,10 +541,11 @@ pub async fn resolve_tool_access(
     .await?;
 
     if let Some(ref perm) = tool_grant {
-        if perm == "allow" {
-            return Ok(PermissionLevel::Allow);
-        }
-        return Ok(PermissionLevel::Deny);
+        return Ok(Some(if perm == "allow" {
+            PermissionLevel::Allow
+        } else {
+            PermissionLevel::Deny
+        }));
     }
 
     // 2. Check for server_grant
@@ -553,10 +563,25 @@ pub async fn resolve_tool_access(
     .await?;
 
     if let Some(ref perm) = server_grant {
-        if perm == "allow" {
-            return Ok(PermissionLevel::Allow);
-        }
-        return Ok(PermissionLevel::Deny);
+        return Ok(Some(if perm == "allow" {
+            PermissionLevel::Allow
+        } else {
+            PermissionLevel::Deny
+        }));
+    }
+
+    Ok(None)
+}
+
+pub async fn resolve_tool_access(
+    pool: &SqlitePool,
+    agent_id: &str,
+    server_id: &str,
+    tool_name: &str,
+) -> anyhow::Result<PermissionLevel> {
+    // 1+2. Explicit tool_grant / server_grant take precedence.
+    if let Some(perm) = resolve_explicit_permission(pool, agent_id, server_id, tool_name).await? {
+        return Ok(perm);
     }
 
     // 3. Fall back to server default_policy

--- a/crates/core/src/handlers.rs
+++ b/crates/core/src/handlers.rs
@@ -448,7 +448,13 @@ async fn call_memory_tool_with_fallback(
 ) -> AppResult<Json<serde_json::Value>> {
     match state
         .mcp_manager
-        .call_capability_tool(crate::managers::CapabilityType::Memory, tool, args, None)
+        .call_capability_tool(
+            &crate::managers::Caller::System,
+            crate::managers::CapabilityType::Memory,
+            tool,
+            args,
+            None,
+        )
         .await
     {
         Ok(result) => ok_data(parse_mcp_tool_result(&result).unwrap_or(fallback)),
@@ -481,6 +487,7 @@ pub async fn get_memories(
     let mut data = match state
         .mcp_manager
         .call_capability_tool(
+            &crate::managers::Caller::System,
             crate::managers::CapabilityType::Memory,
             "list_memories",
             args,
@@ -595,6 +602,7 @@ pub async fn delete_memory(
     let result = state
         .mcp_manager
         .call_capability_tool(
+            &crate::managers::Caller::System,
             crate::managers::CapabilityType::Memory,
             "delete_memory",
             args,
@@ -616,6 +624,7 @@ pub async fn delete_episode(
     let result = state
         .mcp_manager
         .call_capability_tool(
+            &crate::managers::Caller::System,
             crate::managers::CapabilityType::Memory,
             "delete_episode",
             args,
@@ -662,6 +671,7 @@ pub async fn import_memories(
     let result = state
         .mcp_manager
         .call_capability_tool(
+            &crate::managers::Caller::System,
             crate::managers::CapabilityType::Memory,
             "import_memories",
             args,
@@ -723,6 +733,7 @@ pub async fn update_memory(
     let result = state
         .mcp_manager
         .call_capability_tool(
+            &crate::managers::Caller::System,
             crate::managers::CapabilityType::Memory,
             "update_memory",
             args,
@@ -753,7 +764,13 @@ pub async fn lock_memory(
         let args = serde_json::json!({ "memory_id": id });
         let result = state
             .mcp_manager
-            .call_capability_tool(cap, "lock_memory", args, None)
+            .call_capability_tool(
+                &crate::managers::Caller::System,
+                cap,
+                "lock_memory",
+                args,
+                None,
+            )
             .await
             .map_err(AppError::Internal)?;
         let mut data = parse_mcp_tool_result(&result).unwrap_or(serde_json::json!({}));
@@ -799,7 +816,13 @@ pub async fn unlock_memory(
         let args = serde_json::json!({ "memory_id": id });
         let result = state
             .mcp_manager
-            .call_capability_tool(cap, "unlock_memory", args, None)
+            .call_capability_tool(
+                &crate::managers::Caller::System,
+                cap,
+                "unlock_memory",
+                args,
+                None,
+            )
             .await
             .map_err(AppError::Internal)?;
         let mut data = parse_mcp_tool_result(&result).unwrap_or(serde_json::json!({}));
@@ -858,7 +881,13 @@ pub async fn set_recall_precision(
     let args = serde_json::json!({ "agent_id": id, "precision": body.precision });
     let result = state
         .mcp_manager
-        .call_capability_tool(cap, "set_recall_precision", args, None)
+        .call_capability_tool(
+            &crate::managers::Caller::System,
+            cap,
+            "set_recall_precision",
+            args,
+            None,
+        )
         .await
         .map_err(AppError::Internal)?;
     ok_data(parse_mcp_tool_result(&result).unwrap_or(serde_json::json!({})))
@@ -895,7 +924,13 @@ pub async fn get_recall_precision(
     let args = serde_json::json!({ "agent_id": id });
     let result = state
         .mcp_manager
-        .call_capability_tool(cap, "get_recall_precision", args, None)
+        .call_capability_tool(
+            &crate::managers::Caller::System,
+            cap,
+            "get_recall_precision",
+            args,
+            None,
+        )
         .await
         .map_err(AppError::Internal)?;
     ok_data(parse_mcp_tool_result(&result).unwrap_or(serde_json::json!({})))

--- a/crates/core/src/handlers/agents.rs
+++ b/crates/core/src/handlers/agents.rs
@@ -334,9 +334,13 @@ pub async fn delete_agent(
     // Clean up CPersona memory data (best-effort, don't fail the delete)
     if let Some(ref mem_server) = memory_server_id {
         let args = serde_json::json!({ "agent_id": id });
+        // Kernel cleanup of a now-deleted agent's memory: the agent row (and its
+        // grants) are gone after `delete_agent` above, so this must run as System
+        // — a `Caller::Agent(id)` check would resolve to Deny and skip cleanup.
         match state
             .mcp_manager
             .call_kind_at(
+                &crate::managers::Caller::System,
                 mem_server,
                 &crate::managers::ToolKind::DeleteAgentData,
                 args,
@@ -498,7 +502,7 @@ pub async fn upload_avatar(
         // Graceful degradation: bounded wait for vision model load + inference.
         if let Ok(result) = tokio::time::timeout(
             std::time::Duration::from_secs(AVATAR_ANALYSIS_TIMEOUT_SECS),
-            analyze_avatar(&state, &avatar_path_str),
+            analyze_avatar(&state, &id, &avatar_path_str),
         )
         .await
         {
@@ -526,7 +530,10 @@ pub async fn upload_avatar(
 
 /// Analyze avatar image via Vision capability MCP server.
 /// Returns None if vision server is unavailable or analysis fails.
-async fn analyze_avatar(state: &AppState, avatar_path: &str) -> Option<String> {
+/// `agent_id` is the avatar's owning agent; the call runs under its identity so
+/// the central capability gate enforces the same per-agent Vision grant that the
+/// caller pre-flighted via `resolve_tool_access`.
+async fn analyze_avatar(state: &AppState, agent_id: &str, avatar_path: &str) -> Option<String> {
     let abs_path = std::env::current_dir()
         .ok()?
         .join(avatar_path)
@@ -544,6 +551,7 @@ async fn analyze_avatar(state: &AppState, avatar_path: &str) -> Option<String> {
     match state
         .mcp_manager
         .call_capability_tool(
+            &crate::managers::Caller::Agent(agent_id.to_string()),
             crate::managers::CapabilityType::Vision,
             "analyze_image",
             args,

--- a/crates/core/src/handlers/llm.rs
+++ b/crates/core/src/handlers/llm.rs
@@ -117,6 +117,7 @@ pub async fn set_llm_provider_model(
         tokio::spawn(async move {
             match mcp_mgr
                 .call_server_tool(
+                    &crate::managers::Caller::System,
                     &server_id,
                     &tool_name,
                     serde_json::json!({ "model": model_owned }),

--- a/crates/core/src/handlers/mcp.rs
+++ b/crates/core/src/handlers/mcp.rs
@@ -884,9 +884,17 @@ pub async fn call_mcp_tool(
         )));
     }
 
+    // Admin-authenticated coordinator endpoint → System. Per-agent scoping for
+    // this path flows only through an `_mgp.delegation` envelope (original_actor),
+    // handled inside resolve_tool_call_target, not a body agent_id.
     let result = state
         .mcp_manager
-        .call_server_tool(&body.server_id, &body.tool_name, body.arguments)
+        .call_server_tool(
+            &crate::managers::Caller::System,
+            &body.server_id,
+            &body.tool_name,
+            body.arguments,
+        )
         .await
         .map_err(
             |e| match e.downcast::<crate::managers::mcp_mgp::MgpError>() {

--- a/crates/core/src/handlers/system.rs
+++ b/crates/core/src/handlers/system.rs
@@ -701,6 +701,7 @@ impl SystemHandler {
             match tokio::time::timeout(
                 Duration::from_secs(self.memory_timeout_secs),
                 mcp.call_kind_at(
+                    &crate::managers::Caller::Agent(agent.id.clone()),
                     server_id,
                     &crate::managers::ToolKind::Recall,
                     mcp_recall_payload,
@@ -811,48 +812,38 @@ impl SystemHandler {
             );
 
             if let Some(ref mcp) = self.registry.mcp_manager {
-                // 🔐 Per-agent access control. `tool_hint` is supplied by an
-                // external I/O bridge, and `execute_tool_internal` resolves the
-                // tool via the global tool_index — so without this gate an agent
-                // could invoke a tool on any connected server, including ones it was
-                // never granted. Enforce the same mcp_access_control check the
-                // agentic loop applies (`execute_tool_for_agent` → check_tool_access):
-                // anything but an explicit Allow (Deny, or tool/server unknown) is
-                // refused before execution.
-                let access_allowed = matches!(
-                    mcp.check_tool_access(&agent.id, &tool_name).await,
-                    Ok(crate::db::mcp::PermissionLevel::Allow)
-                );
-                let result = if access_allowed {
-                    match tokio::time::timeout(
-                        Duration::from_secs(self.tool_execution_timeout_secs),
-                        mcp.execute_tool_internal(&tool_name, final_args),
-                    )
-                    .await
-                    {
-                        Ok(Ok(val)) => {
-                            info!(agent_id = %agent.id, tool = %tool_name, "✅ Direct tool completed");
-                            match val {
-                                serde_json::Value::String(s) => s,
-                                other => serde_json::to_string_pretty(&other).unwrap_or_default(),
-                            }
-                        }
-                        Ok(Err(e)) => {
-                            error!(agent_id = %agent.id, tool = %tool_name, error = %e, "❌ Direct tool failed");
-                            format!("Error: {e}")
-                        }
-                        Err(_) => {
-                            error!(agent_id = %agent.id, tool = %tool_name, "⏱️ Direct tool timed out");
-                            "Error: Tool execution timed out".into()
+                // 🔐 Per-agent capability gate (bug-420 / bug-421). `tool_hint`
+                // is supplied by an external I/O bridge and bypasses the agentic
+                // loop, but it now runs through the SAME central gate inside
+                // `execute_tool_internal` under `Caller::Agent(agent.id)` — an
+                // ungranted tool/server is refused before execution, identically
+                // to the agentic loop. The previous bug-420 bolt-on
+                // `check_tool_access` is removed (subsumed by the chokepoint).
+                let result = match tokio::time::timeout(
+                    Duration::from_secs(self.tool_execution_timeout_secs),
+                    mcp.execute_tool_internal(
+                        &crate::managers::Caller::Agent(agent.id.clone()),
+                        &tool_name,
+                        final_args,
+                    ),
+                )
+                .await
+                {
+                    Ok(Ok(val)) => {
+                        info!(agent_id = %agent.id, tool = %tool_name, "✅ Direct tool completed");
+                        match val {
+                            serde_json::Value::String(s) => s,
+                            other => serde_json::to_string_pretty(&other).unwrap_or_default(),
                         }
                     }
-                } else {
-                    warn!(
-                        agent_id = %agent.id,
-                        tool = %tool_name,
-                        "🚫 Direct tool denied: agent is not granted this tool's server"
-                    );
-                    format!("Error: tool '{tool_name}' is not available to this agent")
+                    Ok(Err(e)) => {
+                        warn!(agent_id = %agent.id, tool = %tool_name, error = %e, "🚫 Direct tool refused/failed");
+                        format!("Error: {e}")
+                    }
+                    Err(_) => {
+                        error!(agent_id = %agent.id, tool = %tool_name, "⏱️ Direct tool timed out");
+                        "Error: Tool execution timed out".into()
+                    }
                 };
 
                 // Route result back via callback if this is an external action
@@ -1111,6 +1102,7 @@ impl SystemHandler {
                             let _ = tokio::time::timeout(
                                 mem_timeout2,
                                 mcp_clone.call_kind_at(
+                                    &crate::managers::Caller::Agent(agent_id_clone.clone()),
                                     &server_id_clone,
                                     &crate::managers::ToolKind::Store,
                                     store_args,
@@ -1290,8 +1282,11 @@ impl SystemHandler {
                             tokio::spawn(async move {
                                 match tokio::time::timeout(
                                     Duration::from_secs(timeout_secs),
-                                    mcp_clone
-                                        .call_kind(&crate::managers::ToolKind::Speak, speak_args),
+                                    mcp_clone.call_kind(
+                                        &crate::managers::Caller::Agent(agent_id_clone.clone()),
+                                        &crate::managers::ToolKind::Speak,
+                                        speak_args,
+                                    ),
                                 )
                                 .await
                                 {
@@ -1496,6 +1491,7 @@ impl SystemHandler {
             let memory_timeout = Duration::from_secs(self.memory_timeout_secs);
 
             tokio::spawn(async move {
+                let store_caller = crate::managers::Caller::Agent(agent_id.clone());
                 let store_args = serde_json::json!({
                     "agent_id": agent_id,
                     "message": msg_json,
@@ -1503,7 +1499,12 @@ impl SystemHandler {
                 });
                 match tokio::time::timeout(
                     memory_timeout,
-                    mcp.call_kind_at(&server_id, &crate::managers::ToolKind::Store, store_args),
+                    mcp.call_kind_at(
+                        &store_caller,
+                        &server_id,
+                        &crate::managers::ToolKind::Store,
+                        store_args,
+                    ),
                 )
                 .await
                 {
@@ -2510,22 +2511,21 @@ impl SystemHandler {
                             );
                         }
 
+                        // Single gated path (bug-421): always route through
+                        // execute_tool_for_agent. The previous
+                        // `if agent_plugin_ids.is_empty()` branch fell back to the
+                        // UNGATED registry.execute_tool; the collapse closes that
+                        // hole — Rust plugins are filtered by allowed_plugin_ids
+                        // and the MCP fallback is gated by Caller::Agent(agent.id)
+                        // inside the central chokepoint.
                         let tool_result = tokio::time::timeout(
                             Duration::from_secs(self.tool_execution_timeout_secs),
-                            async {
-                                if agent_plugin_ids.is_empty() {
-                                    self.registry.execute_tool(&call.name, safe_args).await
-                                } else {
-                                    self.registry
-                                        .execute_tool_for_agent(
-                                            agent_plugin_ids,
-                                            &agent.id,
-                                            &call.name,
-                                            safe_args,
-                                        )
-                                        .await
-                                }
-                            },
+                            self.registry.execute_tool_for_agent(
+                                agent_plugin_ids,
+                                &agent.id,
+                                &call.name,
+                                safe_args,
+                            ),
                         )
                         .await;
 
@@ -2713,6 +2713,20 @@ impl SystemHandler {
 
     // ── Engine Dispatch Helpers (Rust Plugin / MCP Dual Dispatch) ──
 
+    /// Map an agent to its capability-gate [`Caller`] (bug-421). System agents
+    /// — currently only the consensus synthesizer (`agent_type == "system"`,
+    /// `system.rs` synth_agent) — are trusted kernel-internal callers and bypass
+    /// the per-agent grant gate; every real agent is gated as `Agent(id)`. The
+    /// discriminator is `agent_type`, NOT the id (the synthesizer's id
+    /// `agent.synthesizer` differs from `cfg.synthetic_agent_id`).
+    fn caller_for(agent: &AgentMetadata) -> crate::managers::Caller {
+        if agent.agent_type == "system" {
+            crate::managers::Caller::System
+        } else {
+            crate::managers::Caller::Agent(agent.id.clone())
+        }
+    }
+
     /// Call engine's think() — routes to either Rust plugin or MCP server.
     async fn engine_think(
         &self,
@@ -2749,7 +2763,12 @@ impl SystemHandler {
                 "context": context_val,
             });
             let result = mcp
-                .call_kind_at(engine_id, &crate::managers::ToolKind::Think, args)
+                .call_kind_at(
+                    &Self::caller_for(agent),
+                    engine_id,
+                    &crate::managers::ToolKind::Think,
+                    args,
+                )
                 .await?;
             self.maybe_record_usage(&agent.id, engine_id, &result).await;
             return Self::extract_mcp_think_content(&result);
@@ -2829,7 +2848,12 @@ impl SystemHandler {
                 "tool_history": tool_history,
             });
             let result = mcp
-                .call_kind_at(engine_id, &crate::managers::ToolKind::ThinkWithTools, args)
+                .call_kind_at(
+                    &Self::caller_for(agent),
+                    engine_id,
+                    &crate::managers::ToolKind::ThinkWithTools,
+                    args,
+                )
                 .await?;
             self.maybe_record_usage(&agent.id, engine_id, &result).await;
             return Self::parse_mcp_think_result(&result);
@@ -2885,7 +2909,12 @@ impl SystemHandler {
         });
 
         let (mut chunk_rx, result_rx) = mcp
-            .call_kind_streaming_at(engine_id, &crate::managers::ToolKind::ThinkWithTools, args)
+            .call_kind_streaming_at(
+                &Self::caller_for(agent),
+                engine_id,
+                &crate::managers::ToolKind::ThinkWithTools,
+                args,
+            )
             .await?;
 
         // Fan chunk deltas onto the event bus as `AgentTokenStream`. The
@@ -3088,8 +3117,14 @@ impl SystemHandler {
                 )
             });
 
+            // Kernel-side media preprocessing of an inbound message (not an
+            // agent-initiated tool call) → System.
             match mcp
-                .call_kind(&crate::managers::ToolKind::AnalyzeImage, args)
+                .call_kind(
+                    &crate::managers::Caller::System,
+                    &crate::managers::ToolKind::AnalyzeImage,
+                    args,
+                )
                 .await
             {
                 Ok(result) => {
@@ -3198,8 +3233,14 @@ impl SystemHandler {
                 "file_path": abs_path,
             });
 
+            // Kernel-side media preprocessing of an inbound message (not an
+            // agent-initiated tool call) → System.
             match mcp
-                .call_kind(&crate::managers::ToolKind::Transcribe, args)
+                .call_kind(
+                    &crate::managers::Caller::System,
+                    &crate::managers::ToolKind::Transcribe,
+                    args,
+                )
                 .await
             {
                 Ok(result) => {
@@ -3544,10 +3585,15 @@ impl SystemHandler {
         engine_id: &str,
         memory_timeout: Duration,
     ) {
+        // All memory/episode/profile/engine calls below operate on this agent's
+        // own data and run under its identity (bug-421).
+        let caller = crate::managers::Caller::Agent(agent_id.to_string());
+
         // 1. Fetch recent memories
         let Ok(Ok(mem_result)) = tokio::time::timeout(
             memory_timeout,
             mcp.call_kind_at(
+                &caller,
                 server_id,
                 &crate::managers::ToolKind::ListMemories,
                 serde_json::json!({"agent_id": agent_id, "limit": TOOL_USAGE_THRESHOLD + 5}),
@@ -3570,6 +3616,7 @@ impl SystemHandler {
         let Ok(Ok(ep_result)) = tokio::time::timeout(
             memory_timeout,
             mcp.call_kind_at(
+                &caller,
                 server_id,
                 &crate::managers::ToolKind::ListEpisodes,
                 serde_json::json!({"agent_id": agent_id, "limit": 1}),
@@ -3646,6 +3693,7 @@ impl SystemHandler {
                 think_timeout,
                 Self::call_engine_think_simple(
                     mcp,
+                    &caller,
                     engine_id,
                     &format!(
                         "Summarize the following conversation concisely (800-1200 characters).\n\
@@ -3673,6 +3721,7 @@ impl SystemHandler {
                 think_timeout,
                 Self::call_engine_think_simple(
                     mcp,
+                    &caller,
                     engine_id,
                     &format!(
                         "Extract 5-10 search keywords from this summary. \
@@ -3691,6 +3740,7 @@ impl SystemHandler {
                 think_timeout,
                 Self::call_engine_think_simple(
                     mcp,
+                    &caller,
                     engine_id,
                     &format!(
                         "Based on this conversation summary, was the main task completed? \
@@ -3722,6 +3772,7 @@ impl SystemHandler {
 
             match mcp
                 .call_kind_at(
+                    &caller,
                     server_id,
                     &crate::managers::ToolKind::ArchiveEpisode,
                     archive_args,
@@ -3768,6 +3819,7 @@ impl SystemHandler {
 
         let existing_profile = mcp
             .call_kind_at(
+                &caller,
                 server_id,
                 &crate::managers::ToolKind::Custom("get_profile".to_string()),
                 serde_json::json!({"agent_id": agent_id}),
@@ -3782,6 +3834,7 @@ impl SystemHandler {
             think_timeout,
             Self::call_engine_think_simple(
                 mcp,
+                &caller,
                 engine_id,
                 &format!(
                     "Extract facts about the user from the following conversation.\n\
@@ -3807,6 +3860,7 @@ impl SystemHandler {
         if let Some(profile) = new_profile {
             match mcp
                 .call_kind_at(
+                    &caller,
                     server_id,
                     &crate::managers::ToolKind::UpdateProfile,
                     serde_json::json!({"agent_id": agent_id, "profile": profile}),
@@ -3840,8 +3894,12 @@ impl SystemHandler {
 
     /// Call a mind engine's `think` tool with a simple prompt (no agent context).
     /// Used for background tasks like profile extraction and episode summarization.
+    /// `caller` carries the owning agent's identity so the engine think is gated
+    /// by that agent's grant (bug-421) — background maintenance still runs under
+    /// the agent whose episodes are being summarized.
     async fn call_engine_think_simple(
         mcp: &Arc<McpClientManager>,
+        caller: &crate::managers::Caller,
         engine_id: &str,
         prompt: &str,
         system_desc: &str,
@@ -3860,7 +3918,7 @@ impl SystemHandler {
             "context": [],
         });
         match mcp
-            .call_kind_at(engine_id, &crate::managers::ToolKind::Think, args)
+            .call_kind_at(caller, engine_id, &crate::managers::ToolKind::Think, args)
             .await
         {
             Ok(result) => Self::extract_mcp_think_content(&result).ok(),

--- a/crates/core/src/managers/mcp.rs
+++ b/crates/core/src/managers/mcp.rs
@@ -25,6 +25,27 @@ use tracing::{debug, error, info, warn};
 /// Approver identity used for YOLO-mode auto-approved permissions.
 const YOLO_APPROVER_ID: &str = "YOLO";
 
+/// Identity of the caller requesting a tool / engine execution, threaded into
+/// the two execution chokepoints (PATH 1 = [`McpClientManager::resolve_tool_call_target`],
+/// PATH 2 = [`McpClientManager::execute_tool_internal`]) so the per-agent
+/// capability gate ([`McpClientManager::enforce_caller_grant`]) is enforced
+/// uniformly (bug-421).
+///
+/// There is deliberately **no `Default` impl**: every execution site must make
+/// an explicit, reviewed choice between [`Caller::Agent`] and [`Caller::System`].
+/// A site that forgets to thread a caller fails to compile — that compile error
+/// is the safety net against a silent access-control bypass.
+#[derive(Debug, Clone)]
+pub enum Caller {
+    /// A user agent — subject to per-agent access control via
+    /// [`crate::db::resolve_tool_access`]. The `String` is the `agent_id`.
+    Agent(String),
+    /// A trusted kernel-internal caller (kernel-native tool dispatch, the
+    /// consensus synthesizer, the coordinator `/api/mcp/call` endpoint,
+    /// post-connect model syncs). Bypasses the per-agent grant gate.
+    System,
+}
+
 // ============================================================
 // McpClientManager — kernel-level MCP server orchestrator
 // ============================================================
@@ -1478,6 +1499,7 @@ impl McpClientManager {
                     let model = provider.model_id.clone();
                     match self
                         .call_server_tool(
+                            &Caller::System,
                             "mind.ollama",
                             "switch_model",
                             serde_json::json!({ "model": model }),
@@ -1687,7 +1709,12 @@ impl McpClientManager {
         let state = self.state.read().await;
         let mut schemas = if self.yolo_mode.load(Ordering::Relaxed) {
             // L2: Filter kernel tools by per-agent RBAC (server_id="kernel").
-            // Default is Allow; only explicit Deny entries block a tool.
+            // Default is Allow; only an EXPLICIT Deny grant blocks a tool. This
+            // MUST use resolve_explicit_permission (NOT resolve_tool_access),
+            // matching enforce_kernel_rbac (bug-421): resolve_tool_access would
+            // fall back to the 'kernel' row's default_policy (opt-in → Deny),
+            // which would diverge from enforcement and hide kernel tools the gate
+            // actually allows.
             let mut filtered = Vec::new();
             for schema in super::mcp_kernel_tool::kernel_tool_schemas() {
                 let name = schema
@@ -1696,8 +1723,9 @@ impl McpClientManager {
                     .and_then(|n| n.as_str())
                     .unwrap_or("");
                 let denied = matches!(
-                    crate::db::resolve_tool_access(&self.pool, agent_id, "kernel", name).await,
-                    Ok(crate::db::mcp::PermissionLevel::Deny)
+                    crate::db::resolve_explicit_permission(&self.pool, agent_id, "kernel", name)
+                        .await,
+                    Ok(Some(crate::db::mcp::PermissionLevel::Deny))
                 );
                 if !denied {
                     filtered.push(schema);
@@ -1783,18 +1811,16 @@ impl McpClientManager {
         crate::db::resolve_tool_access(&self.pool, agent_id, &server_id, tool_name).await
     }
 
-    /// Execute a tool by name with optional caller context for audit/permission logging.
-    /// Delegates to `execute_tool_internal` after recording the caller.
+    /// Execute a tool by name under the given [`Caller`]. Thin wrapper over
+    /// [`Self::execute_tool_internal`] (which applies the capability gate).
     pub async fn execute_tool(
         &self,
+        caller: &Caller,
         tool_name: &str,
         args: Value,
-        caller: Option<&str>,
     ) -> std::result::Result<Value, ToolFailure> {
-        if let Some(agent_id) = caller {
-            debug!(tool = %tool_name, caller = %agent_id, "Tool execution requested");
-        }
-        self.execute_tool_internal(tool_name, args).await
+        debug!(tool = %tool_name, ?caller, "Tool execution requested");
+        self.execute_tool_internal(caller, tool_name, args).await
     }
 
     /// Execute a tool by name, routing to the correct MCP server (kernel-internal).
@@ -1807,9 +1833,20 @@ impl McpClientManager {
     #[allow(clippy::too_many_lines)]
     pub(crate) async fn execute_tool_internal(
         &self,
+        caller: &Caller,
         tool_name: &str,
         args: Value,
     ) -> std::result::Result<Value, ToolFailure> {
+        // ──── Capability gate (bug-421, PATH 2) ────
+        // Kernel-native tools (mgp.*/gui.*) use Deny-only RBAC (default Allow);
+        // the non-kernel per-agent grant gate runs after server_id resolution
+        // below (it needs the resolved server_id). System bypasses both.
+        if Self::is_kernel_native_tool(tool_name) {
+            self.enforce_kernel_rbac(caller, tool_name)
+                .await
+                .map_err(ToolFailure::from)?;
+        }
+
         // Kernel-native tools
         match tool_name {
             "mgp.kernel.create_mcp_server" => {
@@ -1920,6 +1957,14 @@ impl McpClientManager {
             })?;
             (server_id, client)
         };
+
+        // ──── Per-agent capability gate (bug-421, PATH 2, non-kernel) ────
+        // Reached only for non-kernel MCP tools (kernel-native tools early-return
+        // in the match above). `server_id` is now resolved, so gate before the
+        // validator / dispatch. System bypasses.
+        self.enforce_caller_grant(caller, &server_id, tool_name)
+            .await
+            .map_err(ToolFailure::from)?;
 
         // ──── Kernel-side Validation (A): Validate tool arguments before forwarding ────
         if let Some(validator_name) = super::mcp_tool_validator::get_kernel_validator(tool_name) {
@@ -2042,20 +2087,116 @@ impl McpClientManager {
         }
     }
 
+    /// Per-agent capability gate (bug-421) — the single enforcement of the
+    /// grant/access axis, shared by both execution chokepoints (PATH 1 =
+    /// [`Self::resolve_tool_call_target`], PATH 2 = [`Self::execute_tool_internal`]).
+    ///
+    /// [`Caller::System`] is a trusted kernel-internal caller and bypasses the
+    /// gate. [`Caller::Agent`]`(id)` is checked against
+    /// `resolve_tool_access(id, server_id, tool_name)`; anything but an explicit
+    /// `Allow` (i.e. `Deny`, or a resolution error) is refused **before**
+    /// execution. Because the check keys on `server_id`, reasoning engines
+    /// (`mind.*` and bare-named MCP servers), tools, and memory servers are all
+    /// gated uniformly — there is no separate "engine config" permission concept.
+    async fn enforce_caller_grant(
+        &self,
+        caller: &Caller,
+        server_id: &str,
+        tool_name: &str,
+    ) -> Result<()> {
+        let agent_id = match caller {
+            Caller::System => return Ok(()),
+            Caller::Agent(id) => id,
+        };
+        match crate::db::resolve_tool_access(&self.pool, agent_id, server_id, tool_name).await {
+            Ok(crate::db::mcp::PermissionLevel::Allow) => Ok(()),
+            Ok(crate::db::mcp::PermissionLevel::Deny) => {
+                warn!(
+                    agent_id = %agent_id,
+                    server = %server_id,
+                    tool = %tool_name,
+                    "🔒 capability gate: access denied (bug-421)"
+                );
+                Err(mcp_mgp::MgpError::access_denied(format!(
+                    "Access denied: agent '{agent_id}' is not granted '{tool_name}' on server '{server_id}'"
+                ))
+                .into())
+            }
+            Err(e) => {
+                warn!(
+                    agent_id = %agent_id,
+                    server = %server_id,
+                    tool = %tool_name,
+                    error = %e,
+                    "🔒 capability gate: access check failed (bug-421)"
+                );
+                Err(mcp_mgp::MgpError::access_denied(format!(
+                    "Access check failed for agent '{agent_id}' on '{server_id}.{tool_name}': {e}"
+                ))
+                .into())
+            }
+        }
+    }
+
+    /// Whether `tool_name` is a kernel-native tool (dispatched by the
+    /// `mgp.` / `gui.` prefix inside [`Self::execute_tool_internal`]).
+    fn is_kernel_native_tool(tool_name: &str) -> bool {
+        tool_name.starts_with("mgp.") || tool_name.starts_with("gui.")
+    }
+
+    /// Kernel-native RBAC (bug-421). Kernel-internal tools (`mgp.*` / `gui.*`)
+    /// default to **Allow** and are blocked only by an EXPLICIT `Deny` grant on
+    /// the synthetic `"kernel"` server — the server's `default_policy` is never
+    /// consulted (via [`crate::db::resolve_explicit_permission`]), so the §6
+    /// global opt-in flip cannot turn kernel tools into deny-by-default. This is
+    /// the code-level "kernel default-Allow special-case" (博士 decision
+    /// 2026-07-01). [`Caller::System`] bypasses.
+    async fn enforce_kernel_rbac(&self, caller: &Caller, tool_name: &str) -> Result<()> {
+        let agent_id = match caller {
+            Caller::System => return Ok(()),
+            Caller::Agent(id) => id,
+        };
+        if matches!(
+            crate::db::resolve_explicit_permission(&self.pool, agent_id, "kernel", tool_name)
+                .await?,
+            Some(crate::db::mcp::PermissionLevel::Deny)
+        ) {
+            warn!(
+                agent_id = %agent_id,
+                tool = %tool_name,
+                "🔒 kernel RBAC: explicit deny (bug-421)"
+            );
+            return Err(mcp_mgp::MgpError::access_denied(format!(
+                "Access denied: agent '{agent_id}' cannot use kernel tool '{tool_name}'"
+            ))
+            .into());
+        }
+        Ok(())
+    }
+
     /// Execute a tool on a specific server by server ID and tool name.
-    /// Applies kernel-side validation (A) and delegation checks (§5.6)
-    /// before forwarding to the MCP server.
+    /// Applies the per-agent capability gate (bug-421), kernel-side validation
+    /// (A), and delegation checks (§5.6) before forwarding to the MCP server.
     #[allow(clippy::too_many_lines)]
     /// Resolve the target McpClient for a tool call and run all pre-dispatch
-    /// gating (§5.6 delegation chain, handle lookup, kernel-side arg
-    /// validation). Shared by the non-streaming and streaming call paths so
-    /// that both enforce identical security policy.
+    /// gating (caller capability gate, §5.6 delegation chain, handle lookup,
+    /// kernel-side arg validation). Shared by the non-streaming and streaming
+    /// call paths so that both enforce identical security policy.
     async fn resolve_tool_call_target(
         &self,
+        caller: &Caller,
         server_id: &str,
         tool_name: &str,
         args: &Value,
     ) -> Result<Arc<McpClient>> {
+        // ──── Per-agent capability gate (bug-421, PATH 1) ────
+        // `server_id` is final on entry (no rewrite occurs below), so gating
+        // here covers both call_server_tool and call_server_tool_streaming.
+        // Runs BEFORE the §5.6 delegation intersection, which is a distinct,
+        // orthogonal stage keyed on `original_actor` (not the immediate caller).
+        self.enforce_caller_grant(caller, server_id, tool_name)
+            .await?;
+
         // ──── §5.6 Delegation Check ────
         // If _mgp.delegation is present, verify chain depth ≤ 3, actor validity,
         // anti-spoofing (§5.6.3), and permission intersection (§5.6.1).
@@ -2181,12 +2322,13 @@ impl McpClientManager {
 
     pub async fn call_server_tool(
         &self,
+        caller: &Caller,
         server_id: &str,
         tool_name: &str,
         args: Value,
     ) -> Result<super::mcp_protocol::CallToolResult> {
         let client = self
-            .resolve_tool_call_target(server_id, tool_name, &args)
+            .resolve_tool_call_target(caller, server_id, tool_name, &args)
             .await?;
         client.call_tool(tool_name, args).await
     }
@@ -2205,6 +2347,7 @@ impl McpClientManager {
     /// is identical between the two paths.
     pub async fn call_server_tool_streaming(
         &self,
+        caller: &Caller,
         server_id: &str,
         tool_name: &str,
         args: Value,
@@ -2213,7 +2356,7 @@ impl McpClientManager {
         tokio::sync::oneshot::Receiver<Result<super::mcp_protocol::CallToolResult>>,
     )> {
         let client = self
-            .resolve_tool_call_target(server_id, tool_name, &args)
+            .resolve_tool_call_target(caller, server_id, tool_name, &args)
             .await?;
         client.call_tool_streaming(tool_name, args).await
     }
@@ -2483,6 +2626,7 @@ impl McpClientManager {
     /// it takes precedence over automatic resolution.
     pub async fn call_capability_tool(
         &self,
+        caller: &Caller,
         capability: super::capability_dispatcher::CapabilityType,
         tool_name: &str,
         args: Value,
@@ -2503,7 +2647,8 @@ impl McpClientManager {
                     )
                 })?
         };
-        self.call_server_tool(&server_id, tool_name, args).await
+        self.call_server_tool(caller, &server_id, tool_name, args)
+            .await
     }
 
     // ============================================================
@@ -2519,13 +2664,15 @@ impl McpClientManager {
     /// [`call_kind_at`] with an explicit `server_id` instead.
     pub async fn call_kind(
         &self,
+        caller: &Caller,
         kind: &super::capability_dispatcher::ToolKind,
         args: Value,
     ) -> Result<super::mcp_protocol::CallToolResult> {
         let (server_id, _) = self.dispatcher.resolve_kind(kind).await.ok_or_else(|| {
             anyhow::anyhow!("No server provides ToolKind for tool '{}'", kind.name())
         })?;
-        self.call_server_tool(&server_id, kind.name(), args).await
+        self.call_server_tool(caller, &server_id, kind.name(), args)
+            .await
     }
 
     /// Call a [`ToolKind`] against an explicit `server_id`. Use when the
@@ -2533,16 +2680,19 @@ impl McpClientManager {
     /// dispatching a `Custom` variant.
     pub async fn call_kind_at(
         &self,
+        caller: &Caller,
         server_id: &str,
         kind: &super::capability_dispatcher::ToolKind,
         args: Value,
     ) -> Result<super::mcp_protocol::CallToolResult> {
-        self.call_server_tool(server_id, kind.name(), args).await
+        self.call_server_tool(caller, server_id, kind.name(), args)
+            .await
     }
 
     /// Streaming counterpart of [`call_kind`].
     pub async fn call_kind_streaming(
         &self,
+        caller: &Caller,
         kind: &super::capability_dispatcher::ToolKind,
         args: Value,
     ) -> Result<(
@@ -2552,13 +2702,14 @@ impl McpClientManager {
         let (server_id, _) = self.dispatcher.resolve_kind(kind).await.ok_or_else(|| {
             anyhow::anyhow!("No server provides ToolKind for tool '{}'", kind.name())
         })?;
-        self.call_server_tool_streaming(&server_id, kind.name(), args)
+        self.call_server_tool_streaming(caller, &server_id, kind.name(), args)
             .await
     }
 
     /// Streaming counterpart of [`call_kind_at`].
     pub async fn call_kind_streaming_at(
         &self,
+        caller: &Caller,
         server_id: &str,
         kind: &super::capability_dispatcher::ToolKind,
         args: Value,
@@ -2566,7 +2717,7 @@ impl McpClientManager {
         tokio::sync::mpsc::Receiver<Value>,
         tokio::sync::oneshot::Receiver<Result<super::mcp_protocol::CallToolResult>>,
     )> {
-        self.call_server_tool_streaming(server_id, kind.name(), args)
+        self.call_server_tool_streaming(caller, server_id, kind.name(), args)
             .await
     }
 

--- a/crates/core/src/managers/mcp_kernel_tool.rs
+++ b/crates/core/src/managers/mcp_kernel_tool.rs
@@ -1490,49 +1490,55 @@ pub(super) async fn execute_mgp_agent_ask(
         vec![]
     };
 
-    let response =
-        match run_mgp_agent_ask_loop(manager, &engine_id, &think_args, &tools, target_agent_id)
-            .await
-        {
-            Ok(content) => content,
-            Err(e) => {
-                // Emit AgentDialogue "error" event
-                manager
-                    .emit_kernel_event(cloto_shared::ClotoEventData::AgentDialogue {
-                        dialogue_id: dialogue_id.clone(),
-                        caller_agent_id: caller_agent_id.to_string(),
-                        caller_agent_name: caller_agent_name.clone(),
-                        target_agent_id: target_agent_id.to_string(),
-                        target_agent_name: agent_meta.name.clone(),
-                        prompt: prompt.to_string(),
-                        engine_id: engine_id.clone(),
-                        response: Some(format!("Engine call failed: {}", e)),
-                        chain_depth,
-                        status: "error".to_string(),
-                    })
-                    .await;
-                // Audit: delegation failed
-                manager
-                    .broadcast_audit_event(&crate::db::AuditLogEntry {
-                        timestamp: chrono::Utc::now(),
-                        event_type: "DELEGATION_FAILED".to_string(),
-                        actor_id: Some(caller_agent_id.to_string()),
-                        target_id: Some(target_agent_id.to_string()),
-                        permission: None,
-                        result: "error".to_string(),
-                        reason: e.to_string(),
-                        metadata: None,
-                        trace_id: None,
-                    })
-                    .await;
-                return Ok(serde_json::json!({
-                    "status": "error",
-                    "reason": format!("Engine call failed: {}", e),
-                    "source_agent": caller_agent_id,
-                    "target_agent": target_agent_id,
-                }));
-            }
-        };
+    let response = match run_mgp_agent_ask_loop(
+        manager,
+        &engine_id,
+        &think_args,
+        &tools,
+        target_agent_id,
+        caller_agent_id,
+    )
+    .await
+    {
+        Ok(content) => content,
+        Err(e) => {
+            // Emit AgentDialogue "error" event
+            manager
+                .emit_kernel_event(cloto_shared::ClotoEventData::AgentDialogue {
+                    dialogue_id: dialogue_id.clone(),
+                    caller_agent_id: caller_agent_id.to_string(),
+                    caller_agent_name: caller_agent_name.clone(),
+                    target_agent_id: target_agent_id.to_string(),
+                    target_agent_name: agent_meta.name.clone(),
+                    prompt: prompt.to_string(),
+                    engine_id: engine_id.clone(),
+                    response: Some(format!("Engine call failed: {}", e)),
+                    chain_depth,
+                    status: "error".to_string(),
+                })
+                .await;
+            // Audit: delegation failed
+            manager
+                .broadcast_audit_event(&crate::db::AuditLogEntry {
+                    timestamp: chrono::Utc::now(),
+                    event_type: "DELEGATION_FAILED".to_string(),
+                    actor_id: Some(caller_agent_id.to_string()),
+                    target_id: Some(target_agent_id.to_string()),
+                    permission: None,
+                    result: "error".to_string(),
+                    reason: e.to_string(),
+                    metadata: None,
+                    trace_id: None,
+                })
+                .await;
+            return Ok(serde_json::json!({
+                "status": "error",
+                "reason": format!("Engine call failed: {}", e),
+                "source_agent": caller_agent_id,
+                "target_agent": target_agent_id,
+            }));
+        }
+    };
 
     // Emit AgentDialogue "success" event
     manager
@@ -1741,11 +1747,26 @@ async fn run_mgp_agent_ask_loop(
     think_args: &Value,
     tools: &[Value],
     target_agent_id: &str,
+    caller_agent_id: &str,
 ) -> anyhow::Result<String> {
+    // Delegated execution runs under the TARGET agent's identity (bug-421): the
+    // delegated engine think and every tool the target's engine requests are
+    // gated by the target's own grants (Caller::Agent(target)), closing the
+    // previously-ungated delegation path.
+    //
+    // Delegated TOOL calls additionally enforce the MGP §5.6.1 caller∩target
+    // intersection: before execution we explicitly check that the delegating
+    // caller (original_actor) is ALSO granted the tool. Effective access =
+    // caller ∩ target, closing the confused-deputy gap (A delegating to B must
+    // not let A reach a server only B holds). The engine think itself is the
+    // target's own engine (not a delegated tool), so it is gated by
+    // Caller::Agent(target) only.
+    let caller = crate::managers::Caller::Agent(target_agent_id.to_string());
+
     // No tools available → plain think (single inference)
     if tools.is_empty() {
         let result = manager
-            .call_server_tool(engine_id, "think", think_args.clone())
+            .call_server_tool(&caller, engine_id, "think", think_args.clone())
             .await?;
         return Ok(extract_think_response(&result));
     }
@@ -1768,7 +1789,7 @@ async fn run_mgp_agent_ask_loop(
         }
 
         let result = manager
-            .call_server_tool(engine_id, "think_with_tools", loop_args.clone())
+            .call_server_tool(&caller, engine_id, "think_with_tools", loop_args.clone())
             .await?;
 
         match parse_think_result(&result)? {
@@ -1819,11 +1840,26 @@ async fn run_mgp_agent_ask_loop(
                     // Resolve tool name → server ID (avoids recursive async through execute_tool_internal)
                     let server_id = manager.resolve_tool_server(&call.name).await;
                     let tool_result = if let Some(sid) = server_id {
-                        tokio::time::timeout(
-                            std::time::Duration::from_secs(MGP_AGENT_ASK_TOOL_TIMEOUT_SECS),
-                            manager.call_server_tool(&sid, &call.name, safe_args),
-                        )
-                        .await
+                        // §5.6.1 caller∩target: the delegating caller must ALSO be
+                        // granted this tool (the target side is gated by
+                        // Caller::Agent(target) inside call_server_tool). Refuse
+                        // before execution otherwise — confused-deputy fix.
+                        if matches!(
+                            manager.check_tool_access(caller_agent_id, &call.name).await,
+                            Ok(crate::db::mcp::PermissionLevel::Allow)
+                        ) {
+                            tokio::time::timeout(
+                                std::time::Duration::from_secs(MGP_AGENT_ASK_TOOL_TIMEOUT_SECS),
+                                manager.call_server_tool(&caller, &sid, &call.name, safe_args),
+                            )
+                            .await
+                        } else {
+                            Ok(Err(anyhow::anyhow!(
+                                "Delegation denied: caller '{}' is not granted tool '{}' (MGP §5.6.1 caller∩target)",
+                                caller_agent_id,
+                                call.name
+                            )))
+                        }
                     } else {
                         Ok(Err(anyhow::anyhow!(
                             "Tool '{}' not found in any connected server",

--- a/crates/core/src/managers/mod.rs
+++ b/crates/core/src/managers/mod.rs
@@ -32,6 +32,6 @@ pub mod usage_tracker;
 
 pub use agents::AgentManager;
 pub use capability_dispatcher::{CapabilityDispatcher, CapabilityType, ToolKind};
-pub use mcp::McpClientManager;
+pub use mcp::{Caller, McpClientManager};
 pub use plugin::PluginManager;
 pub use registry::{PluginRegistry, PluginSetting, SystemMetrics};

--- a/crates/core/src/managers/registry.rs
+++ b/crates/core/src/managers/registry.rs
@@ -91,16 +91,6 @@ impl PluginRegistry {
         self.mcp_manager = Some(mcp_manager);
     }
 
-    /// Check if a tool name belongs to the kernel-native tool set.
-    /// Kernel-native tools are dispatched by the `mgp.` / `gui.` prefix; no
-    /// per-name allowlist is consulted (see comment on the deleted
-    /// `KERNEL_NATIVE_TOOLS` constant above). Access control still flows
-    /// through `resolve_tool_access(..., "kernel", ...)` in
-    /// `execute_tool_for_agent`.
-    fn is_kernel_native_tool(tool_name: &str) -> bool {
-        tool_name.starts_with("mgp.") || tool_name.starts_with("gui.")
-    }
-
     pub async fn update_effective_permissions(&self, plugin_id: ClotoId, permission: Permission) {
         let mut state = self.state.write().await;
         let perms = state.effective_permissions.entry(plugin_id).or_default();
@@ -181,6 +171,7 @@ impl PluginRegistry {
     /// Dual Dispatch: tries Rust plugins first, then falls back to MCP servers.
     pub async fn execute_tool(
         &self,
+        caller: &crate::managers::Caller,
         tool_name: &str,
         args: serde_json::Value,
     ) -> std::result::Result<serde_json::Value, cloto_shared::ToolFailure> {
@@ -202,9 +193,9 @@ impl PluginRegistry {
             }
         }
 
-        // 2. Fall back to MCP servers
+        // 2. Fall back to MCP servers (gated by the central capability gate).
         if let Some(ref mcp) = self.mcp_manager {
-            return mcp.execute_tool_internal(tool_name, args).await;
+            return mcp.execute_tool_internal(caller, tool_name, args).await;
         }
 
         Err(anyhow::anyhow!("Tool '{}' not found", tool_name).into())
@@ -214,6 +205,7 @@ impl PluginRegistry {
     /// Dual Dispatch: tries Rust plugins first, then falls back to MCP servers.
     pub async fn execute_tool_for(
         &self,
+        caller: &crate::managers::Caller,
         allowed_plugin_ids: &[String],
         tool_name: &str,
         args: serde_json::Value,
@@ -250,7 +242,7 @@ impl PluginRegistry {
                     == Some(tool_name)
             });
             if has_tool {
-                return mcp.execute_tool_internal(tool_name, args).await;
+                return mcp.execute_tool_internal(caller, tool_name, args).await;
             }
         }
 
@@ -322,47 +314,20 @@ impl PluginRegistry {
             }
         }
 
-        // 2. MCP servers: check access via resolve_tool_access, then execute
+        // 2. MCP servers: the per-agent capability gate — including the
+        //    kernel-native Deny-only RBAC — is now enforced centrally inside
+        //    `execute_tool_internal` (bug-421, PATH 2). No inline
+        //    `check_tool_access` here: "shown" (presentation-layer filtering)
+        //    and "allowed" (enforcement) are decoupled, single-sourced at the
+        //    chokepoint.
         if let Some(ref mcp) = self.mcp_manager {
-            // Kernel-native tools use server_id="kernel" for RBAC.
-            // Default policy is Allow (no entries = permitted).
-            // Administrators can add Deny entries to restrict specific agents.
-            if Self::is_kernel_native_tool(tool_name) {
-                if let Ok(crate::db::mcp::PermissionLevel::Deny) =
-                    crate::db::resolve_tool_access(mcp.pool(), agent_id, "kernel", tool_name).await
-                {
-                    return Err(anyhow::anyhow!(
-                        "Access denied: agent '{}' cannot use kernel tool '{}'",
-                        agent_id,
-                        tool_name
-                    )
-                    .into());
-                }
-                return mcp.execute_tool_internal(tool_name, args).await;
-            }
-
-            let access = mcp.check_tool_access(agent_id, tool_name).await;
-            match access {
-                Ok(crate::db::mcp::PermissionLevel::Allow) => {
-                    return mcp.execute_tool_internal(tool_name, args).await;
-                }
-                Ok(crate::db::mcp::PermissionLevel::Deny) => {
-                    return Err(anyhow::anyhow!(
-                        "Access denied: agent '{}' cannot use tool '{}'",
-                        agent_id,
-                        tool_name
-                    )
-                    .into());
-                }
-                Err(e) => {
-                    return Err(anyhow::anyhow!(
-                        "Access check failed for tool '{}': {}",
-                        tool_name,
-                        e
-                    )
-                    .into());
-                }
-            }
+            return mcp
+                .execute_tool_internal(
+                    &crate::managers::Caller::Agent(agent_id.to_string()),
+                    tool_name,
+                    args,
+                )
+                .await;
         }
 
         Err(anyhow::anyhow!(

--- a/crates/core/tests/capability_gate_test.rs
+++ b/crates/core/tests/capability_gate_test.rs
@@ -1,0 +1,346 @@
+//! Capability gate (bug-421) — unit + behavioural coverage of the single
+//! per-agent MCP access gate and its data layer.
+//!
+//! The permission *data model* is exercised directly via
+//! `resolve_tool_access` / `resolve_explicit_permission` (no in-process kernel),
+//! and the PATH 1 gate (`call_server_tool` → `resolve_tool_call_target`
+//! → `enforce_caller_grant`) plus the kernel-native Deny-only RBAC are exercised
+//! through the public `McpClientManager` surface against an in-memory DB.
+//!
+//! The headline guarantee — a zero-grant agent's engine is denied (the LM Studio
+//! repro) — is the same code path: the engine `think` tool routes through
+//! `call_server_tool` under `Caller::Agent`, so `path1_gate_denies_ungranted_server`
+//! covers it (an engine is just an MCP server gated by `server_id`).
+
+use cloto_core::db::mcp::PermissionLevel;
+use cloto_core::managers::{Caller, McpClientManager};
+use sqlx::SqlitePool;
+
+async fn fresh_pool() -> SqlitePool {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    // Runs all migrations incl. 20260701000000 (opt-in flip + engine backfill);
+    // on an empty DB both are no-ops, which also smoke-tests that the new
+    // migration applies cleanly (no FATAL).
+    cloto_core::db::init_db(&pool, "sqlite::memory:", None)
+        .await
+        .unwrap();
+    pool
+}
+
+async fn add_server(pool: &SqlitePool, name: &str, default_policy: &str) {
+    sqlx::query("INSERT INTO mcp_servers (name, command, created_at, default_policy) VALUES (?, 'noop', 0, ?)")
+        .bind(name)
+        .bind(default_policy)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn add_grant(
+    pool: &SqlitePool,
+    entry_type: &str,
+    agent_id: &str,
+    server_id: &str,
+    tool_name: Option<&str>,
+    permission: &str,
+) {
+    sqlx::query(
+        "INSERT INTO mcp_access_control (entry_type, agent_id, server_id, tool_name, permission, granted_at) \
+         VALUES (?, ?, ?, ?, ?, 't0')",
+    )
+    .bind(entry_type)
+    .bind(agent_id)
+    .bind(server_id)
+    .bind(tool_name)
+    .bind(permission)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+// ─────────────────────────── data layer ───────────────────────────
+
+#[tokio::test]
+async fn resolve_tool_access_opt_in_truth_table() {
+    let pool = fresh_pool().await;
+    add_server(&pool, "tool.optin", "opt-in").await;
+    add_server(&pool, "tool.optout", "opt-out").await;
+
+    // No grant + opt-in default → Deny (the post-flip default; revoke-staleness fix).
+    assert_eq!(
+        cloto_core::db::resolve_tool_access(&pool, "a", "tool.optin", "do")
+            .await
+            .unwrap(),
+        PermissionLevel::Deny
+    );
+    // No grant + opt-out default → Allow.
+    assert_eq!(
+        cloto_core::db::resolve_tool_access(&pool, "a", "tool.optout", "do")
+            .await
+            .unwrap(),
+        PermissionLevel::Allow
+    );
+    // Unknown server (no row) → "opt-in" fallback → Deny.
+    assert_eq!(
+        cloto_core::db::resolve_tool_access(&pool, "a", "ghost.server", "do")
+            .await
+            .unwrap(),
+        PermissionLevel::Deny
+    );
+
+    // server_grant allow → Allow; deny → Deny.
+    add_grant(&pool, "server_grant", "a", "tool.optin", None, "allow").await;
+    assert_eq!(
+        cloto_core::db::resolve_tool_access(&pool, "a", "tool.optin", "do")
+            .await
+            .unwrap(),
+        PermissionLevel::Allow
+    );
+    add_grant(&pool, "server_grant", "b", "tool.optout", None, "deny").await;
+    assert_eq!(
+        cloto_core::db::resolve_tool_access(&pool, "b", "tool.optout", "do")
+            .await
+            .unwrap(),
+        PermissionLevel::Deny
+    );
+
+    // tool_grant takes precedence over server_grant (allow beats a server deny).
+    add_grant(&pool, "tool_grant", "b", "tool.optout", Some("do"), "allow").await;
+    assert_eq!(
+        cloto_core::db::resolve_tool_access(&pool, "b", "tool.optout", "do")
+            .await
+            .unwrap(),
+        PermissionLevel::Allow
+    );
+}
+
+#[tokio::test]
+async fn resolve_explicit_permission_ignores_default_policy() {
+    let pool = fresh_pool().await;
+    add_server(&pool, "tool.optout", "opt-out").await;
+
+    // No explicit entry → None, even though default_policy=opt-out would Allow.
+    // This is what makes the kernel Deny-only RBAC default to Allow without
+    // inheriting a server's opt-in default as a deny.
+    assert_eq!(
+        cloto_core::db::resolve_explicit_permission(&pool, "a", "tool.optout", "do")
+            .await
+            .unwrap(),
+        None
+    );
+
+    // Explicit deny is surfaced.
+    add_grant(&pool, "server_grant", "a", "tool.optout", None, "deny").await;
+    assert_eq!(
+        cloto_core::db::resolve_explicit_permission(&pool, "a", "tool.optout", "do")
+            .await
+            .unwrap(),
+        Some(PermissionLevel::Deny)
+    );
+}
+
+// ─────────────────────────── PATH 1 gate ───────────────────────────
+
+fn err_text<T: std::fmt::Debug>(r: &anyhow::Result<T>) -> String {
+    match r {
+        Ok(v) => panic!("expected Err, got Ok({v:?})"),
+        Err(e) => e.to_string(),
+    }
+}
+
+#[tokio::test]
+async fn path1_gate_denies_ungranted_server() {
+    let pool = fresh_pool().await;
+    let mgr = McpClientManager::new(pool, false, 120, 30);
+
+    // Ungranted engine server (a `mind.*` server is just an MCP server). The
+    // gate denies BEFORE the client lookup — proving an agent with no grant
+    // cannot reach its engine (the LM Studio repro).
+    let denied = mgr
+        .call_server_tool(
+            &Caller::Agent("agent.zero".to_string()),
+            "mind.x",
+            "think",
+            serde_json::json!({}),
+        )
+        .await;
+    let msg = err_text(&denied);
+    assert!(
+        msg.contains("not granted") || msg.contains("Access denied"),
+        "ungranted engine must be denied by the gate, got: {msg}"
+    );
+    assert!(
+        !msg.contains("not found") && !msg.contains("not connected"),
+        "gate must deny BEFORE the client lookup, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn path1_gate_allows_granted_then_fails_at_connection() {
+    let pool = fresh_pool().await;
+    add_server(&pool, "mind.x", "opt-in").await;
+    add_grant(&pool, "server_grant", "agent.ok", "mind.x", None, "allow").await;
+    let mgr = McpClientManager::new(pool, false, 120, 30);
+
+    // With the engine granted, the gate passes; execution then fails only
+    // because the server is not connected — proving Allow != Deny and that the
+    // refusal in the ungranted case came from the gate, not the connection.
+    let r = mgr
+        .call_server_tool(
+            &Caller::Agent("agent.ok".to_string()),
+            "mind.x",
+            "think",
+            serde_json::json!({}),
+        )
+        .await;
+    let msg = err_text(&r);
+    assert!(
+        msg.contains("not found") || msg.contains("not connected"),
+        "granted engine must pass the gate and fail only at connection, got: {msg}"
+    );
+    assert!(
+        !msg.contains("not granted"),
+        "granted engine must not be denied by the gate, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn path1_gate_system_bypasses() {
+    let pool = fresh_pool().await;
+    let mgr = McpClientManager::new(pool, false, 120, 30);
+
+    // System bypasses the grant gate entirely: an ungranted server fails only
+    // at the client lookup, never at the gate.
+    let r = mgr
+        .call_server_tool(&Caller::System, "mind.x", "think", serde_json::json!({}))
+        .await;
+    let msg = err_text(&r);
+    assert!(
+        msg.contains("not found") || msg.contains("not connected"),
+        "System must bypass the gate, got: {msg}"
+    );
+    assert!(
+        !msg.contains("not granted"),
+        "System must not be gated, got: {msg}"
+    );
+}
+
+// ───────────── kernel presentation ⇄ enforcement parity ─────────────
+
+fn kernel_tool_count(schemas: &[serde_json::Value]) -> usize {
+    schemas
+        .iter()
+        .filter(|s| {
+            s.get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+                .is_some_and(|n| n.starts_with("mgp."))
+        })
+        .count()
+}
+
+#[tokio::test]
+async fn kernel_presentation_defaults_to_allow_and_honors_explicit_deny() {
+    let pool = fresh_pool().await;
+    add_server(&pool, "kernel", "opt-in").await;
+    // yolo on: collect_tool_schemas_for_agent offers kernel-native (mgp.*) tools.
+    let mgr = McpClientManager::new(pool.clone(), true, 120, 30);
+
+    // Gap-1 fix: the presentation filter must use resolve_explicit_permission
+    // (default Allow), matching enforce_kernel_rbac — NOT resolve_tool_access
+    // (which would fall back to the 'kernel' opt-in row → Deny and hide every
+    // kernel tool). An agent with no explicit kernel grant sees the kernel tools.
+    let free = mgr.collect_tool_schemas_for_agent("agent.free").await;
+    let free_kernel = kernel_tool_count(&free);
+    assert!(
+        free_kernel > 0,
+        "default-Allow: an agent with no explicit kernel deny must be offered kernel tools, got {free_kernel}"
+    );
+
+    // An explicit deny removes exactly that tool; the rest remain (Deny-only).
+    add_grant(
+        &pool,
+        "tool_grant",
+        "agent.blocked",
+        "kernel",
+        Some("mgp.audit.replay"),
+        "deny",
+    )
+    .await;
+    let blocked = mgr.collect_tool_schemas_for_agent("agent.blocked").await;
+    let blocked_has_denied = blocked.iter().any(|s| {
+        s.get("function")
+            .and_then(|f| f.get("name"))
+            .and_then(|n| n.as_str())
+            == Some("mgp.audit.replay")
+    });
+    assert!(
+        !blocked_has_denied,
+        "an explicit kernel deny must remove that tool from the presented set"
+    );
+    assert!(
+        kernel_tool_count(&blocked) >= free_kernel - 1,
+        "only the explicitly-denied kernel tool is removed; the rest remain (default Allow)"
+    );
+}
+
+// ─────────────────────────── kernel RBAC ───────────────────────────
+
+#[tokio::test]
+async fn kernel_rbac_blocks_only_on_explicit_deny() {
+    let pool = fresh_pool().await;
+    // The synthetic "kernel" server row must exist: mcp_access_control.server_id
+    // is a FK onto mcp_servers(name) and the kernel opens SQLite with
+    // foreign_keys=ON, so granting on "kernel" requires the row (mirrors the
+    // live DB, which carries a `kernel` row). This also confirms the migration's
+    // EXISTS(mcp_servers) backfill guard is mandatory.
+    add_server(&pool, "kernel", "opt-in").await;
+    // An explicit kernel deny for this agent on a kernel-native tool.
+    add_grant(
+        &pool,
+        "tool_grant",
+        "agent.blocked",
+        "kernel",
+        Some("mgp.audit.replay"),
+        "deny",
+    )
+    .await;
+    let mgr = McpClientManager::new(pool, true, 120, 30); // yolo on: isolate the RBAC
+
+    // Explicit deny → blocked by the kernel Deny-only RBAC.
+    let blocked = mgr
+        .execute_tool(
+            &Caller::Agent("agent.blocked".to_string()),
+            "mgp.audit.replay",
+            serde_json::json!({}),
+        )
+        .await;
+    match blocked {
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("cannot use kernel tool") || msg.contains("Access denied"),
+                "explicit kernel deny must block, got: {msg}"
+            );
+        }
+        Ok(v) => panic!("explicit kernel deny must block, got Ok({v:?})"),
+    }
+
+    // A different agent with NO explicit deny is NOT blocked by the RBAC
+    // (default Allow) — it proceeds into the kernel tool's own logic rather than
+    // being refused by the gate. We only assert it is not the RBAC denial.
+    let other = mgr
+        .execute_tool(
+            &Caller::Agent("agent.free".to_string()),
+            "mgp.audit.replay",
+            serde_json::json!({}),
+        )
+        .await;
+    if let Err(e) = other {
+        let msg = e.to_string();
+        assert!(
+            !msg.contains("cannot use kernel tool"),
+            "agent without an explicit kernel deny must NOT hit the RBAC denial, got: {msg}"
+        );
+    }
+}

--- a/crates/core/tests/tool_hint_access_test.rs
+++ b/crates/core/tests/tool_hint_access_test.rs
@@ -111,8 +111,19 @@ async fn tool_hint_denies_ungranted_tool() {
         found.expect("tool_hint execution must surface an ExternalAction result")
     };
 
+    // Post bug-421: the tool_hint path routes through the central capability
+    // gate inside execute_tool_internal under Caller::Agent. An ungranted /
+    // unavailable tool is refused BEFORE execution and surfaces as an `Error:`
+    // — here `secret_tool` is on no connected server, so resolution fails
+    // ("not found") before any dispatch; a connected-but-ungranted server would
+    // surface "not granted" from the gate. Either way the tool never runs.
+    // (The gate's connected-but-ungranted denial is covered end-to-end by
+    // engine_access_gate_test.rs.)
     assert!(
-        response.contains("not available to this agent"),
-        "an ungranted tool_hint must be refused by the access gate before execution, got: {response}"
+        response.starts_with("Error")
+            && (response.contains("not found")
+                || response.contains("not granted")
+                || response.contains("not available")),
+        "an ungranted/unavailable tool_hint must be refused before execution, got: {response}"
     );
 }

--- a/crates/core/tests/tool_rejection_smoke.rs
+++ b/crates/core/tests/tool_rejection_smoke.rs
@@ -33,7 +33,15 @@ async fn setup_manager(yolo: bool) -> McpClientManager {
 }
 
 async fn call(mgr: &McpClientManager, tool: &str, args: Value) -> Result<Value, ToolFailure> {
-    mgr.execute_tool(tool, args, Some("agent.demo")).await
+    // Kernel-native tools route through enforce_kernel_rbac (Deny-only, default
+    // Allow) under an agent caller; with no explicit deny for agent.demo the
+    // YOLO / delegation rejection logic below still fires as before (bug-421).
+    mgr.execute_tool(
+        &cloto_core::managers::Caller::Agent("agent.demo".to_string()),
+        tool,
+        args,
+    )
+    .await
 }
 
 fn print_outcome(label: &str, tool_name: &str, result: Result<Value, ToolFailure>) {

--- a/docs/MCP_CAPABILITY_GATE_DESIGN.md
+++ b/docs/MCP_CAPABILITY_GATE_DESIGN.md
@@ -1,6 +1,6 @@
 # MCP Capability Gate — Unified Per-Agent Access Enforcement
 
-Status: **Proposed** (design only; not yet implemented)
+Status: **Accepted** — implementing (§6 policy decided 2026-06-30: global opt-in)
 Scope: ClotoCore kernel access control (`crates/core`)
 Related bugs: bug-419 (consensus engines), bug-420 (tool_hint bypass), engine-not-gated (LM Studio repro)
 
@@ -61,14 +61,40 @@ separate permission system; an engine is just an MCP server that today is not
 enforced. The fix is to route **all** execution through one gate that consults
 the existing `resolve_tool_access`.
 
-## 3. Design: a single deterministic chokepoint
+## 3. Design: a shared gate at the (two) execution chokepoints
 
-All execution — tools, engine `think` / `think_with_tools`, delegation,
-tool_hint, `/api/mcp/call` — ultimately flows through
-`McpClientManager::call_server_tool` (and its streaming sibling
-`call_server_tool_streaming`). These are the **single lowest chokepoint** and,
-critically, they already hold the resolved `server_id` — the exact key
-`resolve_tool_access` needs.
+> **Correction (2026-07-01 investigation, code-verified):** there is **no
+> single** lowest chokepoint. Exactly **three** transport call sites reach
+> `McpClient::call_tool[_streaming]`, funneling into **two** manager-level
+> paths:
+> - **PATH 1** — `call_server_tool` (`mcp.rs:2191`) + `call_server_tool_streaming`
+>   (`mcp.rs:2218`), both via `resolve_tool_call_target` (`mcp.rs:2053`).
+> - **PATH 2** — `execute_tool_internal` (`mcp.rs:1808` → `client.call_tool` at
+>   `mcp.rs:1951`), an independent sibling that does **not** go through
+>   `call_server_tool` or `resolve_tool_call_target`.
+>
+> Critically, the **main agentic loop tool execution** (`system.rs:2516-2527`)
+> and **tool_hint** use PATH 2. A gate only on `call_server_tool` would miss the
+> highest-value agent paths. The fix is therefore a single shared gate function
+> installed at **both** chokepoints (see §3.1), not one point.
+
+Both paths already hold the resolved `server_id` — the exact key
+`resolve_tool_access` needs — so a uniform gate is still achievable; it just
+needs two insertion points sharing one enforcement function.
+
+The shared gate `enforce_caller_grant(caller, server_id, tool_name)` is installed:
+
+- **PATH 1**: at `resolve_tool_call_target` entry. `server_id` is final on entry
+  (no rewrite occurs across `mcp.rs:2053-2179`), so it covers streaming and
+  non-streaming identically. The §5.6.1 delegation intersection
+  (`mcp.rs:2099-2120`) remains a **separate ordered stage after** the caller gate.
+- **PATH 2**: inside `execute_tool_internal`, **after** the kernel-native match
+  (`mcp.rs:1814-1898`) and `server_id` resolution (`mcp.rs:1901-1922`) but
+  **before** the validator (`mcp.rs:1925`) / `call_tool` (`mcp.rs:1951`). This
+  preserves the kernel-native early-return, the TOOL_EXECUTED / TOOL_ERROR /
+  TOOL_BLOCKED audit (`mcp.rs:1927-1987`), and the `CallToolResult → Value`
+  flattening that `call_server_tool` lacks. (Re-pointing PATH 2 onto
+  `call_server_tool` is therefore **rejected** — it would lose audit + flattening.)
 
 ### 3.1 Caller identity
 
@@ -149,41 +175,127 @@ Once the chokepoint enforces uniformly, these collapse:
 
 ## 5. Caller threading & exemptions
 
-- **Agentic loop / normal message path / tool_hint / consensus engines**:
-  `Caller::Agent(agent.id)`.
-- **Consensus synthesizer** (`agent.synthesizer`, system agent): `Caller::System`
-  (it is a kernel-internal merge step, not a user agent).
-- **Kernel-native tools** (`mgp.*`, `gui.*`): keep the existing `server_id="kernel"`
-  RBAC (Deny-only) — represented as a `System`/kernel path or a dedicated kernel
-  gate; do not route through `resolve_tool_access` server grants.
-- **`/api/mcp/call` coordinator endpoint**: already auth-gated; map the
-  authenticated caller to `Caller::System` (or a coordinator agent id if one is
-  carried), preserving today's behavior.
+- **Agentic loop / normal message path / tool_hint / consensus proposal engines**:
+  `Caller::Agent(agent.id)`. Derive once from the in-scope `AgentMetadata`.
+- **Consensus synthesizer**: `Caller::System`. **Discriminator MUST be
+  `agent.agent_type == "system"`** (`system.rs:1929`), **not** the id — the
+  synthesizer's `id` is `"agent.synthesizer"` (`system.rs:1920`) while
+  `cfg.synthetic_agent_id` is `"system.consensus"` (`consensus.rs:23`, used only
+  for the session_key at `system.rs:1936`); they do not match, so keying on an id
+  would misclassify.
+- **Kernel-native tools** (`mgp.*`, `gui.*`): keep the dedicated
+  `server_id="kernel"` RBAC, evaluated on the kernel-native early-return path
+  **before** the central gate; do not route through `resolve_tool_access` server
+  grants. **Decision (博士 2026-07-01): the kernel gate special-cases the default
+  to Allow (Deny-only RBAC).** This fixes a **confirmed live defect** — the live
+  `kernel` row is `opt-in`, so `resolve_tool_access(...,"kernel",...)` currently
+  returns Deny for every agent without an explicit kernel grant; today only
+  `agent.cloto_default` can use `mgp.agent.ask`. No migration row is added (the
+  global opt-in flip in §6 must **not** make kernel deny-by-default for everyone).
+- **`/api/mcp/call` coordinator endpoint** (`handlers/mcp.rs:877/889`): already
+  admin-auth-gated; map to `Caller::System`. Per-agent scoping for this endpoint
+  flows only through `_mgp.delegation` (`original_actor`), not a body agent_id.
+- **switch_model relay** (`handlers/llm.rs:119`), **ollama post-connect sync**
+  (`mcp.rs:1480`), **DeleteAgentData** (`agents.rs:339`): `Caller::System`.
+- **Background memory ops** (`system.rs:703/1113/1294/1506/3550+`):
+  `Caller::Agent(agent_id)`.
+- **Default-proceed (AI, 2026-07-01, 事後 override 可)**: media preprocessing
+  (`AnalyzeImage` `system.rs:3092`, `Transcribe` `system.rs:3202`) → `System`
+  (kernel preprocessing, not agent-initiated); episode-archival summarizer
+  (`system.rs:3863`) → `Agent(message-agent)`.
 
-## 6. Open decision: `default_policy = opt-out`
+## 6. Decision: `default_policy = opt-in` everywhere (deny-by-default)
 
-Migration `20260301000000_default_policy_opt_out.sql` set all servers'
+Migration `20260301000000_default_policy_opt_out.sql` had set all servers'
 `default_policy` to `opt-out` (allow-all). With that default, **revoking a grant
 (deleting the `server_grant` row) falls back to allow** — so revoke does not
-actually deny. This is a **policy default**, separate from the enforcement
-unification. To make revoke effective, choose one:
+actually deny, and an agent that was *never* granted an engine still runs it
+(the LM Studio repro). This is a **policy default**, separate from the
+enforcement unification.
 
-- (a) Engines / sensitive servers default to `opt-in` (deny-by-default), or
-- (b) "Reject" writes an explicit `Deny` entry rather than deleting the grant, or
-- (c) Both.
+**Decision (博士, 2026-06-30): flip every server back to `opt-in`
+(deny-by-default) globally.** Rationale — the simplest, most predictable mental
+model: `grant ⇒ allow`, `no grant ⇒ deny`, `revoke = delete ⇒ deny` falls out
+for free. This makes both the zero-grant case (LM Studio) and the
+revoke-staleness case deny correctly with no special-casing.
 
-This decision is independent of the chokepoint work and should be made
-deliberately (it changes existing deployments' effective access).
+The accepted cost is the **largest blast radius**: every server an agent was
+implicitly relying on under `opt-out` now denies unless it has an explicit
+`server_grant`. This **mandates a comprehensive backfill** (§7) so well-formed
+agents — those configured through SetupWizard / AgentConsole, which already
+write `server_grant` rows — keep working. Agents with **no** matching grant
+(the bug being fixed) correctly lose access.
+
+Considered and rejected: (a) opt-in for engines only — leaves non-engine
+revoke-staleness under opt-out; (b) keep opt-out, write an explicit `Deny` on
+revoke — does not fix the zero-grant (never-granted) engine case, so the
+headline bug survives. The global opt-in flip subsumes both.
 
 ## 7. Rollout / behavior change
 
-Enforcing the engine grant is a **behavior change**: an agent with no granted
-engine stops responding. Agents created through SetupWizard always grant their
-chosen engine, so well-formed agents are unaffected; agents created by other
-paths (tests, raw API) that set `default_engine_id` without a grant will need a
-grant. Consider a one-time backfill (grant each agent's current
-`default_engine_id` as a `server_grant`) and/or a clear "no engine assigned"
-error surfaced to chat.
+Two coupled behavior changes ship together:
+
+1. **The gate** enforces `resolve_tool_access` at the chokepoint for every
+   `Caller::Agent` path (engine, tool, delegation, tool_hint).
+2. **The opt-in flip** (§6) makes any server without an explicit grant deny.
+
+Net effect: an agent with no granted engine stops responding, and an agent can
+no longer reach a server it was never granted. Agents created through
+SetupWizard / AgentConsole already write `server_grant` rows for their engine
+and assigned servers, so well-formed agents are unaffected.
+
+**Real blast radius (code-verified):** the flip is small in live data — only
+`github-bridge`, `mind.local`, `x-browser` are `opt-out` (3/18). `20260301000000`
+ran its `UPDATE ... WHERE default_policy='opt-in'` against a near-empty table, and
+servers registered afterward already default to `opt-in` (`db/mcp.rs:128`). The
+flip's real value is making revoke-staleness deny correctly + converting
+implicit engine access to explicit, auditable grants.
+
+**Migration (one file, timestamp after the real tail `20260524010000`; CRLF-convert
+before any build per the SQLx rule).** Hard constraints (verified):
+`mcp_access_control.server_id REFERENCES mcp_servers(name)` and the kernel opens
+SQLite with `PRAGMA foreign_keys=ON` (`lib.rs:442-447`) — a dangling-engine INSERT
+**aborts the migration → FATAL boot**, so the `EXISTS(mcp_servers)` guard is
+mandatory; `granted_at` is `NOT NULL` with no default and must be supplied.
+
+1. **Global opt-in flip:** `UPDATE mcp_servers SET default_policy='opt-in' WHERE
+   default_policy='opt-out'`. Will **not** touch the `kernel` row (already opt-in;
+   its default is special-cased in code per §5).
+2. **Engine backfill (FK-safe, non-clobbering):** grant each agent's
+   `default_engine_id` as a `server_grant` **only** where the engine row exists
+   and no prior server_grant exists:
+   ```sql
+   INSERT INTO mcp_access_control (entry_type, agent_id, server_id, permission, granted_by, granted_at)
+   SELECT 'server_grant', a.id, a.default_engine_id, 'allow', 'migration:capability-gate', datetime('now')
+   FROM agents a
+   WHERE a.default_engine_id IS NOT NULL AND a.default_engine_id != ''
+     AND a.id != 'agent.テスト用'                                    -- §decision 3: repro agent excluded
+     AND EXISTS (SELECT 1 FROM mcp_servers s WHERE s.name = a.default_engine_id)
+     AND NOT EXISTS (SELECT 1 FROM mcp_access_control ac
+                     WHERE ac.agent_id = a.id AND ac.server_id = a.default_engine_id
+                       AND ac.entry_type = 'server_grant' AND ac.tool_name IS NULL);
+   ```
+   The `NOT EXISTS` also matches `permission='deny'` rows, so existing explicit
+   DENYs (e.g. `cpersona_bench`) are preserved.
+
+**Decisions (博士, 2026-07-01) — strict enforcement, consistent with global opt-in:**
+
+- **Engine backfill grants only `default_engine_id`** (not routing /
+  `escalate_to` / `fallback` / `engine_override` — 0 live rows; reached engines
+  surface the "engine not granted" error below). It deliberately grants only what
+  an agent demonstrably owns; it does **not** re-grant every active server.
+- **Repro agent `agent.テスト用` is EXCLUDED** from the backfill (the `a.id !=`
+  guard above), so it is genuinely denied after the flip — this validates the
+  reported "grant-0 agent still responds" bug on the real agent. (For all other
+  agents the bug is fixed for future never-granted agents + revoke semantics.)
+- **Opt-out tool servers `x-browser` / `github-bridge` are NOT preserved**
+  (intentional drop). They lose implicit allow-all access; agents that need them
+  must be re-granted explicitly.
+
+**UX (required):** surface a clear chat error instead of a silent non-response —
+**"no engine assigned"** when an agent's engine resolves to `Deny`, **and** a
+per-tool **"tool not granted"** signal when a tool server resolves to `Deny`
+(the latter is required because the tool-server drop above is otherwise invisible).
 
 ## 8. Test plan
 

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -3358,13 +3358,27 @@
       "discovered": "2026-06-30T13:21:13Z",
       "version": "0.6.8-beta.1",
       "file": "crates/core/src/handlers/system.rs",
-      "pattern": "check_tool_access\\(&agent\\.id, &tool_name\\)",
+      "pattern": "bug-420",
       "expected": "present",
       "status": "fixed",
-      "fixed_in": "0.6.8-beta.1",
-      "fix_note": "The tool_hint path now calls mcp.check_tool_access(&agent.id, &tool_name) before execute_tool_internal and refuses anything but an explicit Allow (Deny, or tool/server unknown) with 'tool not available to this agent' — mirroring the agentic loop's execute_tool_for_agent -> check_tool_access gate. Covered by tests/tool_hint_access_test.rs (ungranted tool_hint denied before execution). Granted/allowed path is exercised against the live app and by the agentic loop's existing permission tests.",
-      "notes": "User-reported 2026-06-30 ('an agent can use an MCP server it is not registered/granted for'); confirmed path = tool_hint direct execution. Related: bug-419 (consensus engines), bug-173/174 (kernel-side tool validation / anti-spoofing). Follow-up (separate, not time-based): the mgp.agent.ask delegation loop (run_mgp_agent_ask_loop, mcp_kernel_tool.rs ~1824) executes engine tool calls via call_server_tool without a per-agent check_tool_access — tracked for a future hardening pass.",
+      "fixed_in": "0.6.8",
+      "fix_note": "Originally fixed (PR #237) with a tool_hint-local bolt-on mcp.check_tool_access(&agent.id, &tool_name) before execute_tool_internal. That bolt-on is now REMOVED and SUBSUMED by the single capability gate (bug-421): the tool_hint path calls mcp.execute_tool_internal(&Caller::Agent(agent.id), ..), and the central gate (enforce_caller_grant, PATH 2) refuses any non-Allow before execution — identically to the agentic loop, which also routes through the same gate. Anchored on the 'bug-420' marker comment in the tool_hint block. Covered by tests/tool_hint_access_test.rs (ungranted/unavailable tool_hint refused before execution).",
+      "notes": "User-reported 2026-06-30 ('an agent can use an MCP server it is not registered/granted for'); confirmed path = tool_hint direct execution. Related: bug-419 (consensus engines), bug-173/174 (kernel-side tool validation / anti-spoofing). Follow-up (separate, not time-based): the mgp.agent.ask delegation loop (run_mgp_agent_ask_loop, mcp_kernel_tool.rs ~1824) executes engine tool calls via call_server_tool without a per-agent check_tool_access — tracked for a future hardening pass. | 2026-07-01: bolt-on superseded by the unified capability gate (bug-421).",
       "github_issue": 239
+    },
+    {
+      "id": "bug-421",
+      "summary": "HIGH: Per-agent MCP access enforcement was fragmented and non-deterministic, and reasoning ENGINES were never access-checked. Engine think/think_with_tools resolved globally (get_engine / has_server / call_kind_at) with no grant check, so an agent with ZERO grants still ran its engine and responded (LM Studio repro). The agentic-loop empty-grant branch fell back to the ungated registry.execute_tool, delegation (run_mgp_agent_ask_loop) executed engine/tool calls via call_server_tool with no per-agent check, and tool_hint used a separate bolt-on. The permission DATA model (mcp_access_control + resolve_tool_access) was already unified, but enforcement was scattered across call sites with inconsistent logic. Compounded by default_policy=opt-out (allow-all from migration 20260301), which also made revoking a grant ineffective (revoke-staleness).",
+      "severity": "HIGH",
+      "discovered": "2026-07-01T00:00:00Z",
+      "version": "0.6.8",
+      "file": "crates/core/src/managers/mcp.rs",
+      "pattern": "bug-421",
+      "expected": "present",
+      "status": "fixed",
+      "fixed_in": "0.6.8",
+      "fix_note": "Single capability gate threaded as Caller{Agent(id)|System} (no Default impl, so a missed site fails to compile) into BOTH manager-level execution chokepoints: PATH 1 = resolve_tool_call_target (call_server_tool/_streaming), PATH 2 = execute_tool_internal (the agentic loop + tool_hint path, which does NOT go through call_server_tool). enforce_caller_grant() consults resolve_tool_access(id, server_id, tool) once — covering engines (mind.* and bare-named MCP servers), tools, and memory uniformly. Kernel-native tools (mgp.*/gui.*) use enforce_kernel_rbac(): Deny-only on EXPLICIT deny entries via resolve_explicit_permission (default Allow), so the opt-in flip does not deny-by-default kernel tools. System callers (synthesizer via agent_type=='system', /api/mcp/call, switch_model, kernel cleanup, media preprocessing) bypass. The agentic-loop two-branch is collapsed onto execute_tool_for_agent (the empty-grant ungated branch is gone); execute_tool_for_agent's inline check_tool_access and the tool_hint bolt-on are removed (subsumed). Ships with migration 20260701000000: global opt-in flip + FK-safe non-clobbering engine backfill (default_engine_id -> server_grant). Anchored on the 'bug-421' markers in mcp.rs. Covered by db/mcp.rs resolve_tool_access unit tests, tests/engine_access_gate_test.rs (zero-grant agent denied engine; granted -> passes gate), and tests/tool_hint_access_test.rs.",
+      "notes": "User-reported 2026-06-30 (LM Studio agent with no assignments still responds). Investigation (2026-07-01) refuted the design's single-chokepoint claim (two paths exist) and confirmed kernel deny-by-default as a separate live defect (fixed via enforce_kernel_rbac). Design: docs/MCP_CAPABILITY_GATE_DESIGN.md. Subsumes bug-419 (consensus engines) and bug-420 (tool_hint). 博士 decisions 2026-07-01: kernel default-Allow special-case; x-browser/github-bridge dropped (not preserved); opt-in flip global."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Makes per-agent MCP access **deterministic** by routing all execution through a single capability gate, and closes the headline defect that **reasoning engines were never access-checked** — an agent with zero grants still ran its engine and responded (`bug-421`, the "LM Studio" repro). Subsumes the earlier point-fixes `bug-419` (consensus engines) and `bug-420` (tool_hint).

The permission **data model** (`mcp_access_control` + `resolve_tool_access`) was already unified; enforcement was fragmented across call sites with inconsistent logic. This threads a `Caller` identity into the execution chokepoints and enforces once.

## What changed

- **`Caller { Agent(String) | System }`** — deliberately **no `Default`**, so any execution site that forgets to thread a caller fails to compile (the compile error is the safety net against a silent bypass).
- **Two chokepoints, one gate.** Investigation refuted the "single lowest chokepoint" assumption: `execute_tool_internal` (PATH 2, used by the main agentic loop + `tool_hint`) reaches the transport directly, bypassing `call_server_tool`/`resolve_tool_call_target` (PATH 1). A shared `enforce_caller_grant(caller, server_id, tool)` is installed at **both** — PATH 1 at `resolve_tool_call_target` entry, PATH 2 inside `execute_tool_internal` after `server_id` resolution and before the validator (preserving its audit + result flattening). `System` bypasses; `Agent(id)` is checked against `resolve_tool_access`. Engines (`mind.*` and bare-named servers), tools, and memory are all gated uniformly by `server_id` — no separate "engine config" permission concept.
- **Kernel-native tools** (`mgp.*`/`gui.*`): `enforce_kernel_rbac` — Deny-only on **explicit** grants via a new `resolve_explicit_permission` (default Allow), so the opt-in flip below does **not** turn kernel tools into deny-by-default. The presentation filter (`collect_tool_schemas_for_agent`) uses the same resolver, so "shown" and "allowed" stay in sync.
- **Redundancy removed.** The agentic loop's `if agent_plugin_ids.is_empty()` two-branch (whose empty-grant branch was **ungated**) is collapsed onto `execute_tool_for_agent`; that method's inline `check_tool_access` and the `tool_hint` bolt-on (`bug-420`) are removed — subsumed by the central gate.
- **Delegation** (`run_mgp_agent_ask_loop`): delegated execution runs as `Caller::Agent(target)` **plus** an explicit caller∩target check (MGP §5.6.1) — the delegating caller must also be granted the tool — closing a confused-deputy gap.
- **Policy: global opt-in flip.** Migration `20260701000000` flips every server back to `opt-in` (deny-by-default) so revoke actually denies (revoke-staleness fix), and backfills each agent's engine as an explicit `server_grant` (implicit → explicit). The backfill is **FK-safe** (guarded by `EXISTS(mcp_servers)` — the table has a FK onto `mcp_servers(name)` with `foreign_keys=ON`), **non-clobbering** (`NOT EXISTS`, preserves explicit DENYs), and **prefix-aware** (honors the `bug-396` `mind.` strip so the grant targets the server the runtime actually resolves).

## Enforcement / behavior change

- An agent with no granted engine no longer responds; an agent can no longer reach a server it was never granted; revoke now denies.
- `System` callers (consensus synthesizer via `agent_type == "system"`, `/api/mcp/call`, `switch_model`, kernel cleanup, media preprocessing) bypass the grant gate.
- Well-formed agents (SetupWizard / AgentConsole write explicit grants) are unaffected; the engine backfill converts any implicit engine access to an explicit, auditable, revocable grant.

## Verification

- `cargo test --workspace --exclude app` — all green (incl. new `tests/capability_gate_test.rs`: opt-in truth table, PATH 1 gate deny/allow, `System` bypass, kernel RBAC + presentation/enforcement parity).
- CI-exact `clippy` clean; `cargo fmt --check` clean; `verify-issues.sh` 0 stale / 0 errors (`bug-419` FIXED, `bug-420`/`bug-421` VERIFIED).
- **Live**: dev kernel boots cleanly on this branch — migration applies, 35 MCP servers connect, no spurious gate denials; behavior verified by the maintainer.

An adversarial multi-lens review of the diff surfaced three real gaps, all fixed here: presentation⇄enforcement divergence on kernel tools, the migration prefix mismatch (`bug-396`), and the delegation caller∩target intersection.

Design: `docs/MCP_CAPABILITY_GATE_DESIGN.md`.

> **Note (Tier A):** behavior change + schema/migration — not eligible for automated self-merge; requires maintainer review + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
