### PR TITLE
fix(dashboard): DeepSeek engine shows 'not connected' in agent console (bug-425)

### DIFF
--- a/dashboard/src/components/AgentConsole.tsx
+++ b/dashboard/src/components/AgentConsole.tsx
@@ -21,6 +21,7 @@ import { useMcpServers } from '../hooks/useMcpServers';
 import { AgentIcon, agentColor } from '../lib/agentIdentity';
 import { findBranchPoints, flattenConversation } from '../lib/conversationTree';
 import { sendNativeNotification } from '../lib/notifications';
+import { isEngineServer } from '../lib/serverCategory';
 import { openVrmWindow } from '../lib/tauri';
 import { EVENTS_URL } from '../services/api';
 import type {
@@ -174,19 +175,20 @@ export function AgentConsole({ agent, onBack }: { agent: AgentMetadata; onBack: 
   const displayMessages = useMemo(() => flattenConversation(messages, activeBranches), [messages, activeBranches]);
   const branchPoints = useMemo(() => findBranchPoints(messages, activeBranches), [messages, activeBranches]);
 
-  // Resolve agent's granted mind.* servers for engine selector
+  // Resolve the agent's granted engine servers for the engine selector.
   useEffect(() => {
     api
       .getAgentAccess(agent.id)
       .then(({ entries }) => {
-        const grantedMindIds = new Set(
-          entries
-            .filter(
-              (e) => e.entry_type === 'server_grant' && e.permission === 'allow' && e.server_id.startsWith('mind.'),
-            )
-            .map((e) => e.server_id),
+        const grantedServerIds = new Set(
+          entries.filter((e) => e.entry_type === 'server_grant' && e.permission === 'allow').map((e) => e.server_id),
         );
-        setAgentEngines(mcpServers.filter((s) => grantedMindIds.has(s.id)));
+        // Keep any granted server the kernel treats as an engine — including
+        // de-prefixed ClotoHub catalog engines (e.g. `deepseek`) that lack the
+        // legacy `mind.` prefix (bug-388/396). The old prefix-only filter
+        // dropped them, so catalog engines showed as "not connected" here even
+        // when granted. Mirror AgentTerminal / AgentPluginWorkspace.
+        setAgentEngines(mcpServers.filter((s) => grantedServerIds.has(s.id) && isEngineServer(s)));
       })
       .catch(() => {
         /* engine list may be unavailable */

--- a/dashboard/src/components/ServerAccessSection.tsx
+++ b/dashboard/src/components/ServerAccessSection.tsx
@@ -41,7 +41,7 @@ export function ServerAccessSection({
   onApplyPreset,
 }: Props) {
   const { t } = useTranslation('agents');
-  const activePreset = detectPreset(grantedIds);
+  const activePreset = detectPreset(grantedIds, grantedServers);
 
   return (
     <>

--- a/dashboard/src/lib/presets.ts
+++ b/dashboard/src/lib/presets.ts
@@ -1,6 +1,8 @@
 /** Server preset definitions shared between SetupWizard and AgentConfig. */
 
 import { Box, Layers, type LucideIcon, Shield, Zap } from 'lucide-react';
+import type { McpServerInfo } from '../types';
+import { isEngineServer } from './serverCategory';
 
 export const MINIMAL_SERVERS = ['cpersona', 'tool.agent_utils'];
 
@@ -25,11 +27,20 @@ export const SERVER_PRESETS: PresetInfo[] = [
 ];
 
 /**
- * Detect which preset matches the current granted set (ignoring mind.* engines).
+ * Detect which preset matches the current granted set (ignoring engines).
  * Returns the preset id or null if no exact match.
+ *
+ * Engines are excluded via `isEngineServer` so de-prefixed ClotoHub catalog
+ * engines (e.g. `deepseek`, which lacks the legacy `mind.` prefix — bug-388/396)
+ * are not counted as preset servers. Falls back to prefix matching when a
+ * granted id has no known server object.
  */
-export function detectPreset(grantedIds: Set<string>): string | null {
-  const nonEngine = [...grantedIds].filter((id) => !id.startsWith('mind.'));
+export function detectPreset(grantedIds: Set<string>, servers: McpServerInfo[] = []): string | null {
+  const isEngine = (id: string): boolean => {
+    const server = servers.find((s) => s.id === id);
+    return server ? isEngineServer(server) : id.startsWith('mind.');
+  };
+  const nonEngine = [...grantedIds].filter((id) => !isEngine(id));
   const sorted = nonEngine.sort().join(',');
   for (const preset of SERVER_PRESETS) {
     if (preset.servers.sort().join(',') === sorted) return preset.id;

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -4,6 +4,18 @@
   "description": "Mechanical verification registry for documented issues. Source of truth for bug existence proof.",
   "issues": [
     {
+      "id": "bug-425",
+      "summary": "MEDIUM: AgentConsole engine selector resolved the agent's granted engines with a prefix-only filter (e.server_id.startsWith('mind.')), so de-prefixed ClotoHub catalog engines (e.g. deepseek — bug-388/396 de-prefixing drops the legacy mind. namespace) were excluded from agentEngines. A deepseek engine granted to an agent therefore appeared as not connected in the chat console, even though AgentTerminal/AgentPluginWorkspace (which use isEngineServer) recognised it correctly. Same de-prefix holdout class also affected preset detection (presets.ts detectPreset counted a granted de-prefixed engine as a non-engine server, breaking active-preset match). Reported by user 2026-07-01.",
+      "severity": "MEDIUM",
+      "discovered": "2026-07-01T00:00:00Z",
+      "version": "0.6.8-beta.1",
+      "file": "dashboard/src/components/AgentConsole.tsx",
+      "pattern": "e\\.server_id\\.startsWith\\('mind\\.'\\)",
+      "expected": "absent",
+      "status": "fixed",
+      "notes": "FIXED 2026-07-01: AgentConsole engine-grant resolution now filters granted servers by isEngineServer(mcpServers lookup) instead of the mind. prefix, matching AgentTerminal/AgentPluginWorkspace. presets.ts detectPreset(grantedIds, servers) now excludes engines via isEngineServer (falls back to prefix when server unknown); ServerAccessSection passes grantedServers. Related same-class holdout NOT changed: AgentConsole.tsx thinking-viz event filter uses engine_id?.startsWith(mind.) — left as-is (broadening risks cross-agent event leakage; de-prefixed engine thinking events for THIS agent are still caught by the agent_id clause). Root: bug-388/396 de-prefixed catalog server ids; canonical engine test = lib/serverCategory.ts isEngineServer."
+    },
+    {
       "id": "bug-139",
       "summary": "PluginManifest/PluginCast traits in shared crate — legacy but used by tests",
       "severity": "LOW",


### PR DESCRIPTION
## Symptom
A DeepSeek engine granted to an agent appeared **"not connected"** in the chat
console's engine selector.

## Root cause
The console resolved an agent's granted engines with a **prefix-only** filter
(`e.server_id.startsWith('mind.')`). De-prefixed ClotoHub catalog engines — e.g.
`deepseek`, whose server id drops the legacy `mind.` namespace (bug-388/396) —
were excluded from `agentEngines` and dropped from the selector.

Verified via the running DB: the affected agents' grants are canonically keyed
`deepseek` with `default_engine_id=deepseek`, so the backend capability gate
(`resolve_tool_access(agent,"deepseek","think")`) **permits** the call —
`AgentTerminal` / `AgentPluginWorkspace` already recognise the engine via the
tool-surface `isEngineServer` test. Only the console's engine-grant resolution
was a prefix-only holdout.

## Fix
- **AgentConsole** — resolve granted engines by `isEngineServer` (looked up in
  `mcpServers`) instead of the `mind.` prefix, matching the other engine surfaces.
- **presets.ts** — `detectPreset(grantedIds, servers)` now excludes engines via
  `isEngineServer` (prefix fallback when a server object is unknown), so a
  granted de-prefixed engine no longer breaks active-preset matching;
  `ServerAccessSection` passes `grantedServers`.
- **Registry** — bug-425 (MEDIUM) → fixed/absent (`verify-issues.sh`: `[FIXED]`).

Gates: biome + build green; `verify-issues.sh` exit 0.

## Related
This is the **scenario-A** (frontend) stopgap. A distinct latent bug —
scenario B, where the Setup Wizard persists the `mind.deepseek` alias as the
grant key and the gate denies it for fresh wizard-configured agents — is the
root that the `mind.` prefix retirement line (**Goal #142**,
`docs/MIND_PREFIX_RETIREMENT_DESIGN.md`) addresses. Not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)