### PR TITLE
feat(llm-providers): seed provider metadata from the marketplace catalog (Goal #148)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4215,8 +4215,8 @@ dependencies = [
 
 [[package]]
 name = "mgp-sdk"
-version = "0.5.0"
-source = "git+https://github.com/Cloto-dev/mgp-rs?tag=mgp-sdk-v0.5.0#7251ed12e1df0c271af1e96c74cdd16745a20b40"
+version = "0.6.0"
+source = "git+https://github.com/Cloto-dev/mgp-rs?tag=mgp-sdk-v0.6.0#6d42fa3ffaef29393d39a6485d754c3d60a1fa3e"
 dependencies = [
  "anyhow",
  "serde",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -42,7 +42,7 @@ clap = { version = "4", features = ["derive"] }
 rand = "0.8"
 subtle = "2"
 mgp-seal = { git = "https://github.com/Cloto-dev/mgp-rs", tag = "mgp-seal-v0.3.0" }
-mgp-sdk = { git = "https://github.com/Cloto-dev/mgp-rs", tag = "mgp-sdk-v0.5.0" }
+mgp-sdk = { git = "https://github.com/Cloto-dev/mgp-rs", tag = "mgp-sdk-v0.6.0" }
 toml = "1.0"
 cron = "0.16"
 uuid.workspace = true

--- a/crates/core/src/db/llm.rs
+++ b/crates/core/src/db/llm.rs
@@ -23,6 +23,12 @@ pub struct ProviderQuirks {
     /// model switch, for providers whose engine binds the model name at startup.
     #[serde(default)]
     pub switch_model_tool: Option<String>,
+    /// Example model id for the dashboard's model-input placeholder (e.g. LM
+    /// Studio's `org/name` vs Ollama's `name:tag`). Ingested from the connector
+    /// catalog's provider block (Goal #148); superseded the frontend's hardcoded
+    /// per-provider map.
+    #[serde(default)]
+    pub model_placeholder: Option<String>,
 }
 
 #[derive(Debug, Clone, sqlx::FromRow, serde::Serialize, serde::Deserialize)]
@@ -97,6 +103,51 @@ pub async fn get_llm_provider(pool: &SqlitePool, id: &str) -> anyhow::Result<Llm
         "SELECT id, display_name, api_url, api_key, model_id, timeout_secs, enabled, created_at, auth_type, context_length, thinking_mode, quirks FROM llm_providers WHERE id = ?"
     ).bind(id).fetch_optional(pool)).await?;
     row.ok_or_else(|| anyhow::anyhow!("LLM provider '{}' not found", id))
+}
+
+/// Upsert an LLM provider's **metadata** from a connector catalog entry
+/// (Goal #148: registry.json provider block → ingest at marketplace install).
+///
+/// Writes only provider-authored metadata columns (display_name, api_url,
+/// auth_type, timeout_secs, quirks). It never overwrites user-owned columns
+/// (`api_key`, `context_length`, `thinking_mode`), and it seeds `model_id`
+/// **only when the row is first created** — a reinstall must not clobber a
+/// model the user has since chosen. `enabled` defaults to 1 on insert and is
+/// left untouched on update. This replaces the per-engine seed migration as
+/// the source of truth so a new engine needs only a catalog entry.
+pub async fn upsert_llm_provider_meta(
+    pool: &SqlitePool,
+    id: &str,
+    display_name: &str,
+    api_url: &str,
+    auth_type: &str,
+    default_model: &str,
+    timeout_secs: i32,
+    quirks_json: Option<String>,
+) -> anyhow::Result<()> {
+    db_timeout(
+        sqlx::query(
+            "INSERT INTO llm_providers \
+                (id, display_name, api_url, api_key, model_id, timeout_secs, enabled, auth_type, quirks) \
+             VALUES (?, ?, ?, '', ?, ?, 1, ?, ?) \
+             ON CONFLICT(id) DO UPDATE SET \
+                display_name = excluded.display_name, \
+                api_url      = excluded.api_url, \
+                timeout_secs = excluded.timeout_secs, \
+                auth_type    = excluded.auth_type, \
+                quirks       = excluded.quirks",
+        )
+        .bind(id)
+        .bind(display_name)
+        .bind(api_url)
+        .bind(default_model)
+        .bind(timeout_secs)
+        .bind(auth_type)
+        .bind(quirks_json)
+        .execute(pool),
+    )
+    .await?;
+    Ok(())
 }
 
 pub async fn set_llm_provider_key(

--- a/crates/core/src/handlers/llm.rs
+++ b/crates/core/src/handlers/llm.rs
@@ -11,13 +11,13 @@ const MODEL_ID_MAX_LEN: usize = 200;
 /// HTTP timeout for calls from the admin API to upstream LLM providers' model-list endpoints.
 const MODELS_FETCH_TIMEOUT_SECS: u64 = 15;
 
-/// Example model-id for a provider, shown as the model-input placeholder.
+/// Fallback example model-id for a provider, shown as the model-input
+/// placeholder when the provider row's `quirks.model_placeholder` is absent.
 ///
-/// This is provider *metadata* (not user config), kept on the backend so the
-/// dashboard carries no hardcoded provider list of its own (Goal #147 — the
-/// former `MODEL_PLACEHOLDER_BY_PROVIDER` map in `LlmProvidersSection.tsx`).
-/// Option B1 will relocate this into the clotohub registry entry so adding a
-/// new engine needs no ClotoCore change.
+/// Goal #147 moved this off the dashboard onto the backend; Goal #148 makes the
+/// catalog `provider` block the source of truth (ingested into
+/// `quirks.model_placeholder`). This hardcoded map remains only as the fallback
+/// for the original seeded engines until they are re-ingested from the catalog.
 fn model_placeholder(provider_id: &str) -> Option<&'static str> {
     match provider_id {
         "local" => Some("qwen/qwen3.5-9b"),
@@ -77,6 +77,12 @@ pub async fn list_llm_providers(
             let configured =
                 !p.api_key.is_empty() || p.context_length.is_some() || p.thinking_mode != "auto";
             let engine_status = classify_engine_status(server_statuses.get(&p.id), configured);
+            // Registry-ingested placeholder (Goal #148) wins; fall back to the
+            // hardcoded map for engines not yet re-ingested from the catalog.
+            let placeholder = p
+                .quirks_parsed()
+                .model_placeholder
+                .or_else(|| model_placeholder(&p.id).map(str::to_string));
             serde_json::json!({
                 "id": p.id,
                 "display_name": p.display_name,
@@ -89,7 +95,7 @@ pub async fn list_llm_providers(
                 "thinking_mode": p.thinking_mode,
                 "engine_status": engine_status,
                 "configured": configured,
-                "model_placeholder": model_placeholder(&p.id),
+                "model_placeholder": placeholder,
             })
         })
         .collect();

--- a/crates/core/src/handlers/marketplace.rs
+++ b/crates/core/src/handlers/marketplace.rs
@@ -1597,6 +1597,42 @@ async fn register_server(
         warn!("Failed to set marketplace fields: {e}");
     }
 
+    // Engine provider metadata (Goal #148): a reasoning-engine connector
+    // (`category = "mind"`) carries its upstream LLM-provider metadata in the
+    // catalog entry's `provider` block. Ingest it into the `llm_providers`
+    // credential registry so a new engine needs only a catalog entry, not a
+    // seed migration. Meta columns only — user-owned key/model/context/thinking
+    // are never overwritten (db::upsert_llm_provider_meta).
+    if let Some(pm) = &entry.provider {
+        let quirks = crate::db::ProviderQuirks {
+            no_api_key: pm.quirks.as_ref().is_some_and(|q| q.no_api_key),
+            models_endpoint_path: pm
+                .quirks
+                .as_ref()
+                .and_then(|q| q.models_endpoint_path.clone()),
+            switch_model_tool: pm.quirks.as_ref().and_then(|q| q.switch_model_tool.clone()),
+            model_placeholder: pm.model_placeholder.clone(),
+        };
+        let quirks_json = serde_json::to_string(&quirks).ok();
+        if let Err(e) = crate::db::upsert_llm_provider_meta(
+            &state.pool,
+            &entry.id,
+            &entry.name,
+            &pm.api_url,
+            &pm.auth_type,
+            pm.model_default.as_deref().unwrap_or(""),
+            pm.timeout_secs.map_or(120, |t| t as i32),
+            quirks_json,
+        )
+        .await
+        {
+            warn!(
+                "Failed to ingest LLM provider metadata for {}: {e}",
+                entry.id
+            );
+        }
+    }
+
     // Modern decouple path (0.6.6+): when a memory-kind plugin is installed
     // and the default agent has not yet picked one, mirror this install id
     // into `agent.cloto_default.metadata.preferred_memory`. This replaces
@@ -3695,6 +3731,7 @@ mod tests {
             entry_point_sha256: None,
             signature_payload: None,
             install: None,
+            provider: None,
         }
     }
 

--- a/crates/core/tests/handlers_http_test.rs
+++ b/crates/core/tests/handlers_http_test.rs
@@ -622,3 +622,74 @@ async fn test_llm_providers_engine_status_annotation() {
         .expect("cerebras row");
     assert_eq!(cerebras["engine_status"], "catalog_only");
 }
+
+/// Ingesting provider metadata from a catalog entry (Goal #148) updates only
+/// provider-authored columns and never clobbers user-owned settings; the
+/// default model is seeded only when the row is first created.
+#[tokio::test]
+async fn test_upsert_llm_provider_meta_preserves_user_columns() {
+    let state = create_test_app_state(Some("test-key".to_string())).await;
+    let pool = state.pool.clone();
+
+    // Existing seeded provider with user-owned settings applied.
+    cloto_core::db::set_llm_provider_key(&pool, "deepseek", "sk-user")
+        .await
+        .expect("set key");
+    sqlx::query("UPDATE llm_providers SET model_id = ?, thinking_mode = ? WHERE id = ?")
+        .bind("user-chosen-model")
+        .bind("on")
+        .bind("deepseek")
+        .execute(&pool)
+        .await
+        .expect("apply user model + thinking mode");
+
+    // Re-ingest metadata (as a reinstall would): different api_url/auth/default.
+    cloto_core::db::upsert_llm_provider_meta(
+        &pool,
+        "deepseek",
+        "DeepSeek Renamed",
+        "https://new.example.com/v1/chat/completions",
+        "x-api-key",
+        "ingested-default-model",
+        99,
+        Some(r#"{"model_placeholder":"org/example"}"#.to_string()),
+    )
+    .await
+    .expect("upsert meta");
+
+    let row = cloto_core::db::get_llm_provider(&pool, "deepseek")
+        .await
+        .expect("get deepseek");
+    // Meta columns updated…
+    assert_eq!(row.api_url, "https://new.example.com/v1/chat/completions");
+    assert_eq!(row.auth_type, "x-api-key");
+    assert_eq!(row.display_name, "DeepSeek Renamed");
+    assert_eq!(row.timeout_secs, 99);
+    assert_eq!(
+        row.quirks_parsed().model_placeholder.as_deref(),
+        Some("org/example")
+    );
+    // …user columns untouched.
+    assert_eq!(row.api_key, "sk-user");
+    assert_eq!(row.model_id, "user-chosen-model");
+    assert_eq!(row.thinking_mode, "on");
+
+    // Brand-new engine id: the row is created and the default model is seeded.
+    cloto_core::db::upsert_llm_provider_meta(
+        &pool,
+        "newengine",
+        "New Engine",
+        "https://n.example.com/v1/chat/completions",
+        "bearer",
+        "seeded-default",
+        120,
+        None,
+    )
+    .await
+    .expect("upsert new");
+    let fresh = cloto_core::db::get_llm_provider(&pool, "newengine")
+        .await
+        .expect("get newengine");
+    assert_eq!(fresh.model_id, "seeded-default");
+    assert_eq!(fresh.api_key, "");
+}


### PR DESCRIPTION
## Summary

Option B1 (follow-up to #249): make the ClotoHub catalog the single source of truth for LLM provider metadata. Reasoning-engine connectors now declare an optional `provider` block (mgp-sdk v0.6.0) in their catalog entry, and ClotoCore ingests it into `llm_providers` on marketplace install — so adding a new engine needs only a catalog entry, no seed migration.

## Changes

- **`db::upsert_llm_provider_meta`** — meta columns only (`display_name`, `api_url`, `auth_type`, `timeout_secs`, `quirks`). User-owned columns (`api_key`, `model_id`, `context_length`, `thinking_mode`) are never overwritten; `model_id` is seeded on INSERT only.
- **`ProviderQuirks.model_placeholder`** — replaces the hardcoded per-provider placeholder map; the handler keeps the legacy map only as a fallback for the original seeded engines until they are re-ingested.
- **`register_server` Step 5** — ingests `entry.provider` when present. Entries without a provider block are untouched: **zero behavior change until the catalog carries provider metadata** (hub re-publish, tracked separately).
- **mgp-sdk `v0.5.0` → `v0.6.0`** (additive shape change; Cloto-dev/mgp-rs#11).

## Tests

- `test_upsert_llm_provider_meta_preserves_user_columns` — re-ingest updates meta, preserves user key/model/context/thinking.
- Existing engine-status (#249) and marketplace suites green; `cargo test --workspace --exclude app` all pass, fmt + CI-exact clippy clean.

## Release note

Seed migrations for the six existing engines stay in place (frozen); fresh installs behave exactly as today until the hub catalog is re-published with provider blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)