### PR TITLE
fix(consensus): store 合議 answer to long-term memory, not just chat (bug-422)

### DIFF
--- a/crates/core/src/handlers/system.rs
+++ b/crates/core/src/handlers/system.rs
@@ -1040,77 +1040,13 @@ impl SystemHandler {
                         .append_message(&session_key, assistant_resp);
 
                     // エージェント返答もメモリに保存 (user messageと対で保存)
-                    if let Some(plugin) = &memory_plugin {
-                        let plugin_clone = plugin.clone();
-                        let agent_resp_msg = ClotoMessage {
-                            id: format!("{}-resp", msg.id),
-                            source: cloto_shared::MessageSource::Agent {
-                                id: agent.id.clone(),
-                            },
-                            target_agent: Some(agent.id.clone()),
-                            content: content.clone(),
-                            timestamp: Utc::now(),
-                            metadata: std::collections::HashMap::new(),
-                        };
-                        let agent_id_clone = agent.id.clone();
-                        let mem_timeout = Duration::from_secs(self.memory_timeout_secs);
-                        tokio::spawn(async move {
-                            if let Some(mem) = plugin_clone.as_memory() {
-                                let _ = tokio::time::timeout(
-                                    mem_timeout,
-                                    mem.store(agent_id_clone, agent_resp_msg),
-                                )
-                                .await;
-                            }
-                        });
-                    } else if let Some((ref mcp, ref server_id)) = mcp_memory {
-                        let mcp_clone = mcp.clone();
-                        let server_id_clone = server_id.clone();
-                        let agent_id_clone = agent.id.clone();
-                        // Same derived channel as the user-message store, so the
-                        // agent's reply is filed alongside it (the concrete
-                        // channel, bridge-type fallback). Channel is
-                        // scope-independent, so the scope is not needed here.
-                        let resp_base_channel = msg
-                            .metadata
-                            .get("external_source")
-                            .cloned()
-                            .unwrap_or_else(|| "chat".into());
-                        let resp_channel = SessionScope::derive_channel(
-                            resp_base_channel,
-                            msg.metadata.get("external_channel_id"),
-                        );
-                        let resp_session_id = msg
-                            .metadata
-                            .get("external_session_id")
-                            .cloned()
-                            .unwrap_or_default();
-                        let resp_msg_json = serde_json::json!({
-                            "id": format!("{}-resp", msg.id),
-                            "content": content.clone(),
-                            "source": { "type": "Agent", "id": agent.id },
-                            "timestamp": Utc::now().to_rfc3339(),
-                            "metadata": { "session_id": resp_session_id },
-                        });
-                        let mem_timeout2 = Duration::from_secs(self.memory_timeout_secs);
-                        tokio::spawn(async move {
-                            let store_args = serde_json::json!({
-                                "agent_id": agent_id_clone,
-                                "message": resp_msg_json,
-                                "channel": resp_channel,
-                            });
-                            let _ = tokio::time::timeout(
-                                mem_timeout2,
-                                mcp_clone.call_kind_at(
-                                    &crate::managers::Caller::Agent(agent_id_clone.clone()),
-                                    &server_id_clone,
-                                    &crate::managers::ToolKind::Store,
-                                    store_args,
-                                ),
-                            )
-                            .await;
-                        });
-                    }
+                    self.spawn_store_agent_response(
+                        &agent.id,
+                        &msg,
+                        &content,
+                        memory_plugin.as_ref(),
+                        mcp_memory.as_ref(),
+                    );
 
                     // External actions: skip chat persistence and ThoughtResponse
                     // (ExternalAction events handle display in the Actions panel)
@@ -2100,6 +2036,96 @@ impl SystemHandler {
     /// the UI. Fixes bug-417: the previous synthetic-agent-id stamping (and the
     /// missing persistence) made every consensus answer/error invisible, leaving
     /// the chat hung on "thinking…". Mirrors the normal path's persist-then-emit.
+    /// Fire-and-forget persist of an agent response into the agent's memory —
+    /// native Rust plugin (`mem.store`) or MCP memory server (`ToolKind::Store`
+    /// with the derived channel). Mirrors the normal agentic path so both
+    /// ordinary replies and consensus (合議) answers reach long-term memory.
+    /// Consensus delivery previously wrote only chat history, so合議 answers
+    /// were never recalled later (bug-419).
+    ///
+    /// `memory_plugin` / `mcp_memory` are the already-resolved memory targets
+    /// (native plugin takes precedence; the MCP fallback is gated by
+    /// `mcp_access_control` at resolution time).
+    fn spawn_store_agent_response(
+        &self,
+        agent_id: &str,
+        msg: &ClotoMessage,
+        content: &str,
+        memory_plugin: Option<&Arc<dyn cloto_shared::Plugin>>,
+        mcp_memory: Option<&(Arc<McpClientManager>, String)>,
+    ) {
+        if let Some(plugin) = memory_plugin {
+            let plugin_clone = plugin.clone();
+            let agent_resp_msg = ClotoMessage {
+                id: format!("{}-resp", msg.id),
+                source: cloto_shared::MessageSource::Agent {
+                    id: agent_id.to_string(),
+                },
+                target_agent: Some(agent_id.to_string()),
+                content: content.to_string(),
+                timestamp: Utc::now(),
+                metadata: std::collections::HashMap::new(),
+            };
+            let agent_id_clone = agent_id.to_string();
+            let mem_timeout = Duration::from_secs(self.memory_timeout_secs);
+            tokio::spawn(async move {
+                if let Some(mem) = plugin_clone.as_memory() {
+                    let _ = tokio::time::timeout(
+                        mem_timeout,
+                        mem.store(agent_id_clone, agent_resp_msg),
+                    )
+                    .await;
+                }
+            });
+        } else if let Some((mcp, server_id)) = mcp_memory {
+            let mcp_clone = mcp.clone();
+            let server_id_clone = server_id.clone();
+            let agent_id_clone = agent_id.to_string();
+            // Same derived channel as the user-message store, so the agent's
+            // reply is filed alongside it (concrete channel, bridge-type
+            // fallback). Channel is scope-independent, so no scope is needed.
+            let resp_base_channel = msg
+                .metadata
+                .get("external_source")
+                .cloned()
+                .unwrap_or_else(|| "chat".into());
+            let resp_channel = SessionScope::derive_channel(
+                resp_base_channel,
+                msg.metadata.get("external_channel_id"),
+            );
+            let resp_session_id = msg
+                .metadata
+                .get("external_session_id")
+                .cloned()
+                .unwrap_or_default();
+            let resp_msg_json = serde_json::json!({
+                "id": format!("{}-resp", msg.id),
+                "content": content.to_string(),
+                "source": { "type": "Agent", "id": agent_id.to_string() },
+                "timestamp": Utc::now().to_rfc3339(),
+                "metadata": { "session_id": resp_session_id },
+            });
+            let mem_timeout2 = Duration::from_secs(self.memory_timeout_secs);
+            tokio::spawn(async move {
+                let store_args = serde_json::json!({
+                    "agent_id": agent_id_clone,
+                    "message": resp_msg_json,
+                    "channel": resp_channel,
+                });
+                let _ = tokio::time::timeout(
+                    mem_timeout2,
+                    mcp_clone.call_kind_at(
+                        &crate::managers::Caller::Agent(agent_id_clone.clone()),
+                        &server_id_clone,
+                        &crate::managers::ToolKind::Store,
+                        store_args,
+                    ),
+                )
+                .await;
+            });
+        }
+    }
+
     async fn deliver_consensus_result(
         &self,
         agent: &AgentMetadata,
@@ -2137,6 +2163,47 @@ impl SystemHandler {
         if let Err(e) = crate::db::save_chat_message_reliable(&self.pool, &chat_msg).await {
             error!(trace_id = %trace_id, error = %e, "Consensus chat persist DROPPED");
         }
+
+        // bug-419: the consensus answer must also reach long-term memory, not
+        // just chat history. Resolve the memory target the same way the normal
+        // agentic path does (preferred_memory → native plugin, else a
+        // capability-resolved MCP memory server gated by mcp_access_control)
+        // and fire-and-forget the store under the originating agent's id.
+        let memory_plugin = if let Some(preferred_id) = agent.metadata.get("preferred_memory") {
+            self.registry.get_engine(preferred_id).await
+        } else {
+            self.registry.find_memory().await
+        };
+        let mcp_memory: Option<(Arc<McpClientManager>, String)> = if memory_plugin.is_none() {
+            if let Some(ref mcp) = self.registry.mcp_manager {
+                let granted = self
+                    .agent_manager
+                    .get_granted_server_ids(&agent.id)
+                    .await
+                    .unwrap_or_default();
+                mcp.resolve_capability_server(crate::managers::CapabilityType::Memory)
+                    .await
+                    .and_then(|server_id| {
+                        if granted.contains(&server_id) {
+                            Some((mcp.clone(), server_id))
+                        } else {
+                            None
+                        }
+                    })
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        self.spawn_store_agent_response(
+            &agent.id,
+            msg,
+            &content,
+            memory_plugin.as_ref(),
+            mcp_memory.as_ref(),
+        );
+
         let response = ClotoEventData::ThoughtResponse {
             agent_id: agent.id.clone(),
             engine_id: "consensus".to_string(),

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -3380,6 +3380,20 @@
       "fix_note": "Single capability gate threaded as Caller{Agent(id)|System} (no Default impl, so a missed site fails to compile) into BOTH manager-level execution chokepoints: PATH 1 = resolve_tool_call_target (call_server_tool/_streaming), PATH 2 = execute_tool_internal (the agentic loop + tool_hint path, which does NOT go through call_server_tool). enforce_caller_grant() consults resolve_tool_access(id, server_id, tool) once — covering engines (mind.* and bare-named MCP servers), tools, and memory uniformly. Kernel-native tools (mgp.*/gui.*) use enforce_kernel_rbac(): Deny-only on EXPLICIT deny entries via resolve_explicit_permission (default Allow), so the opt-in flip does not deny-by-default kernel tools. System callers (synthesizer via agent_type=='system', /api/mcp/call, switch_model, kernel cleanup, media preprocessing) bypass. The agentic-loop two-branch is collapsed onto execute_tool_for_agent (the empty-grant ungated branch is gone); execute_tool_for_agent's inline check_tool_access and the tool_hint bolt-on are removed (subsumed). Ships with migration 20260701000000: global opt-in flip + FK-safe non-clobbering engine backfill (default_engine_id -> server_grant). Anchored on the 'bug-421' markers in mcp.rs. Covered by db/mcp.rs resolve_tool_access unit tests, tests/engine_access_gate_test.rs (zero-grant agent denied engine; granted -> passes gate), and tests/tool_hint_access_test.rs.",
       "notes": "User-reported 2026-06-30 (LM Studio agent with no assignments still responds). Investigation (2026-07-01) refuted the design's single-chokepoint claim (two paths exist) and confirmed kernel deny-by-default as a separate live defect (fixed via enforce_kernel_rbac). Design: docs/MCP_CAPABILITY_GATE_DESIGN.md. Subsumes bug-419 (consensus engines) and bug-420 (tool_hint). 博士 decisions 2026-07-01: kernel default-Allow special-case; x-browser/github-bridge dropped (not preserved); opt-in flip global.",
       "github_issue": 241
+    },
+    {
+      "id": "bug-422",
+      "summary": "MEDIUM: Consensus terminal answer is persisted to chat history but never written to the agent's long-term memory (CPersona / memory plugin). deliver_consensus_result (added in PR #231) calls save_chat_message_reliable only; unlike the normal agentic path (which fire-and-forgets ToolKind::Store to the resolved memory plugin / capability-resolved MCP memory server under agent.id with the derived channel), it never invokes the memory Store tool. Consequence: consensus (合議) answers survive reload in the chat UI but are absent from long-term memory, so they are never recalled in later turns — a memory-continuity gap (no data loss; chat history intact).",
+      "severity": "MEDIUM",
+      "discovered": "2026-06-30T00:00:00Z",
+      "version": "0.6.8-beta.1",
+      "file": "crates/core/src/handlers/system.rs",
+      "pattern": "spawn_store_agent_response",
+      "expected": "present",
+      "status": "fixed",
+      "fixed_in": "0.6.8-beta.1",
+      "fix_note": "deliver_consensus_result now resolves the memory target the same way the normal path does (preferred_memory -> native plugin, else capability-resolved MCP memory server gated by mcp_access_control) and fire-and-forgets the store via a new shared spawn_store_agent_response helper. The helper is extracted from the normal agentic path's inline store block, so ordinary replies and consensus answers now go through one code path; the consensus answer is filed under the originating agent.id with the derived channel, matching the normal reply's memory record.",
+      "notes": "User-reported 2026-06-30 (consensus answers not recalled in later turns). MEDIUM: memory-continuity gap, not data loss — chat_messages persistence (bug-417 fix) is unaffected. Task #118 / Goal #138. Cross-ref bug-417 (chat delivery), docs/CONSENSUS_REVIVAL_DESIGN.md. Registered as bug-422 because bug-419 — the id named in the original task write-up — was already assigned to the consensus-engine-grants issue."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Consensus (合議) terminal answers were persisted to chat history but **never written to the agent's long-term memory** (CPersona / memory plugin). `deliver_consensus_result` (added in PR #231) called `save_chat_message_reliable` only; unlike the normal agentic path it never fired `ToolKind::Store` to the resolved memory plugin / MCP memory server. Consequence: consensus answers survived reload in the chat UI but were absent from long-term memory and **never recalled in later turns** — a memory-continuity gap (no data loss; chat history intact).

Fixes **bug-422** (MEDIUM). Task #118 / Goal #138 (consensus revival).

## Changes

- Extract the normal agentic path's inline memory-store block into a shared `spawn_store_agent_response` helper:
  - native Rust memory plugin → `mem.store`
  - else capability-resolved MCP memory server → `ToolKind::Store` with the derived channel
- Call it from `deliver_consensus_result` after resolving the memory target the same way the normal path does (`preferred_memory` → native plugin, else `mcp_access_control`-gated MCP memory server), filed under the **originating agent id**.
- Normal replies and consensus answers now go through **one code path** (removes ~66 lines of duplication).
- Register `bug-422` in `qa/issue-registry.json` (status: fixed).

> Note: the id `bug-419` named in the original task write-up was already assigned to the consensus-engine-grants issue, so this is registered as `bug-422`.

## Verification (local, all green)

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --exclude app` (CI-exact flags from `ci.yml`) — clean
- `cargo test --workspace --exclude app` — all pass (incl. `consensus_test` 3/3)
- `bash scripts/verify-issues.sh` — bug-422 `[VERIFIED]`, exit 0; pre-commit registry check passed

### Testing note

The fire-and-forget MCP memory store cannot be observed in `consensus_test` (there is no mock memory server; every engine/memory is an external MCP, and the test file's stated philosophy is structural guarantees only, with the happy path verified against the running app). Coverage is via the shared-helper extraction plus the existing normal-path tests that exercise the same store code. The happy path is best confirmed against a running kernel with a memory plugin (e.g. a `consensus:` message, then a follow-up turn that recalls it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
