### PR TITLE
fix(mcp): reap MCP subprocess trees on restart and app exit

### DIFF
--- a/crates/core/src/handlers.rs
+++ b/crates/core/src/handlers.rs
@@ -223,35 +223,10 @@ pub async fn shutdown_handler(
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        // Drain all MCP servers concurrently (5s per server, 10s global cap)
-        let server_ids: Vec<String> = {
-            let state = mcp.state.read().await;
-            state.servers.keys().cloned().collect()
-        };
-        let drain_futures: Vec<_> = server_ids
-            .iter()
-            .map(|sid| {
-                let mcp = mcp.clone();
-                let sid = sid.clone();
-                async move {
-                    if let Err(e) = mcp.drain_server(&sid, "kernel shutdown", 5000).await {
-                        tracing::warn!(server = %sid, error = %e, "MCP drain failed during shutdown");
-                    }
-                }
-            })
-            .collect();
-        if tokio::time::timeout(
-            Duration::from_secs(10),
-            futures::future::join_all(drain_futures),
-        )
-        .await
-        .is_err()
-        {
-            tracing::error!(
-                "MCP shutdown drain timed out after 10s — {} server(s) may not have shut down cleanly",
-                server_ids.len()
-            );
-        }
+        // Drain all MCP servers (5s per server, 10s global cap), reaping each
+        // child's process group. Shared with the Tauri app-exit path via
+        // McpClientManager::drain_all (orphan-leak fix, Step 4).
+        mcp.drain_all("kernel shutdown", 5000, 10).await;
 
         // 🚧 Signal maintenance mode (atomic write to prevent symlink attacks)
         let maint = crate::config::exe_dir().join(".maintenance");

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -315,6 +315,10 @@ pub type AppResult<T> = Result<T, AppError>;
 pub struct KernelHandle {
     /// Notify to trigger graceful shutdown of the HTTP server and background tasks.
     pub shutdown: Arc<Notify>,
+    /// The MCP client manager, exposed so an embedder (e.g. Tauri) can drain and
+    /// reap MCP subprocesses on app exit instead of orphaning them
+    /// (orphan-leak fix, Step 4). Use `mcp_manager.drain_all(...)` before exit.
+    pub mcp_manager: Arc<managers::McpClientManager>,
     /// Join handle for the HTTP server task.
     _server_task: tokio::task::JoinHandle<()>,
 }
@@ -1329,6 +1333,7 @@ pub async fn start_kernel() -> anyhow::Result<KernelHandle> {
 
     Ok(KernelHandle {
         shutdown: shutdown_handle,
+        mcp_manager: app_state.mcp_manager.clone(),
         _server_task: server_task,
     })
 }

--- a/crates/core/src/managers/mcp.rs
+++ b/crates/core/src/managers/mcp.rs
@@ -99,6 +99,11 @@ pub struct McpClientManager {
     /// Default minimum severity sent via `logging/setLevel` to servers that
     /// advertise the MCP `logging` capability (design §7).
     mcp_default_log_level: String,
+    /// Per-server-id locks serialising connect/restart so concurrent restart
+    /// triggers (health monitor, manual API, env update) can't both spawn a child
+    /// and orphan the previous one (orphan-leak fix, Step 2). Different ids still
+    /// connect in parallel — only same-id connects serialise.
+    connect_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
 }
 
 impl McpClientManager {
@@ -135,7 +140,20 @@ impl McpClientManager {
             allow_unsigned: false,
             sandbox_base_dir: std::path::PathBuf::from("data/mcp-sandbox"),
             mcp_default_log_level: super::mcp_client::DEFAULT_MCP_LOG_LEVEL.to_string(),
+            connect_locks: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Get (or lazily create) the per-server-id lock that serialises
+    /// connect/restart for `id` (orphan-leak fix, Step 2). Held across the whole
+    /// of `connect_server` so two concurrent restart triggers can't double-spawn
+    /// a child and orphan the previous one.
+    async fn connect_lock_for(&self, id: &str) -> Arc<Mutex<()>> {
+        let mut locks = self.connect_locks.lock().await;
+        locks
+            .entry(id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
     }
 
     /// Configure isolation settings from AppConfig (called once at startup).
@@ -778,6 +796,13 @@ impl McpClientManager {
     pub async fn connect_server(&self, config: McpServerConfig) -> Result<Vec<String>> {
         let id = config.id.clone();
 
+        // Orphan-leak fix (Step 2): serialise connect for this id so concurrent
+        // restart triggers (health monitor, manual API, env update) can't both
+        // spawn a child and orphan the previous one. Held for the whole function;
+        // different ids still connect in parallel.
+        let connect_lock = self.connect_lock_for(&id).await;
+        let _connect_guard = connect_lock.lock().await;
+
         let is_http_transport = config.transport == "streamable-http";
 
         // Validate command against whitelist (skip for HTTP transport)
@@ -1391,6 +1416,22 @@ impl McpClientManager {
             connected_at: Some(std::time::Instant::now()),
             isolation_profile,
         };
+
+        // Orphan-leak fix (Step 1): if a handle for this id already holds a live
+        // client (a racy reconnect, or a prior stop that failed), reap its child
+        // process group before overwriting the entry — otherwise the old
+        // subprocess (and its forked subtree) is dropped with only a best-effort
+        // start_kill and can leak. Take the client out under the lock, then run
+        // the (up-to-~8s) kill_and_wait with the lock released. The per-id
+        // connect_lock held above guarantees no concurrent connect races this.
+        let previous_client = {
+            let mut state = self.state.write().await;
+            state.servers.get_mut(&id).and_then(|h| h.client.take())
+        };
+        if let Some(old) = previous_client {
+            debug!(server = %id, "Reaping previous live client before re-registering");
+            old.shutdown().await;
+        }
 
         // Register in servers map + update tool routing index under single lock.
         // Skip reasoning engines — their tools (think, think_with_tools) are
@@ -2879,6 +2920,41 @@ impl McpClientManager {
         Ok(())
     }
 
+    /// Drain and stop **every** MCP server, reaping each child's process group.
+    /// Shared by the HTTP `/api/system/shutdown` endpoint and the Tauri app-exit
+    /// path (orphan-leak fix, Step 4) so a GUI quit reaps subprocesses instead of
+    /// orphaning them. Each server gets `per_server_ms` to drain gracefully; the
+    /// whole sweep is capped at `global_timeout_secs`.
+    pub async fn drain_all(&self, reason: &str, per_server_ms: u64, global_timeout_secs: u64) {
+        let server_ids: Vec<String> = {
+            let state = self.state.read().await;
+            state.servers.keys().cloned().collect()
+        };
+        if server_ids.is_empty() {
+            return;
+        }
+        let drain_futures = server_ids.iter().map(|sid| {
+            let sid = sid.clone();
+            async move {
+                if let Err(e) = self.drain_server(&sid, reason, per_server_ms).await {
+                    tracing::warn!(server = %sid, error = %e, "MCP drain failed");
+                }
+            }
+        });
+        if tokio::time::timeout(
+            std::time::Duration::from_secs(global_timeout_secs),
+            futures::future::join_all(drain_futures),
+        )
+        .await
+        .is_err()
+        {
+            tracing::error!(
+                "MCP drain_all timed out after {global_timeout_secs}s — {} server(s) may not have shut down cleanly",
+                server_ids.len()
+            );
+        }
+    }
+
     /// Start a stopped or errored server by re-connecting with its preserved config.
     pub async fn start_server(&self, id: &str) -> Result<Vec<String>> {
         // 1. Read config from existing entry (clone, don't move)
@@ -2969,8 +3045,13 @@ impl McpClientManager {
         )
         .await;
 
-        // Stop if running (ignore error if already stopped)
-        let _ = self.stop_server(id).await;
+        // Stop if running. A failed stop that leaves the old client attached would
+        // otherwise be silently overwritten by start_server below; log it so the
+        // orphan-leak reap in connect_server (Step 1) is the visible safety net,
+        // not silence. ("already stopped" is expected and benign.)
+        if let Err(e) = self.stop_server(id).await {
+            debug!(server = %id, error = %e, "stop during restart failed (continuing to start)");
+        }
         self.start_server(id).await
     }
 
@@ -3049,7 +3130,9 @@ impl McpClientManager {
         }
 
         // Restart to apply new env
-        let _ = self.restart_server(id).await;
+        if let Err(e) = self.restart_server(id).await {
+            warn!(server = %id, error = %e, "restart after env update failed");
+        }
         Ok(())
     }
 
@@ -3757,5 +3840,147 @@ mod tests {
         assert!(super::detect_external_rejection("{status: rejected}").is_none());
         // Empty string
         assert!(super::detect_external_rejection("").is_none());
+    }
+
+    // ── drain_all reaps subprocess trees end-to-end (orphan-leak fix, Step 4) ──
+
+    /// Poll `kill(pid, 0)` until the process is gone (reaped) or the deadline
+    /// elapses. Returns true if it terminated.
+    #[cfg(unix)]
+    async fn wait_pid_gone(pid: i32, within: std::time::Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + within;
+        loop {
+            // SAFETY: signal 0 only probes existence/permission, sends nothing.
+            if unsafe { libc::kill(pid, 0) } != 0 {
+                return true; // ESRCH — process no longer exists
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    /// End-to-end proof of Step 4 through the real manager: a connected server
+    /// that forked a helper (grandchild) has its whole process group reaped when
+    /// `drain_all` runs, so the app-exit path can no longer orphan MCP
+    /// subprocesses. Exercises drain_all → drain_server → stop_server →
+    /// client.shutdown() → kill_and_wait() with a real subprocess tree.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn drain_all_reaps_connected_server_subtree() {
+        // Mock MCP server: fork a long-lived `sleep 600` grandchild, record its
+        // PID to a file, answer `initialize`, then stay alive on stdin.
+        const MOCK: &str = "import sys, json, os, subprocess\n\
+g = subprocess.Popen(['sleep', '600'])\n\
+open(os.environ['CLOTO_TEST_PIDFILE'], 'w').write(str(g.pid))\n\
+while True:\n\
+\x20   line = sys.stdin.readline()\n\
+\x20   if not line:\n\
+\x20       break\n\
+\x20   line = line.strip()\n\
+\x20   if not line:\n\
+\x20       continue\n\
+\x20   try:\n\
+\x20       req = json.loads(line)\n\
+\x20   except Exception:\n\
+\x20       continue\n\
+\x20   if req.get('method') == 'initialize':\n\
+\x20       sys.stdout.write(json.dumps({'jsonrpc': '2.0', 'id': req.get('id'), 'result': {}}) + '\\n')\n\
+\x20       sys.stdout.flush()\n";
+
+        if std::process::Command::new("python3")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            eprintln!("skipping drain_all_reaps_connected_server_subtree: python3 not found");
+            return;
+        }
+
+        // Temp pidfile for the grandchild PID handoff.
+        let pidfile =
+            std::env::temp_dir().join(format!("cloto_drain_test_{}.pid", std::process::id()));
+        let _ = std::fs::remove_file(&pidfile);
+        let mut env = std::collections::HashMap::new();
+        env.insert(
+            "CLOTO_TEST_PIDFILE".to_string(),
+            pidfile.to_string_lossy().to_string(),
+        );
+
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let manager = McpClientManager::new(pool, false, 30, 30);
+
+        let (notif_tx, _notif_rx) = tokio::sync::mpsc::channel::<McpNotification>(16);
+        let (client, _caps) = McpClient::connect(
+            "mock-drain",
+            "python3",
+            &["-c".to_string(), MOCK.to_string()],
+            &env,
+            notif_tx,
+            5,
+            5,
+            None,
+            0,
+            &[],
+            crate::managers::mcp_client::DEFAULT_MCP_LOG_LEVEL,
+        )
+        .await
+        .expect("mock server should complete the initialize handshake");
+
+        // Register a live Connected handle directly — bypasses the seal gate;
+        // drain_all only needs a handle holding a live client.
+        let handle = McpServerHandle {
+            id: "mock-drain".to_string(),
+            config: McpServerConfig {
+                id: "mock-drain".to_string(),
+                command: "python3".to_string(),
+                ..Default::default()
+            },
+            client: Some(std::sync::Arc::new(client)),
+            tools: Vec::new(),
+            handshake: None,
+            mgp_negotiated: None,
+            status: ServerStatus::Connected,
+            audit_seq: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            connected_at: Some(std::time::Instant::now()),
+            isolation_profile: None,
+        };
+        manager
+            .state
+            .write()
+            .await
+            .servers
+            .insert("mock-drain".to_string(), handle);
+
+        // Read the grandchild PID the mock recorded.
+        let mut grandchild: i32 = 0;
+        for _ in 0..50 {
+            if let Ok(s) = std::fs::read_to_string(&pidfile) {
+                if let Ok(pid) = s.trim().parse::<i32>() {
+                    grandchild = pid;
+                    break;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(
+            grandchild > 0,
+            "mock server did not record its grandchild PID"
+        );
+        assert_eq!(
+            unsafe { libc::kill(grandchild, 0) },
+            0,
+            "grandchild {grandchild} should be alive before drain_all"
+        );
+
+        // Behaviour under test: drain reaps the whole subtree.
+        manager.drain_all("test drain", 100, 5).await;
+
+        assert!(
+            wait_pid_gone(grandchild, std::time::Duration::from_secs(5)).await,
+            "grandchild {grandchild} survived drain_all — Step 4 failed to reap the subtree"
+        );
+        let _ = std::fs::remove_file(&pidfile);
     }
 }

--- a/crates/core/src/managers/mcp_transport.rs
+++ b/crates/core/src/managers/mcp_transport.rs
@@ -166,9 +166,22 @@ pub struct StdioTransport {
 
 impl Drop for StdioTransport {
     fn drop(&mut self) {
-        // P9: Ensure child process is killed on transport drop
+        // P9 + orphan-leak fix: the child is spawned as its own process-group
+        // leader (`process_group(0)` in `start`), so kill the whole group — not
+        // just the direct PID — otherwise a dropped transport strands any helper
+        // processes the server forked (grandchildren). Best-effort and
+        // synchronous: Drop can't await, and `kill_on_drop(true)` still reaps the
+        // direct child. Prefer explicit `kill_and_wait()` wherever an async
+        // context is available.
+        #[cfg(unix)]
+        if let Some(pid) = self.child.id() {
+            // SAFETY: forceful kill of a process group we created and own.
+            unsafe {
+                libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+            }
+        }
         let _ = self.child.start_kill();
-        debug!("StdioTransport dropped — child process kill signal sent");
+        debug!("StdioTransport dropped — child process group kill signal sent");
     }
 }
 
@@ -176,17 +189,23 @@ impl StdioTransport {
     /// Kill the child process and wait for it to actually exit.
     /// Ensures file locks (DB, ports) are released before returning.
     pub async fn kill_and_wait(&mut self) {
-        // bug-358: try a graceful SIGTERM first so the MCP server can flush
-        // state and release locks, then escalate to SIGKILL if it refuses to
-        // exit. SIGTERM is Unix-only; other platforms go straight to start_kill
-        // (already a forceful kill).
+        // bug-358 + orphan-leak fix: the child is spawned as its own
+        // process-group leader (`process_group(0)` in `start`), so signalling the
+        // negative pid (== pgid) delivers to the server AND every helper process
+        // it forked, reaping the whole subtree instead of leaking grandchildren.
+        // Try a graceful SIGTERM first so the server can flush state and release
+        // locks, then escalate to SIGKILL. Unix-only; other platforms go straight
+        // to start_kill (single-PID — subtree containment there needs a Job
+        // Object, tracked for the cross-platform harness).
         #[cfg(unix)]
         {
             if let Some(pid) = self.child.id() {
-                // SAFETY: sending SIGTERM to a child PID we own. libc::kill is
-                // the only way to send a non-SIGKILL signal via tokio's process API.
+                let pgid = pid as libc::pid_t;
+                // SAFETY: signalling a process group we created and own (the child
+                // is its own group leader). A stray pgid at worst no-ops (ESRCH),
+                // and the start_kill fallback below still reaps the direct child.
                 unsafe {
-                    libc::kill(pid as libc::pid_t, libc::SIGTERM);
+                    libc::kill(-pgid, libc::SIGTERM);
                 }
                 if let Ok(Ok(status)) = tokio::time::timeout(
                     std::time::Duration::from_secs(SHUTDOWN_GRACE_SECS),
@@ -194,16 +213,21 @@ impl StdioTransport {
                 )
                 .await
                 {
-                    debug!("Child process exited gracefully after SIGTERM: {status}");
+                    debug!("Child process group exited gracefully after SIGTERM: {status}");
                     return;
                 }
                 tracing::warn!(
-                    "Child did not exit within {SHUTDOWN_GRACE_SECS}s of SIGTERM — escalating to SIGKILL"
+                    "Child did not exit within {SHUTDOWN_GRACE_SECS}s of SIGTERM — escalating to SIGKILL (process group)"
                 );
+                // SAFETY: same owned process group, forceful kill of the subtree.
+                unsafe {
+                    libc::kill(-pgid, libc::SIGKILL);
+                }
             }
         }
 
-        // SIGKILL fallback (also the primary path on non-Unix targets).
+        // SIGKILL fallback for the direct child (also the primary path on non-Unix
+        // targets) + reap so we never leave a zombie of our own child.
         let _ = self.child.start_kill();
         match tokio::time::timeout(std::time::Duration::from_secs(5), self.child.wait()).await {
             Ok(Ok(status)) => {
@@ -263,6 +287,17 @@ impl StdioTransport {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+
+        // Orphan-leak fix: put each MCP server in its own process group so the
+        // child becomes the group leader (pgid == child pid). On restart/shutdown
+        // we signal the whole group (see `kill_and_wait` / `Drop`), reaping any
+        // helper processes the server forks (a launcher → real server, a bridge →
+        // workers) as a unit instead of orphaning them with a bare single-PID
+        // kill. Unix-only; Windows subtree containment needs a Job Object (TODO,
+        // tracked for the cross-platform harness) — the CREATE_NO_WINDOW path
+        // below is unchanged there.
+        #[cfg(unix)]
+        cmd.process_group(0);
 
         // Windows: prevent console windows from appearing for child processes
         #[cfg(windows)]
@@ -827,5 +862,80 @@ mod tests {
         // Relative scripts depend on the child cwd; not checkable here.
         let args = vec!["server.py".to_string()];
         assert!(validate_entry_point_exists("python", &args).is_ok());
+    }
+
+    // ── process-group reaping (orphan-leak fix, Step 3) ──
+
+    /// Poll `kill(pid, 0)` until the process is gone (reaped by init) or the
+    /// deadline elapses. Returns true if it terminated.
+    #[cfg(unix)]
+    async fn wait_gone(pid: libc::pid_t, within: std::time::Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + within;
+        loop {
+            // SAFETY: signal 0 only probes existence/permission, sends nothing.
+            if unsafe { libc::kill(pid, 0) } != 0 {
+                return true; // ESRCH — process no longer exists
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    /// The core RC3 guarantee: a helper process the server forks (a grandchild)
+    /// must be reaped when the server is killed. Because each server is spawned as
+    /// its own process-group leader and `kill_and_wait` signals the whole group,
+    /// the grandchild dies too — a bare single-PID kill would leave it orphaned.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn kill_and_wait_reaps_the_whole_process_group() {
+        // python launcher that forks a long-lived `sleep 600` grandchild, prints
+        // its PID to stderr, then idles. Killing only the direct (python) PID
+        // would strand the sleep; the process-group kill must take it out.
+        let script = "import sys,subprocess,time;\
+                      p=subprocess.Popen(['sleep','600']);\
+                      sys.stderr.write(str(p.pid)+chr(10));sys.stderr.flush();\
+                      time.sleep(600)";
+        let (tx, mut rx) = mpsc::channel::<String>(16);
+        let started = StdioTransport::start(
+            "python3",
+            &["-c".to_string(), script.to_string()],
+            &HashMap::new(),
+            None,
+            0,
+            &[],
+            Some(tx),
+        )
+        .await;
+        // Skip gracefully where python3 is unavailable rather than fail spuriously.
+        let Ok(mut transport) = started else {
+            eprintln!("skipping: python3 unavailable for process-group test");
+            return;
+        };
+
+        // First stderr line is the grandchild PID.
+        let line = match tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv()).await {
+            Ok(Some(l)) => l,
+            _ => {
+                eprintln!("skipping: no grandchild PID line from python3");
+                return;
+            }
+        };
+        let grandchild: libc::pid_t = line.trim().parse().expect("grandchild pid");
+
+        // Precondition: the grandchild is alive before we kill.
+        assert_eq!(
+            unsafe { libc::kill(grandchild, 0) },
+            0,
+            "grandchild {grandchild} should be alive before kill_and_wait"
+        );
+
+        transport.kill_and_wait().await;
+
+        assert!(
+            wait_gone(grandchild, std::time::Duration::from_secs(5)).await,
+            "grandchild {grandchild} survived kill_and_wait — process-group reap failed (orphan leak)"
+        );
     }
 }

--- a/dashboard/src-tauri/src/lib.rs
+++ b/dashboard/src-tauri/src/lib.rs
@@ -19,6 +19,41 @@ macro_rules! with_window_log {
 /// Holds the API key for the dashboard (auto-generated or from .env).
 static DASHBOARD_API_KEY: OnceLock<String> = OnceLock::new();
 
+/// The running kernel handle, captured once `start_kernel` succeeds. Kept alive
+/// here (the kernel task runs regardless) and used by the app-exit path to drain
+/// and reap MCP subprocesses instead of orphaning them (orphan-leak fix, Step 4).
+static KERNEL_HANDLE: OnceLock<cloto_core::KernelHandle> = OnceLock::new();
+
+/// Guard so the MCP drain runs at most once across the tray-quit and
+/// `RunEvent::ExitRequested` paths.
+static MCP_DRAINED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Drain and reap all MCP subprocesses before the process exits.
+///
+/// Runs at most once (guarded). `app.exit()` / `std::process::exit` skip Rust
+/// destructors, so `kill_on_drop` and transport `Drop` never fire on a normal
+/// quit — the drain must be explicit. The async drain is spawned on the
+/// Tauri/tokio runtime and the calling (GUI) thread blocks until it completes or
+/// a hard cap elapses, so quit stays responsive even if a server ignores SIGTERM.
+fn drain_mcp_before_exit() {
+    use std::sync::atomic::Ordering;
+    if MCP_DRAINED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let Some(handle) = KERNEL_HANDLE.get() else {
+        return;
+    };
+    let mcp = handle.mcp_manager.clone();
+    let (tx, rx) = std::sync::mpsc::channel::<()>();
+    tauri::async_runtime::spawn(async move {
+        // 2s graceful drain per server, 6s global cap; the recv timeout below is
+        // the hard ceiling on how long quit may block.
+        mcp.drain_all("app exit", 2000, 6).await;
+        let _ = tx.send(());
+    });
+    let _ = rx.recv_timeout(std::time::Duration::from_secs(8));
+}
+
 /// Generate a cryptographically random API key (64 hex chars).
 fn generate_api_key() -> String {
     use rand::rngs::OsRng;
@@ -442,6 +477,10 @@ pub fn run() {
                         }
                     }
                     "quit" => {
+                        // Reap MCP subprocesses before exiting (orphan-leak fix,
+                        // Step 4). app.exit skips destructors, so this explicit
+                        // drain is the only reliable reap on quit.
+                        drain_mcp_before_exit();
                         app.exit(0);
                     }
                     _ => {}
@@ -492,9 +531,12 @@ pub fn run() {
             let kernel_app_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 match cloto_core::start_kernel().await {
-                    Ok(_handle) => {
-                        // Kernel ready — _handle is kept alive by the spawn.
-                        // Shutdown is triggered via the /api/system/shutdown endpoint.
+                    Ok(handle) => {
+                        // Kernel ready. Stash the handle so the app-exit path can
+                        // drain and reap MCP subprocesses (orphan-leak fix, Step 4);
+                        // the kernel task keeps running regardless. Shutdown is also
+                        // available via the /api/system/shutdown endpoint.
+                        let _ = KERNEL_HANDLE.set(handle);
                     }
                     Err(e) => {
                         eprintln!("FATAL: Failed to start Cloto Kernel: {}", e);
@@ -559,11 +601,19 @@ pub fn run() {
         .expect("error while building tauri application");
 
     // Run with cleanup on exit
-    app.run(|_app_handle, event| {
-        if let tauri::RunEvent::Exit = event {
+    app.run(|_app_handle, event| match event {
+        // Fires before the process tears down (covers macOS Cmd+Q and any other
+        // exit path, not just the tray Quit item). Drain MCP subprocesses here
+        // too — the once-guard makes a second call after tray Quit a no-op
+        // (orphan-leak fix, Step 4).
+        tauri::RunEvent::ExitRequested { .. } => {
+            drain_mcp_before_exit();
+        }
+        tauri::RunEvent::Exit => {
             // Clean up stale maintenance file if present
             let maint = cloto_core::config::exe_dir().join(".maintenance");
             let _ = std::fs::remove_file(maint);
         }
+        _ => {}
     });
 }

--- a/qa/issue-registry.json
+++ b/qa/issue-registry.json
@@ -2242,7 +2242,7 @@
       "discovered": "2026-03-20T00:00:00Z",
       "version": "0.6.3-alpha.10",
       "commit": "08fc0e1",
-      "file": "crates/core/src/handlers.rs",
+      "file": "crates/core/src/managers/mcp.rs",
       "pattern": "join_all\\(drain_futures\\)",
       "expected": "present",
       "status": "fixed"


### PR DESCRIPTION
## Problem

The kernel leaked MCP server subprocesses — most visibly the discord bridge (48 orphans observed) — because children survived both restart and kernel shutdown. This is a recurring class of bug (known since 2026-04-14).

### Root causes
- **RC1 (restart):** `connect_server` overwrote an existing handle (`state.servers.insert`) whose client still held a live child, dropping it with only a best-effort `start_kill` (no shutdown/wait). The dup guard only rejected `status == Connected`, so any other status leaked.
- **RC2 (shutdown):** the iterate-and-kill drain lived only behind `POST /api/system/shutdown` and was never wired to the Tauri lifecycle. Tray Quit → `app.exit(0)` and `RunEvent::Exit` skip Rust destructors, so `kill_on_drop` never fired and every direct child leaked on a GUI quit.
- **RC3 (grandchildren):** children were spawned without a process group, so SIGTERM/SIGKILL hit only the direct PID — any helper a server forked survived even the graceful drain.

## Fix (Steps 1–4)
- **Step 1:** `connect_server` reaps a pre-existing live client (take + `shutdown()`, with the state lock released across the ~8s `kill_and_wait`) before overwriting the handle, and reasons about a live client rather than only `status`.
- **Step 2:** per-server-id `connect_locks` serialise connect/restart so the health monitor, manual API, and env-update restarts can't double-spawn and orphan the previous child; swallowed stop/restart `Result`s are now logged.
- **Step 3:** spawn each server as its own process-group leader (`process_group(0)`, unix) and signal the whole group (`kill(-pgid, ...)`) in `kill_and_wait` and `Drop`, reaping forked helpers as a unit.
- **Step 4:** extract the drain loop into `McpClientManager::drain_all`, expose the manager via `KernelHandle`, and drain-before-exit from the tray Quit and `RunEvent::ExitRequested` paths (once-guarded, since `app.exit` skips `Drop`).

## Verification
- **446 tests** green, including two unix integration tests that spawn a real subprocess which forks a grandchild: `kill_and_wait_reaps_the_whole_process_group` (transport level) and `drain_all_reaps_connected_server_subtree` (manager level, end-to-end).
- `cargo fmt --check`, CI-exact clippy, `cargo check -p app`, and `verify-issues.sh`: all clean.
- **Live-verified in the real headless kernel (17 MCP servers connected):**
  - every child has `pgid == pid` (Step 3 is active),
  - restarting `cpersona` reaps the old PID and re-spawns it in a fresh group (Steps 1–3),
  - `POST /api/system/shutdown` reaps **17/17** children with **zero orphans** and a clean kernel exit (Step 4).

## Follow-ups (out of scope)
- Windows subtree containment via a Job Object — unix uses the process group; Windows currently keeps the prior direct-child kill (no regression). Tracked for the cross-platform harness.
- Persisted PID/PGID registry + boot-time orphan sweep for crash / power-off (additive resilience; the current fix covers graceful restart/quit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
